### PR TITLE
iRODS transfer support for application_to_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## [Whimsical-Wyvern](https://github.com/cyverse/atmosphere/milestone/10?closed=1) (as of 3/21/2017)
+## [Whimsical-Wyvern](https://github.com/cyverse/atmosphere/milestone/10?closed=1) (as of 4/6/2017)
 
 Features:
   - Include sentry.io error reporting for production environments
+  - [application_to_provider](https://github.com/cyverse/atmosphere/pull/284) migration script
+  - [iRODS transfer support](https://github.com/cyverse/atmosphere/pull/318) for application_to_provider script
 
 Improvements:
   - Improved support for Instance Actions in v2 APIs

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 -e git+https://github.com/steve-gregory/billiard.git#egg=billiard # TEMPORARY
+-e git+https://github.com/c-mart/python-irodsclient.git@data-object-copy#egg=python-irodsclient  # Temporary until https://github.com/irods/python-irodsclient/pull/67 is merged
 
 Django==1.10.6
 django-cors-headers==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ pyparsing==2.2.0          # via cliff, cmd2, oslo.utils, packaging
 python-cinderclient==1.9.0  # via python-openstackclient, rtwo
 python-dateutil==2.6.0
 python-glanceclient==2.5.0  # via python-openstackclient, rtwo
-python-irodsclient==0.4.0  # via rtwo
+-e git+https://github.com/c-mart/python-irodsclient.git@data-object-copy#egg=python-irodsclient
 python-keystoneclient==3.6.0  # via django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
 python-ldap==2.4.19
 python-logstash==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 -e git+https://github.com/steve-gregory/billiard.git#egg=billiard
+-e git+https://github.com/c-mart/python-irodsclient.git@data-object-copy#egg=python-irodsclient
+
 amqp==2.1.4               # via kombu
 ansible==2.2.1.0          # via subspace
 apache-libcloud==0.20.1
@@ -90,7 +92,8 @@ pyparsing==2.2.0          # via cliff, cmd2, oslo.utils, packaging
 python-cinderclient==1.9.0  # via python-openstackclient, rtwo
 python-dateutil==2.6.0
 python-glanceclient==2.5.0  # via python-openstackclient, rtwo
--e git+https://github.com/c-mart/python-irodsclient.git@data-object-copy#egg=python-irodsclient
+# python-irodsclient commented out until https://github.com/irods/python-irodsclient/pull/67 and https://github.com/cyverse/rtwo/pull/10 are merged
+# python-irodsclient==0.4.0  # via rtwo
 python-keystoneclient==3.6.0  # via django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
 python-ldap==2.4.19
 python-logstash==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
-rtwo==0.5.6
+rtwo==0.5.8
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 six==1.10.0               # via cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-swiftclient, setuptools, stevedore, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -422,9 +422,6 @@ def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, lo
 
 
 def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irods_dst_coll, img_uuid):
-
-    # TODO test me and add exception handling! Test me in sad cases (e.g. bad creds, could not make connection)
-
     sess = iRODSSession(host=irods_conn.get('host'),
                         port=irods_conn.get('port'),
                         zone=irods_conn.get('zone'),

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -439,6 +439,19 @@ def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, lo
 
 
 def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irods_dst_coll, img_uuid):
+    """
+    Migrates image data using iRODS and then sets image location using Glance API.
+
+    Args:
+        dst_glance_client: glance client object for destination provider
+        irods_conn: dict as returned by _parse_irods_conn()
+        irods_src_coll: Path to collection for iRODS images on source provider
+        irods_dst_coll: Path to collection for iRODS images on destination provider
+        img_uuid: UUID of image to be migrated
+
+    Returns:
+
+    """
     sess = iRODSSession(host=irods_conn.get('host'),
                         port=irods_conn.get('port'),
                         zone=irods_conn.get('zone'),
@@ -459,6 +472,7 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
     # Assumption that iRODS copy will always be correct+complete, not inspecting checksums afterward?
     dst_glance_client.images.add_location(img_uuid, dst_img_location, dict())
     logging.info("Set image location in Glance")
+    
 
 
 def _parse_irods_conn(irods_conn_str):

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -432,7 +432,7 @@ def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, lo
                 logging.warning("Image data upload attempt failed")
 
     if src_img.checksum != dst_glance_client.images.get(img_uuid).checksum:
-        raise Exception("Could not upload image data")
+        raise Exception("Image checksums don't match, upload may have failed!")
     else:
         os.remove(local_path)
         return True

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -51,10 +51,15 @@ limited use elsewhere. In order to use it:
 - Credentials passed in --irods-conn must have write access to both source and
   destination collections
 
-When using iRODS transfer, this script does not set data object permissions in
-iRODS. This means that for the destination provider, the iRODS account used by
-Glance server should have write (or own) access to the destination collection
-(where new data objects are created), and *inheritance should be enabled*.
+Considerations when using iRODS transfer:
+- The credentials passed in --irods-conn will be used to populate the image
+  location in the Glance database on the destination provider. Consider passing
+  the iRODS credentials already in use for the Glance iRODS back-end on that
+  provider, and making the source collection readable to same.
+- This script does not set data object permissions in iRODS. This means that
+  for the destination provider, the iRODS account used by Glance server should
+  have write (or own) access to the destination collection (where new data
+  objects are created), and *inheritance should be enabled*.
 """
 
 max_tries = 3  # Maximum number of times to attempt downloading and uploading image data

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -449,8 +449,7 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
         irods_dst_coll: Path to collection for iRODS images on destination provider
         img_uuid: UUID of image to be migrated
 
-    Returns:
-
+    Returns: True if successful, else raises exception
     """
     sess = iRODSSession(host=irods_conn.get('host'),
                         port=irods_conn.get('port'),
@@ -472,7 +471,7 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
     # Assumption that iRODS copy will always be correct+complete, not inspecting checksums afterward?
     dst_glance_client.images.add_location(img_uuid, dst_img_location, dict())
     logging.info("Set image location in Glance")
-    
+    return True
 
 
 def _parse_irods_conn(irods_conn_str):

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -60,6 +60,9 @@ Considerations when using iRODS transfer:
   for the destination provider, the iRODS account used by Glance server should
   have write (or own) access to the destination collection (where new data
   objects are created), and *inheritance should be enabled*.
+- When using iRODS transfer, the Glance image object in the destination provider
+  will not have a checksum (will be "None"). This is a known issue in Glance:
+  https://bugs.launchpad.net/glance/+bug/1551498
 """
 
 max_tries = 3  # Maximum number of times to attempt downloading and uploading image data


### PR DESCRIPTION
This PR adds support for image data transfer via iRODS data object copy, when both the source and destination providers both use the [iRODS storage back-end for Glance](https://github.com/cyverse/glance-irods), and both providers share a common iRODS zone. Very specific to CyVerse atmosphere(0) and perhaps not likely that anyone else will use it! The benefit for us is that migrating images becomes very fast, on the order of a minute rather than 10-30+ minutes.

Using iRODS to transfer image data requires us to reach "around" the Glance API, populating the image data in iRODS out-of-band, and then adding the location to the image object in the Glance API. Unfortunately, using Glance in this way has some caveats:
- Glance does not allow adding a location to an image unless we enable a feature (`show_multiple_locations`) which presents a security issue for us: it would expose a connection string to users which contains credentials for the iRODS service account used by Glance server. For now, commenting out [three lines of code](https://github.com/openstack/glance/blob/master/glance/api/v2/images.py#L294-L297) fixes this limitation. Such a patch will no longer be necessary in OpenStack Pike release, when [`show_multiple_locations` is deprecated](https://github.com/openstack/glance/blob/85eaa3929e5c41396d7c7139446ea9dd098da421/releasenotes/notes/deprecate-show-multiple-location-9890a1e961def2f6.yaml) and instead we can use `policy.json` to control who can set/get image locations.
- The image checksum is not populated in the Glance database when the Glance API is not used to upload image data, so we end up with Glance images that have a checksum of `None`.
  - This means that when we transfer image data using iRODS, `application_to_provider.py` can no longer use checksums to determine if image data needs to be transferred. It needs to use the image size, which is not a strong assurance that the bits match.
  - This could be changed in glance, see [my comment on bug 1551498](https://bugs.launchpad.net/glance/+bug/1551498/comments/4).

## Checklist before merging
- [x] test final changeset against a fresh development environment, ensure that images migrated using iRODS are launchable
- [x] resolve python-irodsclient dependency in rtwo
- [ ] ~ideally get [irods/python-irodsclient #67](https://github.com/irods/python-irodsclient/pull/67) merged so we don't need to use my fork~ (not waiting for this to happen)
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~ (script already referenced [here](https://github.com/cyverse/atmosphere-guides/pull/17/files) and iRODS support options are documented in script help)
- [ ] Reviewed and approved by at least one other contributor.
- [x] If necessary, include a snippet in CHANGELOG.md

## Checklist after merging
- [ ] For a maintainer: backport change to whymsical-wyvern