### PR TITLE
Create new management command: find_uuid

### DIFF
--- a/core/management/commands/find_uuid.py
+++ b/core/management/commands/find_uuid.py
@@ -1,0 +1,40 @@
+import os
+from django.core.management.base import BaseCommand
+import django.db.models.base
+from subprocess import call
+import core.models
+
+class Command(BaseCommand):
+    help = 'Custom manage.py command to start celery.'
+
+    def add_arguments(self, parser):
+        parser.add_argument("needle", type=str, help="The uuid/field that you are looking for")
+
+    def handle(self, *args, **options):
+        needle = options.get('needle')
+        if not needle:
+            print "Exception: Missing value to search for"
+            return
+        field_type, result = find_string_in_models(core.models, needle)
+        if not result:
+            print "Exception:Could not find value %s in any of the imports from %s (Using %s field types)" % (needle, core.models, field_type)
+        else:
+            human_field_type = "UUID" if field_type == 'uuidfield' else 'String'
+            if hasattr(result, 'get_source_class'):
+                result = result.get_source_class
+            print "%s <%s> belongs to %s %s" % (human_field_type, needle, str(result.__class__), result)
+
+def find_string_in_models(import_base, needle):
+    for modelKey in import_base.__dict__.keys():
+     if 'pyc' not in modelKey:
+         modelCls = getattr(import_base, modelKey)
+         if type(modelCls) != django.db.models.base.ModelBase:
+             continue
+         for field in modelCls._meta.get_fields():
+             field_name = field.name
+             field_type = str(modelCls._meta.get_field(field_name).get_internal_type()).lower()
+             if field_type in ['uuidfield','charfield']:
+                 res = modelCls.objects.filter(**{field_name:needle})
+                 if res:
+                     return field_type, res.last()
+    return (None, None)

--- a/core/models/instance_source.py
+++ b/core/models/instance_source.py
@@ -88,6 +88,15 @@ class InstanceSource(models.Model):
         return source
 
     @property
+    def get_source_class(self):
+        if self.is_machine():
+            return self.machine
+        elif self.is_volume():
+            return self.volume
+        elif self.is_snapshot():
+            return self.volume
+
+    @property
     def source_type(self):
         if self.is_machine():
             return "machine"


### PR DESCRIPTION
## Description
**Huge shoutout to @amit4111989 for figuring out how to make this happen in Django!**

A common support use-case is that you are given a UUID without a whole lot of context. This PR creates a management command `./manage.py find_uuid` that will allow you to gather additional context, quickly, from the command line.

Examples:
```
/opt/dev/atmosphere# ./manage.py find_uuid '11223344-07a2-4e22-ae52-a61e87155c1f'
String <11223344-07a2-4e22-ae52-a61e87155c1f> belongs to <class 'core.models.volume.Volume'> 11223344-07a2-4e22-ae52-a61e87155c1f
/opt/dev/atmosphere# ./manage.py find_uuid '12345678-ef90-48ec-9be0-1b2ca71ee8c8'
UUID <12345678-ef90-48ec-9be0-1b2ca71ee8c8> belongs to <class 'core.models.provider.Provider'> 6:iPlant Cloud - Austin
```
## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Documentation created/updated (via argparse and the Django commands/management interface) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
