### PR TITLE
Fix nginx proxy pass unable to resolve localhost

### DIFF
--- a/extras/nginx/locations/flower.conf
+++ b/extras/nginx/locations/flower.conf
@@ -1,7 +1,7 @@
 location /flower {
     rewrite ^/flower/?(.*)$ /$1 break;
 
-    proxy_pass $scheme://localhost:8443;
+    proxy_pass https://127.0.0.1:8443;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Proxy_pass defines a uri for some proxied resource. If the uri contains a
variable nginx applies special rules. A resolver must be defined. We use
google's 8.8.8.8 dns. We used to use SERVER_NAME in the uri for the
resource, this works for productions servers with dns entries but fails for
local machines.

This solution removed the variables that were unnecessary and removed any
hostname that would need to be resolved.

I tested this on a production server with dns resolution, on a vm without dns, and I tested on my vm with app.atmo.cloud (since nginx special cases hostname ending in .dev).