### PR TITLE
Fix logrotate permissions error

### DIFF
--- a/extras/logrotate.atmosphere
+++ b/extras/logrotate.atmosphere
@@ -1,17 +1,78 @@
 # Note: for apache2 and celery, use the packaged version of logrotate
-su www-data www-data
-daily
-rotate 10
-missingok
-compress
-delaycompress
-notifempty
-copytruncate
-dateext
-/opt/dev/atmosphere/logs/atmosphere.log {}
-/opt/dev/atmosphere/logs/libcloud.log {}
-/opt/dev/atmosphere/logs/atmosphere_api.log {}
-/opt/dev/atmosphere/logs/atmosphere_auth.log {}
-/opt/dev/atmosphere/logs/atmosphere_deploy.log {}
-/opt/dev/atmosphere/logs/atmosphere_email.log {}
-/opt/dev/atmosphere/logs/atmosphere_status.log {}
+/opt/dev/atmosphere/logs/atmosphere.log {
+    su www-data www-data
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/libcloud.log {
+    su www-data www-data
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/atmosphere_api.log {
+    su www-data www-data
+    daily
+    rotate 4
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/atmosphere_auth.log {
+    su www-data www-data
+    daily
+    rotate 4
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/atmosphere_deploy.log {
+    su www-data www-data
+    daily
+    rotate 4
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/atmosphere_email.log {
+    su www-data www-data
+    daily
+    rotate 2
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/opt/dev/atmosphere/logs/atmosphere_status.log {
+    su www-data www-data
+    daily
+    rotate 4
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}

--- a/extras/logrotate.celery
+++ b/extras/logrotate.celery
@@ -1,16 +1,51 @@
 # Note: for apache2 and celery, use the packaged version of logrotate
-
-daily
-rotate 20
-missingok
-compress
-delaycompress
-notifempty
-copytruncate
-dateext
-
-/var/log/celery/celery_periodic.log {}
-/var/log/celery/atmosphere-*.log {}
-/var/log/celery/imaging.log {}
-/var/log/celery/email.log {}
-/var/log/celery/flower.log {}
+/var/log/celery/celery_periodic.log {
+    daily
+    rotate 20
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/var/log/celery/atmosphere-*.log {
+    daily
+    rotate 20
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/var/log/celery/imaging.log {
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/var/log/celery/email.log {
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}
+/var/log/celery/flower.log {
+    daily
+    rotate 10
+    missingok
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+    dateext
+}


### PR DESCRIPTION
Problem: Getting error messages like this:

```
error: error opening /var/log/celery/atmosphere-deploy_7.log: Permission denied
```

Solution: Change the structure of the logrotate config files back to what they
were and just have the `dateext` line added.

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
