### PR TITLE
WIP - DON'T MERGE - Simplify allocations

### DIFF
--- a/atmosphere/settings/testing.j2
+++ b/atmosphere/settings/testing.j2
@@ -43,3 +43,8 @@ INSTALLED_APPS += (
     'django_jenkins',
 )
 {% endif %}
+
+
+INSTALLED_APPS += (
+    'behave_django',
+)

--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,3 +1,5 @@
+behave
+behave-django
 coverage
 colorama==0.3.3 # used by ./configure
 django-debug-toolbar  #NOTE: Profiles SQL/CPU time of requests real-time.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,10 @@
 #    pip-compile --output-file dev_requirements.txt dev_requirements.in
 #
 appdirs==1.4.3            # via setuptools
+appnope==0.1.0            # via ipython
 backports.shutil-get-terminal-size==1.0.0  # via ipython
+behave-django==0.5.0
+behave==1.2.5
 click==6.7                # via pip-tools
 colorama==0.3.3
 configparser==3.5.0       # via flake8
@@ -15,9 +18,9 @@ decorator==4.0.11         # via ipython, traitlets
 django-debug-toolbar==1.7
 django-jenkins==0.19.0
 django-nose==1.4.4
-Django==1.10.6            # via django-debug-toolbar, django-jenkins
+django==1.10.6            # via behave-django, django-debug-toolbar, django-jenkins
 emoji==0.3.6
-enum34==1.1.6             # via flake8, traitlets
+enum34==1.1.6             # via flake8, parse-type, traitlets
 factory-boy==2.4.1
 first==2.0.1              # via pip-tools
 flake8==3.3.0
@@ -33,6 +36,8 @@ mock==1.0.1
 newrelic==2.64.0.48
 nose==1.3.7               # via django-nose
 packaging==16.8           # via setuptools
+parse-type==0.3.4         # via behave
+parse==1.8.0              # via behave, parse-type
 pathlib2==2.2.1           # via ipython, pickleshare
 pathlib==1.0.1
 pep8==1.7.0

--- a/jetstream/allocation.py
+++ b/jetstream/allocation.py
@@ -86,6 +86,9 @@ class TASAPIDriver(object):
     def get_all_project_users(self):
         if not self.user_project_list:
             self.project_list = self._get_all_projects()
+            with open('/tmp/project_list.json', 'w') as f:  # TODO: DON'T COMMIT
+                import json
+                json.dump(self.project_list, fp=f, indent=2)
             for project in sorted(self.project_list, key=lambda p: p['id']):
                 project_users = self.get_project_users(project['id'])
                 project['users'] = project_users

--- a/jetstream/features/environment.py
+++ b/jetstream/features/environment.py
@@ -1,0 +1,7 @@
+def before_feature(context, feature):
+    import pydevd
+    pydevd.settrace('127.0.0.1', port=4567, stdoutToServer=True, stderrToServer=True, suspend=False)
+
+
+def before_scenario(context, scenario):
+    pass

--- a/jetstream/features/environment.py
+++ b/jetstream/features/environment.py
@@ -1,6 +1,5 @@
 def before_feature(context, feature):
-    import pydevd
-    pydevd.settrace('127.0.0.1', port=4567, stdoutToServer=True, stderrToServer=True, suspend=False)
+    pass
 
 
 def before_scenario(context, scenario):

