### PR TITLE
Problem: Typo in variable

### DIFF
--- a/api/tests/v2/test_image_metrics.py
+++ b/api/tests/v2/test_image_metrics.py
@@ -56,7 +56,7 @@ class InstanceTests(APITestCase):
             created_by_identity=self.user_identity,
             start_date=start_date)
 
-        build = InstanceStatusFactory.create(name='build')
+        self.status_build = InstanceStatusFactory.create(name='build')
         self.status_suspended = InstanceStatusFactory.create(name='suspended')
         self.status_active = InstanceStatusFactory.create(name='active')
         self.status_networking = InstanceStatusFactory.create(name='networking')


### PR DESCRIPTION
## Description

Problem: Typo in variable

Solution: Change `build` to `self.status_build`

Note: This test still breaks, but I'm not sure why. See #294

## Checklist before merging Pull Requests
~~- [ ] New test(s) included to reproduce the bug/verify the feature~~
~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
- [ ] Reviewed and approved by at least one other contributor.
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
