### PR TITLE
Enable expiration plugins so that ldap expiration surfaces

### DIFF
--- a/atmosphere/plugins/auth/expiration.py
+++ b/atmosphere/plugins/auth/expiration.py
@@ -12,10 +12,15 @@ class ExpirationPlugin(object):
             "takes a single argument: 'user'")
 
 
-class AlwaysAllow(ExpirationPlugin):
+class NeverExpire(ExpirationPlugin):
     def is_expired(self, user):
         return False
 
+# This plugin reports all accounts as expired. This is useful for testing the
+# UI, without having to make any changes to models.
+class AlwaysExpire(ExpirationPlugin):
+    def is_expired(self, user):
+        return True
 
 class LDAPPasswordExpired(ExpirationPlugin):
     """

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -418,3 +418,16 @@ VALIDATION_PLUGINS = [
     'atmosphere.plugins.auth.validation.AlwaysAllow',
 ]
 {%- endif %}
+
+{%- if EXPIRATION_PLUGINS %}
+EXPIRATION_PLUGINS = [
+{%- for plugin in EXPIRATION_PLUGINS %}
+  "{{ plugin }}",
+{%- endfor %}
+]
+{%- else %}
+EXPIRATION_PLUGINS = [
+    # 'atmosphere.plugins.auth.expiration.LDAPPasswordExpired',
+    'atmosphere.plugins.auth.expiration.NeverExpire',
+]
+{%- endif %}

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -108,6 +108,7 @@ INSTANCE_HOSTNAMING_DOMAIN = ; iplantcollaborative.org
 INSTANCE_HOSTNAMING_FORMAT = ; vm%(three)s-%(four)s.%(domain)s
 DEPLOYMENT_KEYPAIR_NAME = ; keypair name inject by atmo-ansible during instance deploy
 VALIDATION_PLUGINS = ; ["atmosphere.plugins.auth.validation.AlwaysAllow"]
+EXPIRATION_PLUGINS = ; ["atmosphere.plugins.auth.validation.NeverExpire"]
 
 #NOTE: Jetstream Specific
 TACC_API_USER = ; "tas-username"


### PR DESCRIPTION
If the following line is added to variables.ini:

    EXPIRATION_PLUGINS = ['atmosphere.plugins.auth.expiration.LDAPPasswordExpired']

Then whenever an LDAP password expires, the AtmosphereUser will have:

    {
    ...
    is_expired=True
    ...
    }

The UI can leverage this state, to prevent instance launches and provide
feedback.

I tested this with ldap enabled an an expired password, and confirmed the ui showed the updated warnings.

I tested the updated clank variables and deployed against a vm.

See https://github.com/cyverse/troposphere/pull/555 for the tropo component.
## Description


## Checklist before merging Pull Requests
- [ ] Production variables need to be udpated (dev/beta/prod/local)
    - [ ]  Merge atmosphere group vars in [clank pr](https://github.com/cyverse/clank/pull/163)
    - [ ]  Merge variables files in private repos
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
