### PR TITLE
Add script to find instances launched from an image

### DIFF
--- a/scripts/print_all_instances_for_image.py
+++ b/scripts/print_all_instances_for_image.py
@@ -1,0 +1,43 @@
+import argparse
+import sys
+
+def main():
+
+    description = (
+        "Print instance launches for a specific image"
+    )
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('uuid', help='An image uuid')
+    args = parser.parse_args()
+
+    # Check environment
+    try:
+        import django; django.setup()
+        from core.models import Application, Instance
+        from django.db.models import Q
+    except:
+        print "\n".join([
+            "ERROR! This script requires a proper environment! Try:",
+            "",
+            "   export PYTHONPATH=\"/opt/dev/atmosphere:$PYTHONPATH\"",
+            "   export DJANGO_SETTINGS_MODULE='atmosphere.settings'",
+            "   . /opt/env/atmo/bin/activate"
+        ])
+        sys.exit(1)
+
+    uuid = args.uuid
+    query = Q(source__providermachine__application_version__application__uuid=uuid)
+    instances = Instance.objects.filter(query) \
+                                .order_by('-start_date')
+
+    print "START_DATE, UUID, NAME, USERNAME"
+    for i in instances:
+        start_date = str(i.start_date)
+        uuid = i.provider_alias
+        name = i.name
+        username = i.created_by.username
+        print ",".join([start_date, uuid, name, username])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This script just prints a csv of instances for a particular image, sorted by launch date. At a glance you can find out the activity for an image. This is helpful, if you have an image that is broken, that you may want to consider end-dating.

## Examples
```
$ python scripts/print_all_instances_for_image.py --help
usage: print_all_instances_for_image.py [-h] uuid

Print instance launches for a specific image

positional arguments:
  uuid        An image uui
```
```
$ python scripts/print_all_instances_for_image.py 360b565e-f886-4640-913c-3d7e538a7e29
START_DATE, UUID, NAME, USERNAME
...
2016-04-02 21:18:22+00:00,f546ad72-0c73-47b0-8eaa-4fe1fafc4477,NGS Viewers v3.2 NOMAC,suberjun
2016-01-18 08:27:47+00:00,ea03193a-5d2a-469b-be8c-bc60b6a8f8c9,NGS Viewers v3.2 NOMAC,ehsaai
2015-09-25 11:27:19+00:00,8615a5db-5ff4-40e5-9e42-0dfb51ca3c1e,Abigaice1_miseq,acail
2015-09-09 17:56:15+00:00,765164e6-f250-4234-a9ed-ba3550eef36f,NGS Viewers v3.2 NOMAC,halun
...
```

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
