### PR TITLE
Problem: Latest migration can result in RuntimeError

### DIFF
--- a/core/migrations/0079_add_events_for_old_allocationsource.py
+++ b/core/migrations/0079_add_events_for_old_allocationsource.py
@@ -13,8 +13,7 @@ from core.hooks.allocation_source import (
     listen_for_allocation_source_created_or_renewed,
     listen_for_allocation_source_compute_allowed_changed
 )
-from jetstream.models import TASAPIDriver
-
+from django.apps import apps
 
 def toggle_signals(event_model, on=True):
     if on:
@@ -33,8 +32,16 @@ def toggle_signals(event_model, on=True):
 def add_events_for_old_allocationsource(apps, schema_editor):
     EventTable = apps.get_model('core', 'EventTable')
     AllocationSourceTable = apps.get_model('core', 'AllocationSource')
+    JETSTREAM_INSTALLED = apps.is_installed('jetstream')
+    if not JETSTREAM_INSTALLED:
+        print "Jetstream not installed -- Skipping migration 0079...",
+        return
+    from jetstream.models import TASAPIDriver
 
     api = TASAPIDriver()
+    if not api:
+        print "TASAPIDriver Invalid -- Skipping migration 0079...",
+        return
     projects = api.get_all_projects()
 
     # switch off signals


### PR DESCRIPTION
... problem occurs when 'jetstream' is not in INSTALLED_APPS.

## Solution
Avoid RuntimeError by checking if jetstream is in INSTALLED_APPS and skipping the migration.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature 
       (Can be verified by successful travis run)
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
