### PR TITLE
Remove ScriptDeployment from mount_volume tasks

### DIFF
--- a/service/deploy.py
+++ b/service/deploy.py
@@ -76,6 +76,24 @@ def ready_to_deploy(instance_ip, username, instance_id):
         limit_playbooks=['check_networking.yml'])
 
 
+def deploy_check_volume(instance_ip, username, instance_id,
+        device, device_type='ext4'):
+    """
+    Use service.ansible to deploy to an instance.
+    """
+    extra_vars = {
+        "VOLUME_DEVICE": device,
+        "VOLUME_DEVICE_TYPE": device_type,
+    }
+    playbooks_dir = settings.ANSIBLE_PLAYBOOKS_DIR
+    playbooks_dir = os.path.join(playbooks_dir, 'utils')
+    limit_playbooks = ['check_volume.yml']
+    return ansible_deployment(
+        instance_ip, username, instance_id, playbooks_dir,
+        limit_playbooks=limit_playbooks,
+        extra_vars=extra_vars)
+
+
 def instance_deploy(instance_ip, username, instance_id,
 		    limit_playbooks=[]):
     """

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -98,7 +98,7 @@ def deploy_mount_volume(instance_ip, username, instance_id,
 def deploy_check_volume(instance_ip, username, instance_id,
         device, device_type='ext4'):
     """
-    Use service.ansible to deploy to an instance.
+    Use ansible to check if an attached volume has run mkfs.
     """
     extra_vars = {
         "VOLUME_DEVICE": device,

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -76,6 +76,25 @@ def ready_to_deploy(instance_ip, username, instance_id):
         limit_playbooks=['check_networking.yml'])
 
 
+def deploy_mount_volume(instance_ip, username, instance_id,
+        device, mount_location=None, device_type='ext4'):
+    """
+    Use service.ansible to mount volume to an instance.
+    """
+    extra_vars = {
+        "VOLUME_DEVICE": device,
+        "VOLUME_MOUNT_LOCATION": mount_location,
+        "VOLUME_DEVICE_TYPE": device_type,
+    }
+    playbooks_dir = settings.ANSIBLE_PLAYBOOKS_DIR
+    playbooks_dir = os.path.join(playbooks_dir, 'utils')
+    limit_playbooks = ['mount_volume.yml']
+    return ansible_deployment(
+        instance_ip, username, instance_id, playbooks_dir,
+        limit_playbooks=limit_playbooks,
+        extra_vars=extra_vars)
+
+
 def deploy_check_volume(instance_ip, username, instance_id,
         device, device_type='ext4'):
     """
@@ -417,16 +436,6 @@ def check_process(proc_name):
         % (proc_name, proc_name, proc_name),
         name="./deploy_check_process_%s.sh"
         % (proc_name,))
-
-
-def check_volume(device):
-    return ScriptDeployment("tune2fs -l %s" % (device),
-                            name="./deploy_check_volume.sh")
-
-
-def mkfs_volume(device):
-    return ScriptDeployment("mkfs.ext3 -F %s" % (device),
-                            name="./deploy_mkfs_volume.sh")
 
 
 def umount_volume(mount_location):

--- a/service/instance.py
+++ b/service/instance.py
@@ -1816,11 +1816,16 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
     instance_id = esh_instance.alias
     volume_id = action_params.get('volume_id')
     mount_location = action_params.get('mount_location')
-    device = action_params.get('device')
+
+    # TODO: We are taking 'device' as a param
+    # but we don't *need* to. volume_id will provide this for us.
+    # Remove this param (and comment) in the future...
+    device_location= action_params.get('device')
+    if device_location == 'null' or device_location == 'None':
+        device_location = None
+
     if mount_location == 'null' or mount_location == 'None':
         mount_location = None
-    if device == 'null' or device == 'None':
-        device = None
     if 'attach_volume' == action_type:
         instance_status = esh_instance.extra.get('status', "N/A")
         if instance_status != 'active':

--- a/service/instance.py
+++ b/service/instance.py
@@ -1830,11 +1830,11 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
                 'Retry request when instance is active.'
                 % (instance_id, instance_status))
         result = task.attach_volume_task(
-                esh_driver, esh_instance.alias,
+                identity, esh_driver, esh_instance.alias,
                 volume_id, device, mount_location)
     elif 'mount_volume' == action_type:
         result = task.mount_volume_task(
-                esh_driver, esh_instance.alias,
+                identity, esh_driver, esh_instance.alias,
                 volume_id, device, mount_location)
     elif 'unmount_volume' == action_type:
         (result, error_msg) =\

--- a/service/instance.py
+++ b/service/instance.py
@@ -1836,16 +1836,16 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
                 % (instance_id, instance_status))
         result = task.attach_volume_task(
                 identity, esh_driver, esh_instance.alias,
-                volume_id, device, mount_location)
+                volume_id, device_location, mount_location)
     elif 'mount_volume' == action_type:
         result = task.mount_volume_task(
                 identity, esh_driver, esh_instance.alias,
-                volume_id, device, mount_location)
+                volume_id, device_location, mount_location)
     elif 'unmount_volume' == action_type:
         (result, error_msg) =\
             task.unmount_volume_task(esh_driver,
                                      esh_instance.alias,
-                                     volume_id, device,
+                                     volume_id, device_location,
                                      mount_location)
     elif 'detach_volume' == action_type:
         instance_status = esh_instance.extra['status']

