### PR TITLE
Fix proxy pass so ngnix server starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ extras/apache/atmo.conf
 extras/nginx/Makefile
 extras/nginx/site.conf
 extras/nginx/locations/atmo.conf
-extras/nginx/locations/flower.conf
-extras/nginx/locations/jenkins.conf
 extras/nginx/locations/lb.conf
 extras/uwsgi/atmo.uwsgi.ini
 tests/secrets

--- a/extras/nginx/Makefile.j2
+++ b/extras/nginx/Makefile.j2
@@ -23,26 +23,20 @@ JENKINS_CONF_FILE=jenkins.conf
 JENKINS_CONF_PATH=$(ATMOSPHERE_PATH)/extras/nginx/locations/$(JENKINS_CONF_FILE)
 
 
-.PHONY: all clean restart test setup setup-site setup-atmo setup-flower setup-jenkins deploy deploy-atmo deploy-flower deploy-jenkins unlink unlink-site unlink-atmo unlink-flower unlink-jenkins $(COMBINED_CERT_PATH)
+.PHONY: all clean restart test setup setup-site setup-atmo deploy deploy-atmo deploy-flower deploy-jenkins unlink unlink-site unlink-atmo unlink-flower unlink-jenkins $(COMBINED_CERT_PATH)
 
 all: deploy
 
 $(DHPARAM):
 	openssl dhparam -out $(DHPARAM) $(KEY_SIZE)
 
-setup: setup-site setup-atmo setup-flower setup-jenkins
+setup: setup-site setup-atmo 
 
 setup-site:
 	$(VIRTUALENV_PATH)/bin/python $(ATMOSPHERE_PATH)/configure -c nginx:nginx-site
 
 setup-atmo:
 	$(VIRTUALENV_PATH)/bin/python $(ATMOSPHERE_PATH)/configure -c nginx:nginx-atmo
-
-setup-flower:
-	$(VIRTUALENV_PATH)/bin/python $(ATMOSPHERE_PATH)/configure -c nginx:nginx-flower
-
-setup-jenkins:
-	$(VIRTUALENV_PATH)/bin/python $(ATMOSPHERE_PATH)/configure -c nginx:nginx-jenkins
 
 deploy: $(DHPARAM) setup unlink deploy-atmo deploy-flower deploy-jenkins
 	mkdir -p $(SITES_AVAILABLE_DIR)

--- a/extras/nginx/locations/flower.conf
+++ b/extras/nginx/locations/flower.conf
@@ -1,7 +1,7 @@
 location /flower {
     rewrite ^/flower/?(.*)$ /$1 break;
 
-    proxy_pass $scheme://{{ SERVER_URL|replace("https://","")}}:8443;
+    proxy_pass $scheme://localhost:8443;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/extras/nginx/locations/jenkins.conf
+++ b/extras/nginx/locations/jenkins.conf
@@ -1,5 +1,5 @@
 location /jenkins {
-    proxy_pass http://{{ SERVER_URL|replace("https://","") }}:8080;
+    proxy_pass http://app.atmo.cloud:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/variables_templates.json
+++ b/variables_templates.json
@@ -9,9 +9,7 @@
         "nginx": [
             "nginx",
             "nginx-site",
-            "nginx-atmo",
-            "nginx-flower",
-            "nginx-jenkins"
+            "nginx-atmo"
         ],
         "uwsgi.ini": ["atmo.uwsgi"],
         "secrets.py": [
@@ -38,14 +36,6 @@
         "nginx-atmo": [
             "extras/nginx/locations/atmo.conf.j2",
             "extras/nginx/locations/atmo.conf"
-        ],
-        "nginx-flower": [
-            "extras/nginx/locations/flower.conf.j2",
-            "extras/nginx/locations/flower.conf"
-        ],
-        "nginx-jenkins": [
-            "extras/nginx/locations/jenkins.conf.j2",
-            "extras/nginx/locations/jenkins.conf"
         ],
         "atmo.uwsgi": [
             "extras/uwsgi/atmo.uwsgi.ini.j2",


### PR DESCRIPTION
Nginx was failing, it's configtest was not passing. The reason was because the
server specified in the proxy_pass directive was not resolving. Nginx checks
these beforehand to help. Nginx cannot resolve SERVER_URL (i.e.
app.atmo.cloud) so it fails. The solution is to use localhost. 