--- a/jetstream/features/monitor_jetstream_allocation_sources.feature
+++ b/jetstream/features/monitor_jetstream_allocation_sources.feature
@@ -1,0 +1,59 @@
+Feature: Monitor Jetstream Allocation Sources
+  Monitoring the TACC API for Jetstream allocation sources
+
+  Background: Some TAS API fixtures
+    Given a TAS API driver
+    And we clear the local cache
+    And the following Atmosphere users:
+      | username |
+      | user107  |
+      | user108  |
+      | user109  |
+      | user110  |
+      | user111  |
+    And the following XSEDE to TACC username mappings:
+    # Note: No tacc_username for `user107`
+      | xsede_username | tacc_username |
+      | user108        | tacc_user108  |
+      | user109        | tacc_user109  |
+      | user110        | tacc_user110  |
+      | user111        | tacc_user111  |
+    And the following TAS projects:
+      | id    | chargeCode   |
+      | 29444 | TG-BIO150062 |
+      | 29456 | TG-TRA160003 |
+    And the following TAS allocations:
+      | id    | projectId | project      | computeAllocated | computeUsed | start                | end                  | status   |
+      | 38229 | 29444     | TG-BIO150062 | 1000000          | 781768.01   | 2016-01-01T06:00:00Z | 2017-06-30T05:00:00Z | Active   |
+      | 38271 | 29456     | TG-TRA160003 | 500000           | 583803.28   | 2016-01-22T06:00:00Z | 2017-01-21T06:00:00Z | Active   |
+      | 45184 | 29456     | TG-TRA160003 | 500000           | 87914.06    | 2017-01-22T06:00:00Z | 2018-01-21T06:00:00Z | Active   |
+      | 55184 | 29456     | TG-TRA160003 | 500000           | 87914.06    | 2018-01-22T06:00:00Z | 2019-01-21T06:00:00Z | Approved |
+    And the following TACC usernames for TAS projects:
+      | project_id | tacc_usernames            |
+      | 29444      | tacc_user108,tacc_user109 |
+      | 29456      | tacc_user109,tacc_user111 |
+
+
+  Scenario: Get all projects
+    When we get all projects
+    Then we should have the following local projects:
+      | id    | chargeCode   |
+      | 29444 | TG-BIO150062 |
+      | 29456 | TG-TRA160003 |
+
+  Scenario: From empty database
+    When we fill user allocation sources from TAS
+    Then we should have the following local username mappings:
+      | key     | value        |
+      | user108 | tacc_user108 |
+      | user109 | tacc_user109 |
+      | user110 | tacc_user110 |
+      | user111 | tacc_user111 |
+    And we should have the following local projects:
+      | id    | chargeCode   |
+      | 29444 | TG-BIO150062 |
+      | 29456 | TG-TRA160003 |
+
+
+#  Scenario: From having existing allocation sources in the database
+#    # Enter steps here

--- a/jetstream/features/monitor_jetstream_allocation_sources.feature
+++ b/jetstream/features/monitor_jetstream_allocation_sources.feature
@@ -40,9 +40,17 @@ Feature: Monitor Jetstream Allocation Sources
       | id    | chargeCode   |
       | 29444 | TG-BIO150062 |
       | 29456 | TG-TRA160003 |
+    And we should have the following local allocations:
+      | id    | projectId | project      | computeAllocated | computeUsed | start                | end                  | status   |
+      | 38229 | 29444     | TG-BIO150062 | 1000000          | 781768.01   | 2016-01-01T06:00:00Z | 2017-06-30T05:00:00Z | Active   |
+      | 38271 | 29456     | TG-TRA160003 | 500000           | 583803.28   | 2016-01-22T06:00:00Z | 2017-01-21T06:00:00Z | Active   |
+      | 45184 | 29456     | TG-TRA160003 | 500000           | 87914.06    | 2017-01-22T06:00:00Z | 2018-01-21T06:00:00Z | Active   |
+      | 55184 | 29456     | TG-TRA160003 | 500000           | 87914.06    | 2018-01-22T06:00:00Z | 2019-01-21T06:00:00Z | Approved |
 
-  Scenario: From empty database
-    When we fill user allocation sources from TAS
+
+  Scenario: Fill user allocation sources
+    When we get all projects
+    And we fill user allocation sources from TAS
     Then we should have the following local username mappings:
       | key     | value        |
       | user108 | tacc_user108 |
@@ -53,6 +61,7 @@ Feature: Monitor Jetstream Allocation Sources
       | id    | chargeCode   |
       | 29444 | TG-BIO150062 |
       | 29456 | TG-TRA160003 |
+    # TODO: User allocation mapping
 
 
 #  Scenario: From having existing allocation sources in the database

--- a/jetstream/features/steps/tas_api_steps.py
+++ b/jetstream/features/steps/tas_api_steps.py
@@ -2,7 +2,6 @@ import copy
 
 import mock
 from behave import *
-from behave import when
 
 import jetstream.allocation as jetstream_allocation
 import jetstream.exceptions as jetstream_exceptions
@@ -119,10 +118,20 @@ def we_should_have_the_following_local_username_mappings(context):
 @then(u'we should have the following local projects')
 def we_should_have_the_following_local_projects(context):
     expected_local_projects = [dict(zip(row.headings, row.cells)) for row in context.table]
-    context.test.maxDiff = None
     projects_without_allocations = []
     for project in context.driver.project_list:
         project_without_allocations = copy.copy(project)
         del project_without_allocations['allocations']
         projects_without_allocations.append(project_without_allocations)
     context.test.assertListEqual(projects_without_allocations, expected_local_projects)
+
+
+@then(u'we should have the following local allocations')
+def we_should_have_the_following_local_allocations(context):
+    expected_local_allocations = [dict(zip(row.headings, row.cells)) for row in context.table]
+    context.test.maxDiff = None
+    local_allocations = []
+    for local_project in context.driver.project_list:
+        for local_allocation in local_project['allocations']:
+            local_allocations.append(local_allocation)
+    context.test.assertListEqual(local_allocations, expected_local_allocations)

