### PR TITLE
Hotfix for monitor_machines_for which is failing

### DIFF
--- a/core/models/application.py
+++ b/core/models/application.py
@@ -473,6 +473,7 @@ def create_application(
             provider_uuid,
             created_by.username)
     if not created_by_identity:
+        logger.error("ERROR: No identity was found for image <%s> -- the 'author' will be admin" % identifier)
         created_by_identity = _get_admin_owner(provider_uuid)
     if not tags:
         tags = []


### PR DESCRIPTION
... due to attr lookup on glance_image. Solution: use `owner` if its
available for the image otherwise use `application_owner`.