### PR TITLE
Add subnet pool specification with a default of None

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -196,6 +196,7 @@ INIT_SCRIPT_PREFIX = '/init_files/'
 DEPLOY_SERVER_URL = SERVER_URL.replace("https", "http")
 
 # These DEFAULT variables can be overridden per provider..
+DEFAULT_SUBNET_POOL_ID = None
 DEFAULT_NAMESERVERS = ['8.8.8.8','8.8.4.4.']
 DEFAULT_RULES = [
     ("ICMP", -1, -1),

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -629,7 +629,7 @@ class AccountDriver(BaseAccountDriver):
             self.network_manager, neutron,
             network['id'], username,
             "%s-subnet" % project_name,
-            subnet_pool = settings.DEFAULT_SUBNET_POOL_ID,
+            subnet_pool_id = settings.DEFAULT_SUBNET_POOL_ID,
             dns_nameservers=dns_nameservers)
         router = network_strategy.get_or_create_router(
             self.network_manager, neutron,

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -629,6 +629,7 @@ class AccountDriver(BaseAccountDriver):
             self.network_manager, neutron,
             network['id'], username,
             "%s-subnet" % project_name,
+            subnet_pool = settings.DEFAULT_SUBNET_POOL_ID,
             dns_nameservers=dns_nameservers)
         router = network_strategy.get_or_create_router(
             self.network_manager, neutron,

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -487,7 +487,7 @@ def check_volume(device):
 
 
 def mkfs_volume(device):
-    return ScriptDeployment("mkfs.ext3 -F %s" % (device),
+    return ScriptDeployment("mkfs.ext4 -K -F %s" % (device),
                             name="./deploy_mkfs_volume.sh")
 
 

--- a/service/networking.py
+++ b/service/networking.py
@@ -131,7 +131,7 @@ class GenericNetworkTopology(object):
         inc = 0
         MAX_SUBNET = 4064
         cidr = None
-        if subnet_pool:
+        if subnet_pool_id:
             return network_driver.create_subnet(neutron, subnet_name,
                                                 network_id, ip_version, subnet_pool_id)
                                                 

--- a/service/networking.py
+++ b/service/networking.py
@@ -120,6 +120,7 @@ class GenericNetworkTopology(object):
             self, network_driver, neutron,
             network_id, username, subnet_name,
             ip_version=4, dns_nameservers=[],
+            subnet_pool_id=None,
             get_unique_number=_get_unique_id,
             get_cidr=get_default_subnet):
         """
@@ -130,6 +131,10 @@ class GenericNetworkTopology(object):
         inc = 0
         MAX_SUBNET = 4064
         cidr = None
+        if subnet_pool:
+            return network_driver.create_subnet(neutron, subnet_name,
+                                                network_id, ip_version, subnet_pool_id)
+                                                
         while not success and inc < MAX_SUBNET:
             try:
                 cidr = get_cidr(username, inc, get_unique_number)


### PR DESCRIPTION
Starting with the kilo release neutron can use a shared subnet pool,
this ensures unique subnets without the need to probe.  When a subnet
pool id is configured skip the search and CIDR specification and just
create the subnet using the subnet pool.

This may need some further polish, I took the per provider override for settings at face value.  One possible improvement would be to use subnet pool name and lookup the id.
