### PR TITLE
add cf2 route to apache conf

### DIFF
--- a/extras/apache/atmo.conf.dist
+++ b/extras/apache/atmo.conf.dist
@@ -124,6 +124,8 @@ ProxyPassReverse  /jenkins  http://MYHOSTNAMEHERE/jenkins
     ProxyPassReverse /forbidden http://localhost:5000/forbidden
     ProxyPass /version http://localhost:5000/version
     ProxyPassReverse /version http://localhost:5000/version
+    ProxyPass /cf2 http://localhost:5000/cf2
+    ProxyPassReverse /cf2 http://localhost:5000/cf2
 
     ProxyPassMatch ^/emulate http://localhost:5000
     ProxyPassReverse /emulate http://localhost:5000


### PR DESCRIPTION
Adding a /cf2 route to the apache conf template.  I'm using this route to serve up the Arturo UI on the Tropo server for testing.  You'll need to add it to you apache.conf if you want the beta on/off toggle to work.

We can remove this once we have a _is_beta_user_ flag in the profile object and the Tropo server is capable of fetching the profile to determine which experience they should serve up to the user.
