### PR TITLE
Problem: `behave` tests fail when not `settings.USE_ALLOCATION_SOURCE`

### DIFF
--- a/jetstream/features/steps/tas_api_steps.py
+++ b/jetstream/features/steps/tas_api_steps.py
@@ -23,7 +23,7 @@ def _get_tas_projects(context):
 
 
 def _get_xsede_to_tacc_username(context, url):
-    xsede_username = url.split('/api/v1/users/xsede/')[-1]
+    xsede_username = url.split('/v1/users/xsede/')[-1]
     if xsede_username not in context.xsede_to_tacc_username_mapping:
         data = {'status': 'error', 'message': 'No user found for XSEDE username {}'.format(xsede_username),
                 'result': None}
@@ -33,7 +33,7 @@ def _get_xsede_to_tacc_username(context, url):
 
 
 def _get_user_projects(context, url):
-    tacc_username = url.split('/api/v1/projects/username/')[-1]
+    tacc_username = url.split('/v1/projects/username/')[-1]
     project_names = list(context.tacc_username_to_tas_project_mapping.get(tacc_username, []))
     user_projects = [project for project in context.tas_projects if project['chargeCode'] in project_names]
     data = {'status': 'success', 'message': None, 'result': user_projects}
@@ -43,11 +43,11 @@ def _make_mock_tacc_api_get(context):
     def _mock_tacc_api_get(*args, **kwargs):
         url = args[0]
         assert isinstance(url, basestring)
-        if url.endswith('/api/v1/projects/resource/Jetstream'):
+        if url.endswith('/v1/projects/resource/Jetstream'):
             data = _get_tas_projects(context)
-        elif '/api/v1/users/xsede/' in url:
+        elif '/v1/users/xsede/' in url:
             data = _get_xsede_to_tacc_username(context, url)
-        elif '/api/v1/projects/username/' in url:  # This can return 'Inactive', 'Active', and 'Approved' allocations. Maybe more.
+        elif '/v1/projects/username/' in url:  # This can return 'Inactive', 'Active', and 'Approved' allocations. Maybe more.
             data = _get_user_projects(context, url)
         else:
             raise ValueError('Unknown URL: {}'.format(url))

--- a/jetstream/models.py
+++ b/jetstream/models.py
@@ -34,6 +34,9 @@ class TASAllocationReport(models.Model):
     report_date = models.DateTimeField(blank=True, null=True)
     success = models.BooleanField(default=False)
 
+    class Meta:
+        app_label = 'jetstream'
+
     def send(self, use_beta=False):
         if not self.id:
             raise Exception("ERROR -- This report should be *saved* before you send it!")

--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -107,8 +107,6 @@ def _create_tas_report_for(user, tacc_username, tacc_project_name, end_date):
 
 @task(name="report_allocations_to_tas")
 def report_allocations_to_tas():
-    if 'jetstream' not in settings.INSTALLED_APPS:
-        return
     logger.info("Reporting: Begin creating reports")
     create_reports()
     logger.info("Reporting: Completed, begin sending reports")
@@ -135,8 +133,6 @@ def send_reports():
 
 @task(name="update_snapshot")
 def update_snapshot(start_date=None, end_date=None):
-    if not settings.USE_ALLOCATION_SOURCE:
-        return False
     end_date = end_date or timezone.now()
     # TODO: Read this start_date from last 'reset event' for each allocation source
     start_date = start_date or '2016-09-01 00:00:00.0-05'


### PR DESCRIPTION
## Description

Problem: `behave` tests fail when not `settings.USE_ALLOCATION_SOURCE`

Solution:
- Tweaked tests and Jetstream allocation tasks
- Jetstream now uses allocations by default
- There was also a missing `app_label` on `TASAllocationReport` model

Fix #331

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature  
~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
~- [ ] If necessary, include a snippet in CHANGELOG.md~
