### PR TITLE
Problem: Instance report email shows wrong provider

### DIFF
--- a/api/v2/views/email.py
+++ b/api/v2/views/email.py
@@ -99,7 +99,7 @@ class InstanceSupportEmailViewSet(EmailViewSet):
             "ui": data.get("user-interface", ""),
             "server": settings.SERVER_URL,
             "message": data["message"],
-            "provider": user.selected_identity.provider,
+            "provider": instance.provider,
             "instance": instance,
             "status": last_status
         }


### PR DESCRIPTION
## Description

Problem: Instance report email shows wrong provider

Solution: Get the provider from the instance instead of the
`user.selected_identity.provider`

refs [#ATMO-1744](https://pods.iplantcollaborative.org/jira/browse/ATMO-1774)

## Checklist before merging Pull Requests
~~- [ ] New test(s) included to reproduce the bug/verify the feature~~
~~- [ ] Documentation created/updated at [Example link to documentation]~~(https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.  
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
