### PR TITLE
Small updates from the Jetstream server

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -167,9 +167,9 @@ JETSTREAM_CELERYBEAT_SCHEDULE = {
     },
   "monitor_jetstream_allocation_sources":{
 	"task":"monitor_jetstream_allocation_sources",
-        # Every 15 minutes
-        "schedule": crontab(minute="*/15"),
-        "options" : {"expires": 10 * 60,"time_limit": 10 * 60}
+        # Every 60 minutes, no longer than 45 minutes
+        "schedule": crontab(minute="*/60"),
+        "options" : {"expires": 45 * 60,"time_limit": 45 * 60}
   }
 }
 CELERYBEAT_SCHEDULE.update(JETSTREAM_CELERYBEAT_SCHEDULE)

--- a/core/models/machine_request.py
+++ b/core/models/machine_request.py
@@ -297,6 +297,8 @@ class MachineRequest(BaseRequest):
         old_admin = old_provider.get_admin_identity().get_credentials()
         if 'ex_force_auth_version' not in old_creds:
             old_creds['ex_force_auth_version'] = '2.0_password'
+        if old_creds['ex_force_auth_version'] != '2.0_password' and 'domain_name' not in old_creds:
+            old_creds['domain_name'] = 'default'
         old_creds.update(old_admin)
 
         new_provider = self.new_machine_provider
@@ -308,6 +310,8 @@ class MachineRequest(BaseRequest):
                 new_creds['ex_force_auth_version'] = '2.0_password'
             new_admin = new_provider.get_admin_identity().get_credentials()
             new_creds.update(new_admin)
+        if new_creds.get('ex_force_auth_version','') != '2.0_password' and 'domain_name' not in new_creds:
+            new_creds['domain_name'] = 'default'
 
         return (old_creds, new_creds)
 

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -441,30 +441,33 @@ class AccountDriver(BaseAccountDriver):
                     for member in shared_with]
         return projects
 
-    def share_image_with_project(self, glance_image, project_name):
+    def share_image_with_identity(self, glance_image, identity):
         try:
+            project_name = identity.project_name()
             self.image_manager.share_image(glance_image, project_name)
-            self.accept_shared_image(glance_image, project_name)
-            logger.info("Added Cloud Access: %s-%s"
-                        % (glance_image, project_name))
         except GlanceClientException as gce:
             message = gce.details
             if 'is duplicated for image' not in message\
                     and 'is already associated with image' not in message:
                 raise
+        self.accept_shared_image(glance_image, identity)
 
-    def accept_shared_image(self, glance_image, project_name):
+    def accept_shared_image(self, glance_image, identity):
         """
         This is only required when sharing using 'the v2 api' on glance.
         """
-        # FIXME: Abusing the 'project_name' == 'username' mapping
-        clients = self.get_openstack_clients(project_name)
+        username = identity.get_credential('key')
+        password = identity.get_credential('secret')
+        project_name = identity.project_name()
+        clients = self.get_openstack_clients(username, password, project_name)
         project = self.user_manager.get_project(project_name)
         glance = clients["glance"]
         glance.image_members.update(
             glance_image.id,
             project.id,
             'accepted')
+        logger.info("Added Cloud Access: %s-%s"
+                    % (glance_image, project_name))
 
         
 

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -327,10 +327,10 @@ class AccountDriver(BaseAccountDriver):
         kwargs = {}
         if self.identity_version > 2:
             kwargs.update({'domain': 'default'})
-        user_matches = [u for u in self.user_manager.keystone.users.list(**kwargs) if u.name == username]
-        if not user_matches or len(user_matches) > 1:
-            raise Exception("User maps to *MORE* than one account on openstack default domain! Ask a programmer for help here!")
-        user = user_matches[0]
+            user_matches = [u for u in self.user_manager.keystone.users.list(**kwargs) if u.name == username]
+            if not user_matches or len(user_matches) > 1:
+                raise Exception("User maps to *MORE* than one account on openstack default domain! Ask a programmer for help here!")
+            user = user_matches[0]  # Not used
         kwargs = {}
         if self.identity_version > 2:
             kwargs.update({'domain_id': 'default'})
@@ -361,7 +361,7 @@ class AccountDriver(BaseAccountDriver):
             return None
         # Start creating security group
         return self.user_manager.build_security_group(
-            user.name, password, project.name,
+            username, password, project.name,
             security_group_name, rules_list)
 
     def add_rules_to_security_groups(self, core_identity_list,

--- a/service/machine.py
+++ b/service/machine.py
@@ -265,12 +265,13 @@ def update_cloud_membership_for_machine(provider_machine, group):
             logger.debug("Skipped %s -- Wrong provider" % identity_membership.identity)
             continue
         # Get project name from the identity's credential-list
-        project_name = identity_membership.identity.get_credential('ex_project_name')
+        identity = identity_membership.identity
+        project_name = identity.get_credential('ex_project_name')
         project = accounts.get_project(project_name)
         if project and project not in projects:
             logger.debug("Skipped Project: %s -- Already shared" % project)
             continue
-        accounts.share_image_with_project(img, project_name)
+        accounts.share_image_with_identity(img, identity)
 
 
 def update_db_membership_for_group(provider_machine, group):


### PR DESCRIPTION
## Description
These unstaged changes were on the jetstream server and should be included before the next release.

**Highlights:**
- Bugfix: Include domain_name for non-2.0 password auth (on openstack clouds)
- Internal: Increase time limit and duration for allocation monitoring tasks.
- Bugfix: Updated 'share_image' to pass Identity (for all credentials) rather than just project_name.


## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