--- a/jetstream/features/steps/tas_api_steps.py
+++ b/jetstream/features/steps/tas_api_steps.py
@@ -1,0 +1,118 @@
+from behave import *
+import mock
+
+import jetstream.allocation as jetstream_allocation
+import jetstream.exceptions as jetstream_exceptions
+
+
+def _make_mock_xsede_to_tacc_username(xsede_to_tacc_username_mapping):
+    def _mock_xsede_to_tacc_username(xsede_username):
+        if xsede_username not in xsede_to_tacc_username_mapping:
+            raise jetstream_exceptions.TASAPINoValidUsernameFound(xsede_username)
+
+        return xsede_to_tacc_username_mapping[xsede_username]
+
+    return _mock_xsede_to_tacc_username
+
+
+def _make_mock_get_all_projects(tas_projects):
+    def _mock_get_all_projects():
+        return tas_projects
+
+    return _mock_get_all_projects
+
+
+def _make_mock_project_users(tas_project_to_tacc_username_mapping):
+    def _mock_get_project_users(project_id):
+        return tas_project_to_tacc_username_mapping[project_id]
+
+    return _mock_get_project_users
+
+
+@given(u'the following Atmosphere users')
+def these_atmosphere_users(context):
+    from core.models import AtmosphereUser
+    atmo_users = [dict(zip(row.headings, row.cells)) for row in context.table]
+    for atmo_user in atmo_users:
+        AtmosphereUser.objects.create(username=atmo_user['username'])
+
+
+@given(u'a TAS API driver')
+def a_tas_api_driver(context):
+    context.driver = jetstream_allocation.TASAPIDriver()
+
+
+@given(u'we clear the local cache')
+def we_clear_the_local_cache(context):
+    context.driver.clear_cache()
+    context.test.assertDictEqual(context.driver.username_map, {})
+    context.test.assertListEqual(context.driver.user_project_list, [])
+    context.test.assertListEqual(context.driver.project_list, [])
+    context.test.assertListEqual(context.driver.allocation_list, [])
+
+
+@given(u'the following XSEDE to TACC username mappings')
+def xsede_to_tacc_username_mappings(context):
+    context.xsede_to_tacc_username_mapping = dict(row.cells for row in context.table)
+
+
+@given(u'the following TAS projects')
+def these_tas_projects(context):
+    context.tas_projects = [dict(zip(row.headings, row.cells)) for row in context.table]
+    for tas_project in context.tas_projects:
+        tas_project['allocations'] = []
+
+
+@given(u'the following TAS allocations')
+def these_tas_allocations(context):
+    context.tas_allocations = [dict(zip(row.headings, row.cells)) for row in context.table]
+    for tas_allocation in context.tas_allocations:
+        matching_tas_project = \
+            [project for project in context.tas_projects if project['id'] == tas_allocation['projectId']][0]
+        matching_tas_project['allocations'].append(tas_allocation)
+
+
+@given(u'the following TACC usernames for TAS projects')
+def these_tacc_usernames_for_tas_projects(context):
+    context.tas_project_to_tacc_username_mapping = dict(
+        (row.cells[0], row.cells[1].split(','),) for row in context.table)
+
+
+@when(u'we get all projects')
+def we_get_all_projects(context):
+    with mock.patch.multiple('jetstream.allocation.TASAPIDriver',
+                             _get_all_projects=mock.DEFAULT
+                             ) as mock_methods:
+        mock_methods['_get_all_projects'].side_effect = _make_mock_get_all_projects(context.tas_projects)
+        all_projects = context.driver.get_all_projects()
+    new_driver = jetstream_allocation.TASAPIDriver()
+    context.test.assertListEqual(new_driver.project_list, context.tas_projects)
+
+
+@when(u'we fill user allocation sources from TAS')
+def we_fill_user_allocation_sources_from_tas(context):
+    with mock.patch.multiple('jetstream.allocation.TASAPIDriver',
+                             _xsede_to_tacc_username=mock.DEFAULT,
+                             _get_all_projects=mock.DEFAULT,
+                             get_project_users=mock.DEFAULT
+                             ) as mock_methods:
+        mock_methods['_xsede_to_tacc_username'].side_effect = _make_mock_xsede_to_tacc_username(
+            context.xsede_to_tacc_username_mapping)
+        mock_methods['_get_all_projects'].side_effect = _make_mock_get_all_projects(context.tas_projects)
+        mock_methods['get_project_users'].side_effect = _make_mock_project_users(
+            context.tas_project_to_tacc_username_mapping)
+        jetstream_allocation.fill_user_allocation_sources()
+    pass
+
+
+@then(u'we should have the following local username mappings')
+def we_should_have_the_following_local_username_mappings(context):
+    expected_username_map = dict(row.cells for row in context.table)
+    context.test.assertDictEqual(jetstream_allocation.TASAPIDriver.username_map, expected_username_map)
+
+
+@then(u'we should have the following local projects')
+def we_should_have_the_following_local_projects(context):
+    expected_local_projects = [dict(zip(row.headings, row.cells)) for row in context.table]
+    new_driver = jetstream_allocation.TASAPIDriver()
+    context.test.assertListEqual(new_driver.project_list, expected_local_projects)

