### PR TITLE
Problem: Reporting api saves all files as reporting.xlsx

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -16,7 +16,8 @@ class PandasExcelRenderer(CSVRenderer):
     format = 'xlsx'
 
     def render(self, data, media_type=None, renderer_context={}):
-        filename = renderer_context.get('filename', 'workbook.xlsx')
+        filename = renderer_context.get('filename', 'excel_workbook.xlsx')
+        drf_response = renderer_context.get('response', None)
         # Hard-coded headers_ordering required to force an explicit ordering, otherwise headers are sorted by key-name
         headers_ordering = renderer_context.get('headers_ordering', None)
         table_gen = self.tablize(data, header=headers_ordering)
@@ -36,8 +37,7 @@ class PandasExcelRenderer(CSVRenderer):
         sio.seek(0)
         workbook = sio.getvalue()
         response = StreamingHttpResponse(workbook, content_type='application/vnd.ms-excel')
-        #FIXME: This doesn't... actually.. work. Filename == pathname.
-        response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+        drf_response['Content-Disposition'] = 'attachment; filename="%s"' % filename
         return response
 
 

--- a/api/v2/views/reporting.py
+++ b/api/v2/views/reporting.py
@@ -34,12 +34,17 @@ class ReportingViewSet(AuthViewSet):
         """
         # Note: Additionally 'response' will also be added to the context,
         #       by the Response object.
+        request = getattr(self, 'request', None)
+        if request and 'filename' in request.query_params:
+            filename = request.query_params['filename']
+        else:
+            filename = 'instance_reporting.xlsx'
         return {
             'view': self,
             'args': getattr(self, 'args', ()),
             'kwargs': getattr(self, 'kwargs', {}),
-            'request': getattr(self, 'request', None),
-            'filename': 'reporting.xlsx',
+            'request': request,
+            'filename': filename,
             'excel_writer_hook': self.create_excel_file,
             'headers_ordering': ["id", "instance_id", "username", "staff_user", "provider", "start_date", "end_date",
                                  "image_name", "version_name", "size.active", "size.start_date", "size.end_date",


### PR DESCRIPTION
Solution:
- Allow `filename` as a query_param on the request
- Respect `filename` by saving headers to the DRF Response, *NOT*
  `StreamingHTTPResponse`