### PR TITLE
Problem: 'Unknown Sizes' appear when sizes are disabled

### DIFF
--- a/core/models/size.py
+++ b/core/models/size.py
@@ -91,15 +91,15 @@ def convert_esh_size(esh_size, provider_uuid):
     return core_size
 
 
-def _update_from_cloud_size(core_size, esh_size):
+def _update_from_cloud_size(core_size, rtwo_size):
     """
     Full scope replacement based on cloud(rtwo) size
     """
-    core_size.name = esh_size.name
-    core_size.disk = esh_size.disk
-    core_size.root = esh_size.ephemeral_disk
-    core_size.cpu = esh_size.vcpus
-    core_size.mem = esh_size.ram
+    core_size.name = rtwo_size.name
+    core_size.disk = rtwo_size.disk
+    core_size.root = rtwo_size.ephemeral
+    core_size.cpu = rtwo_size.cpu
+    core_size.mem = rtwo_size.ram
     core_size.save()
     return core_size
 

--- a/core/models/size.py
+++ b/core/models/size.py
@@ -76,6 +76,8 @@ def convert_esh_size(esh_size, provider_uuid):
     try:
         core_size = Size.objects.get(alias=alias, provider__uuid=provider_uuid)
         core_size = _update_from_cloud_size(core_size, esh_size)
+    except AttributeError:
+        raise Exception("The 'contract' for an esh_size has likely changed -- check _update_from_cloud_size'")
     except Size.DoesNotExist:
         # Gather up the additional, necessary information to create a DB repr
         try:
@@ -95,8 +97,8 @@ def _update_from_cloud_size(core_size, esh_size):
     """
     core_size.name = esh_size.name
     core_size.disk = esh_size.disk
-    core_size.root = esh_size.ephemeral
-    core_size.cpu = esh_size.cpu
+    core_size.root = esh_size.ephemeral_disk
+    core_size.cpu = esh_size.vcpus
     core_size.mem = esh_size.ram
     core_size.save()
     return core_size

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
-rtwo==0.5.5
+rtwo==0.5.7
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 six==1.10.0               # via cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-swiftclient, setuptools, stevedore, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -723,6 +723,15 @@ def monitor_sizes_for(provider_id, print_logs=False):
         size.end_date = now_time
         size.save()
 
+    # Find home for 'Unknown Size'
+    unknown_sizes = Size.objects.filter(provider=provider, name__contains='Unknown Size')
+    for size in unknown_sizes:
+        # Lookup sizes may not show up in 'list_sizes'
+        cloud_size = admin_driver.get_size(size.alias, forced_lookup=True)
+        if not cloud_size:
+            continue
+        core_size = convert_esh_size(cloud_size, provider.uuid)
+
     if print_logs:
         _exit_stdout_logging(console_handler)
 


### PR DESCRIPTION
## Solution:
  - It turns out openstack will show disabled sizes if you query for
    them explicitly. The latest version of rtwo will enable you to
    force lookups on sizes and re-name Unknown sizes as part of the
    'monitor_sizes' periodic task.

## Test by REPL:
```
>> from core.models import Size
>> unknown_sizes = Size.objects.filter(name__contains='Unknown Size')
>> unknown_sizes.count()
8
>> from service.tasks.monitoring import monitor_sizes_for
>> monitor_sizes_for(5)
>> unknown_sizes = Size.objects.filter(name__contains='Unknown Size')
>> unknown_sizes.count()
2
```

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