--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -106,8 +106,9 @@ def mount_task(driverCls, provider, identity, instance_id, volume_id,
                                % (volume,))
         if not device:
             raise Exception("No device found or inferred by volume %s" % volume)
+        last_char = device[-1]
         if not mount_location:
-            mount_location = "/vol-" + device[-1]
+            mount_location = "/vol_" + last_char
         playbooks = deploy_mount_volume(
             instance.ip, username, instance.id,
             device, mount_location=mount_location, device_type=device_type)

--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -405,16 +405,17 @@ def update_volume_metadata(driverCls, provider,
 
 
 @task(name="mount_failed")
-def mount_failed(task_uuid, driverCls, provider, identity, volume_id,
-                 unmount=False, **celery_task_args):
+def mount_failed(
+        context,
+        exception_msg,
+        traceback,
+        driverCls, provider, identity, volume_id,
+        unmount=False, **celery_task_args):
     from service import volume as volume_service
     try:
         celery_logger.debug("mount_failed task started at %s." % datetime.now())
-        celery_logger.info("task_uuid=%s" % task_uuid)
-        result = app.AsyncResult(task_uuid)
-        with allow_join_result():
-            exc = result.get(propagate=False)
-        err_str = "Mount Error Traceback:%s" % (result.traceback,)
+        celery_logger.info("task context=%s" % context)
+        err_str = "%s\nMount Error Traceback:%s" % (exception_msg, traceback)
         celery_logger.error(err_str)
         driver = get_driver(driverCls, provider, identity)
         volume = driver.get_volume(volume_id)

--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -17,11 +17,12 @@ from rtwo.exceptions import LibcloudDeploymentError
 
 from atmosphere.settings.local import ATMOSPHERE_PRIVATE_KEYFILE
 
-from core.email import send_instance_email
-
 from service.driver import get_driver
-from service.deploy import mount_volume, check_volume, mkfs_volume,\
-    check_mount, umount_volume, lsof_location
+from service.deploy import (
+    mount_volume,
+    check_mount, umount_volume, lsof_location,
+    deploy_check_volume,
+    build_host_name, execution_has_failures, execution_has_unreachable)
 from service.exceptions import DeviceBusyException
 
 
@@ -30,45 +31,33 @@ from service.exceptions import DeviceBusyException
       default_retry_delay=20,
       ignore_result=False)
 def check_volume_task(driverCls, provider, identity,
-                      instance_id, volume_id, *args, **kwargs):
+                      instance_id, volume_id, device_type='ext4', *args, **kwargs):
     try:
         celery_logger.debug("check_volume task started at %s." % datetime.now())
         driver = get_driver(driverCls, provider, identity)
         instance = driver.get_instance(instance_id)
         volume = driver.get_volume(volume_id)
+        username = identity.get_username()
         attach_data = volume.extra['attachments'][0]
         device = attach_data['device']
 
         private_key = ATMOSPHERE_PRIVATE_KEYFILE
         kwargs.update({'ssh_key': private_key})
         kwargs.update({'timeout': 120})
-
+        celery_logger.info("Device: %s" % device)
         # One script to make two checks:
         # 1. Voume exists 2. Volume has a filesystem
-        cv_script = check_volume(device)
-        # NOTE: non_zero_deploy needed to stop LibcloudDeploymentError from being
-        # raised
-        kwargs.update({'deploy': cv_script,
-                       'non_zero_deploy': True})
-        driver.deploy_to(instance, **kwargs)
-        kwargs.pop('non_zero_deploy', None)
-        # Script execute
-
-        if cv_script.exit_status != 0:
-            if 'No such file' in cv_script.stdout:
-                raise Exception('Volume check failed: %s. '
-                                'Device %s does not exist on instance %s'
-                                % (volume, device, instance))
-            elif 'Bad magic number' in cv_script.stdout:
-                # Filesystem needs to be created for this device
-                celery_logger.info("Mkfs needed")
-                mkfs_script = mkfs_volume(device)
-                kwargs.update({'deploy': mkfs_script})
-                driver.deploy_to(instance, **kwargs)
-            else:
-                raise Exception('Volume check failed: Something weird')
-
-        celery_logger.debug("check_volume task finished at %s." % datetime.now())
+        playbooks = deploy_check_volume(
+            instance.ip, username, instance.id,
+            device, device_type=device_type)
+        celery_logger.info(playbooks.__dict__)
+        hostname = build_host_name(instance.id, instance.ip)
+        result = False if execution_has_failures(playbooks, hostname) or execution_has_unreachable(playbooks, hostname) else True
+        if not result:
+            raise Exception(
+                "Error encountered while checking volume for filesystem: %s"
+                % playbooks.stats.summarize(host=hostname))
+        return result
     except LibcloudDeploymentError as exc:
         celery_logger.exception(exc)
     except Exception as exc:


### PR DESCRIPTION
## Description

- [x] Support for ext4 as default filesystem type.
- [x] Allow overriding the default filesystem type via cloud config option: `provider.cloud_config["deploy"]["volume_fs_type"]`
- [x] Allow overriding the default volume mount prefix `/vol_` via cloud config option: `provider.cloud_config['deploy']['volume_mount_prefix']`
- [x] Ansible modules over ScriptDeployment for 'checking' and 'mounting' the volume.

## Related PRs
https://github.com/cyverse/atmosphere-ansible/pull/79

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
