### PR TITLE
Prefer provider location rather than uuid in support emails

### DIFF
--- a/api/v2/views/email.py
+++ b/api/v2/views/email.py
@@ -65,7 +65,7 @@ class VolumeSupportEmailViewSet(EmailViewSet):
             "ui": data.get("user-interface", ""),
             "server": settings.SERVER_URL,
             "message": data["message"],
-            "provider": user.selected_identity.provider_uuid(),
+            "provider": user.selected_identity.provider,
             "volume": volume,
         }
 
@@ -99,7 +99,7 @@ class InstanceSupportEmailViewSet(EmailViewSet):
             "ui": data.get("user-interface", ""),
             "server": settings.SERVER_URL,
             "message": data["message"],
-            "provider": user.selected_identity.provider_uuid(),
+            "provider": user.selected_identity.provider,
             "instance": instance,
             "status": last_status
         }
@@ -138,7 +138,7 @@ class FeedbackEmailViewSet(EmailViewSet):
             "ui": data.get("user-interface", ""),
             "server": settings.SERVER_URL,
             "feedback": data["message"],
-            "provider": user.selected_identity.provider_uuid(),
+            "provider": user.selected_identity.provider,
             "instances": instances,
             "volumes": volumes,
         }

--- a/core/templates/core/email/feedback.html
+++ b/core/templates/core/email/feedback.html
@@ -2,7 +2,7 @@ Username : {{ username }} ({{ name|safe }})
 
 Feedback : {{ feedback|safe }}
 
-Provider : {{ provider }}
+Provider : {{ provider.location }}
 
 User-interface : {{ ui }}
 
@@ -13,6 +13,7 @@ Instances :
     Name : {{ i.name|safe }}
     UUID : {{ i.provider_alias }}
     Image : {{ i.provider_machine.identifier }}
+    Provider : {{ i.provider.location }}
     IP : {{ i.ip_address }}
 {% endfor %}
 

--- a/core/templates/core/email/instance_report.html
+++ b/core/templates/core/email/instance_report.html
@@ -1,9 +1,9 @@
 Username : {{ username }} ({{ name|safe }})
 {% if problems %}
-Problems : 
+Problems :
     {{ problems|join("\n")|indent(4, false)|safe }}
 {% endif %}
-Details : 
+Details :
     {{ message|safe }}
 
 Instance :
@@ -15,7 +15,9 @@ Instance :
     Image : {{ instance.provider_machine.identifier }}
     IP : {{ instance.ip_address }}
 
-Provider : {{ provider }}
+Provider :
+    Location: {{ provider.location }}
+    UUID: {{ provider.uuid }}
 
 User-interface : {{ ui }}
 

--- a/core/templates/core/email/volume_report.html
+++ b/core/templates/core/email/volume_report.html
@@ -11,7 +11,7 @@ Volume :
     UUID : {{ volume.identifier }}
     Size : {{ volume.size }} GB
 
-Provider : {{ provider }}
+Provider : {{ provider.location }}
 
 User-interface : {{ ui }}
 


### PR DESCRIPTION
When I deal with a ticket its not helpful for me to have the provider uuid, i need to know at a glance the location (Tucson vs Workshop). 

@steve-gregory Do you ever need the uuid?