### PR TITLE
WIP DON'T MERGE - Problem: Jetstream TAS API tests don't run without 'jetstream' app

### DIFF
--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -24,7 +24,7 @@ class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
 
     @my_vcr.use_cassette()
-    def test_validate_account(cassette, self):
+    def test_validate_account(self, cassette):
         """Test for a valid account based on the business logic assigned by Jetstream"""
         from jetstream.plugins.auth.validation import XsedeProjectRequired
         jetstream_auth_plugin = XsedeProjectRequired()
@@ -35,7 +35,7 @@ class TestJetstream(TestCase):
         assert_cassette_playback_length(cassette, 2)
 
     @my_vcr.use_cassette()
-    def test_get_all_allocations(cassette, self):
+    def test_get_all_allocations(self, cassette):
         """Test retrieving allocations for a Jetstream user"""
         from jetstream.allocation import TASAPIDriver
         tas_driver = TASAPIDriver()
@@ -55,7 +55,7 @@ class TestJetstream(TestCase):
         assert_cassette_playback_length(cassette, 1)
 
     @my_vcr.use_cassette()
-    def test_get_all_projects(cassette, self):
+    def test_get_all_projects(self, cassette):
         """Test retrieving projects for a Jetstream user"""
         from jetstream.allocation import TASAPIDriver
         tas_driver = TASAPIDriver()

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -19,10 +19,10 @@ my_vcr = vcr.VCR(
 @modify_settings(INSTALLED_APPS={
     'append': 'jetstream',
 })
+@override_settings(TACC_API_URL='https://localhost/api-test')
 class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
 
-    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
     def test_validate_account(cassette, self):
         """Test for a valid account based on the business logic assigned by Jetstream"""
@@ -34,7 +34,6 @@ class TestJetstream(TestCase):
         self.assertTrue(is_jetstream_valid)
         assert_cassette_playback_length(cassette, 2)
 
-    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
     def test_get_all_allocations(cassette, self):
         """Test retrieving allocations for a Jetstream user"""
@@ -55,7 +54,6 @@ class TestJetstream(TestCase):
 
         assert_cassette_playback_length(cassette, 1)
 
-    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
     def test_get_all_projects(cassette, self):
         """Test retrieving projects for a Jetstream user"""

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -2,10 +2,9 @@ import json
 
 import freezegun
 import vcr
-from django.test import TestCase
-from django.conf import settings
-from api.tests.factories import UserFactory
+from django.test import TestCase, override_settings, modify_settings
 
+from api.tests.factories import UserFactory
 from test_utils.cassette_utils import assert_cassette_playback_length, scrub_host_name
 
 my_vcr = vcr.VCR(
@@ -17,15 +16,15 @@ my_vcr = vcr.VCR(
 )
 
 
+@modify_settings(INSTALLED_APPS={
+    'append': 'jetstream',
+})
 class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
 
-    def setUp(self):
-        if 'jetstream' not in settings.INSTALLED_APPS:
-            self.skipTest('jetstream not in settings.INSTALLED_APPS')
-
+    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
-    def test_validate_account(self, cassette):
+    def test_validate_account(cassette, self):
         """Test for a valid account based on the business logic assigned by Jetstream"""
         from jetstream.plugins.auth.validation import XsedeProjectRequired
         jetstream_auth_plugin = XsedeProjectRequired()
@@ -35,8 +34,9 @@ class TestJetstream(TestCase):
         self.assertTrue(is_jetstream_valid)
         assert_cassette_playback_length(cassette, 2)
 
+    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
-    def test_get_all_allocations(self, cassette):
+    def test_get_all_allocations(cassette, self):
         """Test retrieving allocations for a Jetstream user"""
         from jetstream.allocation import TASAPIDriver
         tas_driver = TASAPIDriver()
@@ -55,8 +55,9 @@ class TestJetstream(TestCase):
 
         assert_cassette_playback_length(cassette, 1)
 
+    @override_settings(TACC_API_URL='https://localhost/api-test')
     @my_vcr.use_cassette()
-    def test_get_all_projects(self, cassette):
+    def test_get_all_projects(cassette, self):
         """Test retrieving projects for a Jetstream user"""
         from jetstream.allocation import TASAPIDriver
         tas_driver = TASAPIDriver()


### PR DESCRIPTION
## Description

Problem: Jetstream TAS API tests don't run without 'jetstream' app

Solution: Modify `TestJetstream` to override settings in order to allow
tests to work.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
- [ ] Reviewed and approved by at least one other contributor.
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
