### PR TITLE
Problem: Instance launch via /api/v2/instances ignore 'project'

### DIFF
--- a/api/v2/serializers/post/instance.py
+++ b/api/v2/serializers/post/instance.py
@@ -1,9 +1,12 @@
+from django.conf import settings
+
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
 from core.models import (
     BootScript, Identity, Instance, InstanceSource,
     Provider, ProviderMachine, Project, UserAllocationSource,
     Size, Volume)
-from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 from api.v2.serializers.fields.base import ReprSlugRelatedField
 
 class InstanceSerializer(serializers.ModelSerializer):
@@ -23,7 +26,7 @@ class InstanceSerializer(serializers.ModelSerializer):
     name = serializers.CharField()
     project = serializers.SlugRelatedField(
         source="projects", slug_field="uuid", queryset=Project.objects.all(),
-        required=False, allow_null=True)
+        required=True)
     scripts = serializers.SlugRelatedField(
         slug_field="uuid", queryset=BootScript.objects.all(),
         many=True, required=False)
@@ -55,18 +58,18 @@ class InstanceSerializer(serializers.ModelSerializer):
         size_queryset = self.fields['size_alias'].queryset
         allocation_source_queryset = UserAllocationSource.objects.filter(user=request_user)
         source_queryset = self.fields['source_alias'].queryset
-
-        allocation_source_id = data.get('allocation_source_id')
-        #NOTE: When CyVerse uses the allocation_source feature, remove 'and 'jetstream' in settings.INSTALLED_APPS'
-        if not allocation_source_id and 'jetstream' in settings.INSTALLED_APPS:
-            raise ValidationError({
-                'allocation_source_id': 'This field is required.'
-            })
-        allocation_source = allocation_source_queryset.filter(allocation_source__source_id=allocation_source_id)
-        if not allocation_source:
-            raise ValidationError({
-                'allocation_source_id': 'Value %s did not match a allocation_source.' % allocation_source_id
-            })
+        import ipdb;ipdb.set_trace()
+        if settings.USE_ALLOCATION_SOURCE:
+            allocation_source_id = data.get('allocation_source_id')
+            if not allocation_source_id:
+                raise ValidationError({
+                    'allocation_source_id': 'This field is required.'
+                })
+            allocation_source = allocation_source_queryset.filter(allocation_source__source_id=allocation_source_id)
+            if not allocation_source:
+                raise ValidationError({
+                    'allocation_source_id': 'Value %s did not match a allocation_source.' % allocation_source_id
+                })
 
         size_alias = data.get('size_alias')
         if not size_alias:

--- a/api/v2/serializers/post/instance.py
+++ b/api/v2/serializers/post/instance.py
@@ -58,7 +58,6 @@ class InstanceSerializer(serializers.ModelSerializer):
         size_queryset = self.fields['size_alias'].queryset
         allocation_source_queryset = UserAllocationSource.objects.filter(user=request_user)
         source_queryset = self.fields['source_alias'].queryset
-        import ipdb;ipdb.set_trace()
         if settings.USE_ALLOCATION_SOURCE:
             allocation_source_id = data.get('allocation_source_id')
             if not allocation_source_id:

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -85,6 +85,13 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
             return True
         return False
 
+    def all_projects(self):
+        from core.models.project import Project
+        p_qs = Project.objects.none()
+        for group in self.group_set.all():
+            p_qs |= group.projects.all()
+        return p_qs
+
     def group_ids(self):
         return self.group_set.values_list('id', flat=True)
 


### PR DESCRIPTION
Solution: Fix /api/v2/instances POST to properly set 'project' after instance launch, but before returning/serializing data for the user.