### PR TITLE
Problem: new versions of image fall through logic-cracks

### DIFF
--- a/api/v1/views/machine_request.py
+++ b/api/v1/views/machine_request.py
@@ -118,7 +118,7 @@ class MachineRequestList(AuthAPIView):
             pending_status = StatusType.objects.get(name='pending')
             machine_request = serializer.save(status=pending_status)
             instance = machine_request.instance
-            if hasattr(settings, 'REPLICATION_PROVIDER_LOCATION'):
+            if getattr(settings, 'REPLICATION_PROVIDER_LOCATION'):
                 try:
                     replication_provider = Provider.objects.get(
                         location=settings.REPLICATION_PROVIDER_LOCATION)

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -408,7 +408,7 @@ class AccountDriver(BaseAccountDriver):
         shared_with = self.image_manager.shared_images_for(
             image_id=image_id)
 
-	if hasattr(settings, "REPLICATION_PROVIDER_LOCATION"):
+	if getattr(settings, "REPLICATION_PROVIDER_LOCATION"):
             from core.models import Provider
             from service.driver import get_account_driver
             provider = Provider.objects.get(location=settings.REPLICATION_PROVIDER_LOCATION)


### PR DESCRIPTION
The situation occurs when new glance images are found that represent **the second version** of an application that has been replicated across providers via an external process. These images were an unexpected edge case because the image ID is *not* the same image that created the *application UUID*, and so the logic (Testing image ID against application UUID) that blocks externally-created-images from being incorrectly ingested as atmosphere was *also* blocking these version from correctly setting the application kwargs, potentially allowing this version to create a new image. 

Instead, if REPLICATION_PROVIDER_LOCATION is set (redefined 'set' as getattr, not hasattr) attempt to find a similar image that already exists in the stack, and use its application to define yourself.