### PR TITLE
Correct variable name to one within scope

### DIFF
--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -278,7 +278,7 @@ def attach_task(driverCls, provider, identity, instance_id, volume_id,
 
         if 'available' in volume.extra.get('status', ''):
             raise Exception("Volume %s failed to attach to instance %s"
-                            % (volume.id, instance.id))
+                            % (volume.id, instance_id))
 
         # Device path for euca == openstack
         try:


### PR DESCRIPTION
It looks like the `instance` variable was removed during an extract
method refactor, but the later exception handling code was not tweaked.

Amit (@amit4111989) & I discovered this while triaging an issue with Volume attachment.