### PR TITLE
Problem: In some conditions, The logfiles are growing at a high rate

### DIFF
--- a/atmosphere/celery_init.py
+++ b/atmosphere/celery_init.py
@@ -4,6 +4,7 @@ import os
 
 from celery import Celery
 from django.conf import settings
+
 cwd_path = os.path.dirname(os.path.dirname(__file__))
 os.environ.setdefault('PYTHONPATH', cwd_path)
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'atmosphere.settings')
@@ -12,7 +13,7 @@ os.environ.setdefault('PYTHONOPTIMIZE', '1')  #NOTE: Required to run ansible2 + 
 app = Celery('atmosphere')
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(settings.INSTALLED_APPS, related_name='tasks')
-#app.log.setup()
+app.log.setup()
 
 @app.task(bind=True)
 def debug_task(self):

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -143,11 +143,28 @@ class AccountDriver(BaseAccountDriver):
         net_creds = self._build_network_creds(all_creds)
         sdk_creds = self._build_sdk_creds(all_creds)
 
+        # Initialize logging
+        self._initialize_loggers()
         # Initialize managers with respective credentials
         self.user_manager = UserManager(**user_creds)
         self.image_manager = ImageManager(**image_creds)
         self.network_manager = NetworkManager(**net_creds)
         self.openstack_sdk = _connect_to_openstack_sdk(**sdk_creds)
+
+    def _initialize_loggers(self):
+        from keystoneauth1 import _utils
+        session_logger = _utils.get_logger('keystoneauth1.session')
+        session_logger.setLevel(settings.DEP_LOGGING_LEVEL)
+        auth1_logger = _utils.get_logger('keystoneauth1')
+        auth1_logger.setLevel(settings.DEP_LOGGING_LEVEL)
+        ksauth_logger = _utils.get_logger('keystoneauth')
+        ksauth_logger.setLevel(settings.DEP_LOGGING_LEVEL)
+        ks_identity_logger = _utils.get_logger('keystoneauth.identity.v3.base')
+        ks_identity_logger.setLevel(settings.DEP_LOGGING_LEVEL)
+        ostack_logger = _utils.get_logger('openstack')
+        ostack_logger.setLevel(settings.DEP_LOGGING_LEVEL)
+        ostack_session_logger = _utils.get_logger('openstack.session')
+        ostack_session_logger.setLevel(settings.DEP_LOGGING_LEVEL)
 
     def get_config(self, section, config_key, default_value):
         try:


### PR DESCRIPTION
## Solution

- Selecting specific loggers, prior to using them, and forcing their log level to respect `DEP_LOGGING_LEVEL` in atmosphere.
- Colorized output in celery (Not required, but expected for future versions of celery initialization).

## Checklist before merging Pull Request
- [ ] Reviewed and approved by at least one other contributor.

## Checklist after merging Pull Request
- [ ] Deploy to the production servers that are experiencing this problem.