--- a/jetstream/fixtures/test_get_tacc_username_api_problem.yaml
+++ b/jetstream/fixtures/test_get_tacc_username_api_problem.yaml
@@ -1,0 +1,30 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Basic XXXXX]
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.11.1]
+    method: GET
+    uri: https://localhost/api-test/v1/users/xsede/jfischer
+  response:
+    body: {string: !!python/unicode '{"status":"error","message":"Unexpected error
+        looking up TACC account for XSEDE username jfischer","result":"FATAL: 28P01:
+        password authentication failed for user \"portaldev\""}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Content-Type, Accept, Authorization']
+      access-control-allow-methods: ['GET, POST, PUT, DELETE, OPTIONS']
+      access-control-allow-origin: ['*']
+      cache-control: ['private, s-maxage=0,no-cache']
+      content-length: ['178']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 25 Jan 2017 17:56:38 GMT']
+      server: [Microsoft-IIS/8.5]
+      x-aspnet-version: [4.0.30319]
+      x-aspnetmvc-version: ['3.0']
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/jetstream/tas_api.py
+++ b/jetstream/tas_api.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def tacc_api_post(url, post_data, username=None, password=None):
+    raise NotImplementedError  # TODO: DON'T COMMIT
     if not username:
         username = settings.TACC_API_USER
     if not password:
@@ -22,6 +23,7 @@ def tacc_api_post(url, post_data, username=None, password=None):
 
 
 def tacc_api_get(url, username=None, password=None):
+    raise NotImplementedError  # TODO: DON'T COMMIT
     if not username:
         username = settings.TACC_API_USER
     if not password:

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -86,7 +86,7 @@ class TestJetstream(TestCase):
         tas_driver.clear_cache()
         self.assertDictEqual(tas_driver.username_map, {})
         user = UserFactory.create(username='jfischer')
-        with self.assertRaises(Exception):
-            tacc_username = tas_driver.get_tacc_username(user)
+        tacc_username = tas_driver.get_tacc_username(user)
+        self.assertIsNone(tacc_username)
         self.assertDictEqual(tas_driver.username_map, {})
         assert_cassette_playback_length(cassette, 1)

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -73,3 +73,20 @@ class TestJetstream(TestCase):
         self.assertEquals(projects[-1], result[-1])
 
         assert_cassette_playback_length(cassette, 1)
+
+    @my_vcr.use_cassette()
+    def test_get_tacc_username_api_problem(self, cassette):
+        """Make sure we don't return the Atmosphere username when we have trouble connecting to the TAS API.
+        It should fail.
+
+        TODO: Figure out how to handle it gracefully.
+        """
+        from jetstream.allocation import TASAPIDriver
+        tas_driver = TASAPIDriver()
+        tas_driver.clear_cache()
+        self.assertDictEqual(tas_driver.username_map, {})
+        user = UserFactory.create(username='jfischer')
+        with self.assertRaises(Exception):
+            tacc_username = tas_driver.get_tacc_username(user)
+        self.assertDictEqual(tas_driver.username_map, {})
+        assert_cassette_playback_length(cassette, 1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 exclude = /**/migrations
 max-complexity = 10
 max-line-length = 120
+
+[behave]
+paths=jetstream/features/


### PR DESCRIPTION
## Description

Problem: Need to a be able to test allocation logic

Solution:  Test suite with dependencies mocked out for full determinism.

The new BDD tests can be run like so:

```shell
./manage.py behave --keepdb
```

Note: Set `TESTING = True` in your variables.ini for `behave_django` to show up in the generated `local.py` file.

### TODO
- [ ] [Mock `tas_api.tacc_api_post` & `tas_api.tacc_api_get` at the scenario level](https://github.com/orgs/cyverse/projects/2#card-2280085)
  - Maybe using VCR cassettes
- [ ] [Integrate Amit's BDD tests from `cyverse_allocations`](https://github.com/orgs/cyverse/projects/2#card-2280190)
- [ ] [Rebase on to Amit's new allocations branch](https://github.com/orgs/cyverse/projects/2#card-2280202)
- [ ] [Add new scenarios](https://github.com/orgs/cyverse/projects/2#card-2280211)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
