### PR TITLE
Use date extension file naming for logrotate for easy archiving.

### DIFF
--- a/extras/logrotate.atmosphere
+++ b/extras/logrotate.atmosphere
@@ -1,71 +1,17 @@
 # Note: for apache2 and celery, use the packaged version of logrotate
-/opt/dev/atmosphere/logs/atmosphere.log {
-    su www-data www-data
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/libcloud.log {
-    su www-data www-data
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/atmosphere_api.log {
-    su www-data www-data
-    daily
-    rotate 4
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/atmosphere_auth.log {
-    su www-data www-data
-    daily
-    rotate 4
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/atmosphere_deploy.log {
-    su www-data www-data
-    daily
-    rotate 4
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/atmosphere_email.log {
-    su www-data www-data
-    daily
-    rotate 2
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/opt/dev/atmosphere/logs/atmosphere_status.log {
-    su www-data www-data
-    daily
-    rotate 4
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
+su www-data www-data
+daily
+rotate 10
+missingok
+compress
+delaycompress
+notifempty
+copytruncate
+dateext
+/opt/dev/atmosphere/logs/atmosphere.log {}
+/opt/dev/atmosphere/logs/libcloud.log {}
+/opt/dev/atmosphere/logs/atmosphere_api.log {}
+/opt/dev/atmosphere/logs/atmosphere_auth.log {}
+/opt/dev/atmosphere/logs/atmosphere_deploy.log {}
+/opt/dev/atmosphere/logs/atmosphere_email.log {}
+/opt/dev/atmosphere/logs/atmosphere_status.log {}

--- a/extras/logrotate.celery
+++ b/extras/logrotate.celery
@@ -1,46 +1,16 @@
 # Note: for apache2 and celery, use the packaged version of logrotate
-/var/log/celery/celery_periodic.log {
-    daily
-    rotate 20
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/var/log/celery/atmosphere-*.log {
-    daily
-    rotate 20
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/var/log/celery/imaging.log {
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/var/log/celery/email.log {
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
-/var/log/celery/flower.log {
-    daily
-    rotate 10
-    missingok
-    compress
-    delaycompress
-    notifempty
-    copytruncate
-}
+
+daily
+rotate 20
+missingok
+compress
+delaycompress
+notifempty
+copytruncate
+dateext
+
+/var/log/celery/celery_periodic.log {}
+/var/log/celery/atmosphere-*.log {}
+/var/log/celery/imaging.log {}
+/var/log/celery/email.log {}
+/var/log/celery/flower.log {}


### PR DESCRIPTION
## Description

### Problem

Current logrotate file naming convention is not conducive to archiving.

### Solution

Add a date to the end of the rotated files. (`dateext` option)

refs [#ATMO-1682](https://pods.iplantcollaborative.org/jira/browse/ATMO-1682)