### PR TITLE
Problem: Bootable volumes caused errors in API and Monitoring 

### DIFF
--- a/api/v2/serializers/details/instance.py
+++ b/api/v2/serializers/details/instance.py
@@ -60,6 +60,8 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return serializer.data
 
     def get_image(self, obj):
+        if obj.source.is_volume():
+            return {}
         image_uuid = obj.application_uuid()
         image = Image.objects.get(uuid=image_uuid)
         serializer = ImageSummarySerializer(image, context=self.context)
@@ -72,6 +74,8 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return obj.ip_address
 
     def get_version(self, obj):
+        if obj.source.is_volume():
+            return {}
         version = obj.source.providermachine.application_version
         serializer = ImageVersionSummarySerializer(
             version,

--- a/api/v2/serializers/summaries/instance.py
+++ b/api/v2/serializers/summaries/instance.py
@@ -29,6 +29,8 @@ class InstanceSummarySerializer(serializers.HyperlinkedModelSerializer):
         return serializer.data
 
     def get_image(self, obj):
+        if obj.source.is_volume():
+            return {}
         image_uuid = obj.application_uuid()
         image = Image.objects.get(uuid=image_uuid)
         serializer = ImageSummarySerializer(image, context=self.context)

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -208,7 +208,7 @@ class Instance(models.Model):
         import traceback
         # 1. Get status name
         status_name = _get_status_name_for_provider(
-            self.provider_machine.provider,
+            self.source.provider,
             status_name,
             task,
             tmp_status)

--- a/core/models/machine.py
+++ b/core/models/machine.py
@@ -2,7 +2,7 @@
   Machine models for atmosphere.
 """
 from hashlib import md5
-import json
+import json, ast
 
 from django.db import models
 from django.db.models import Q
@@ -204,7 +204,7 @@ def collect_image_metadata(glance_image):
         if verify_app_uuid(glance_image.get('application_uuid'), glance_image.id):
             app_kwargs['uuid'] = glance_image.get('application_uuid')
             app_kwargs['description'] = glance_image.get('application_description')#TODO: Verify that _LINE_BREAK_ is fixed
-            app_kwargs['tags'] = glance_image.get('application_tags')
+            app_kwargs['tags'] = ast.literal_eval(glance_image.get('application_tags'))
         elif is_replicated_version(glance_image.id):
             app_kwargs = replicate_app_kwargs(glance_image.id)
     except AttributeError as exc:

--- a/core/models/volume.py
+++ b/core/models/volume.py
@@ -61,7 +61,7 @@ class Volume(BaseSource):
         return projects
 
     def __unicode__(self):
-        return "%s" % (self.instance_source.identifier)
+        return "%s - %s" % (self.instance_source.identifier, self.name)
 
     def get_status(self):
         if hasattr(self,'esh') and self.esh.extra:

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
-rtwo==0.5.8
+rtwo==0.5.9
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 six==1.10.0               # via cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-swiftclient, setuptools, stevedore, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient

--- a/service/instance.py
+++ b/service/instance.py
@@ -936,7 +936,7 @@ def _select_and_launch_source(
             boot_source.identifier,
             "machine")
         core_instance = launch_machine_instance(
-            esh_driver, identity, machine, size, name,
+            esh_driver, user, identity, machine, size, name,
             deploy=deploy, **launch_kwargs)
     else:
         raise Exception("Boot source is of an unknown type")
@@ -944,7 +944,7 @@ def _select_and_launch_source(
 
 
 def boot_volume_instance(
-        driver, identity, copy_source, size, name,
+        driver, user, identity, copy_source, size, name,
         # Depending on copy source, these specific kwargs may/may not be used.
         boot_index=0, shutdown=False, volume_size=None,
         # Other kwargs passed for future needs
@@ -953,45 +953,45 @@ def boot_volume_instance(
     Create a new volume and launch it as an instance
     """
     kwargs, userdata, network = _pre_launch_instance(
-        driver, identity, size, name, **kwargs)
+        driver, user, identity, size, name, **kwargs)
     kwargs.update(prep_kwargs)
     instance, token, password = _boot_volume(
         driver, identity, copy_source, size,
         name, userdata, network, **prep_kwargs)
     return _complete_launch_instance(
         driver, identity, instance,
-        identity.created_by, token, password, deploy=deploy)
+        user, token, password, deploy=deploy)
 
 
-def launch_volume_instance(driver, identity, volume, size, name,
+def launch_volume_instance(driver, user, identity, volume, size, name,
                            deploy=True, **kwargs):
     """
     Re-Launch an existing volume as an instance
     """
     kwargs, userdata, network = _pre_launch_instance(
-        driver, identity, size, name, **kwargs)
+        driver, user, identity, size, name, **kwargs)
     kwargs.update(prep_kwargs)
     instance, token, password = _launch_volume(
         driver, identity, volume, size,
         name, userdata, network, **kwargs)
     return _complete_launch_instance(driver, identity, instance,
-                                     identity.created_by, token, password,
+                                     user, token, password,
                                      deploy=deploy)
 
 
-def launch_machine_instance(driver, identity, machine, size, name,
+def launch_machine_instance(driver, user, identity, machine, size, name,
                             deploy=True, **kwargs):
     """
     Launch an existing machine as an instance
     """
     prep_kwargs, userdata, network = _pre_launch_instance(
-        driver, identity, size, name, **kwargs)
+        driver, user, identity, size, name, **kwargs)
     kwargs.update(prep_kwargs)
     instance, token, password = _launch_machine(
         driver, identity, machine, size,
         name, userdata, network, **kwargs)
     return _complete_launch_instance(driver, identity, instance,
-                                     identity.created_by, token, password,
+                                     user, token, password,
                                      deploy=deploy)
 
 
@@ -1066,7 +1066,7 @@ def _launch_machine(driver, identity, machine, size,
     return (esh_instance, token, password)
 
 
-def _pre_launch_instance(driver, identity, size, name, **kwargs):
+def _pre_launch_instance(driver, user, identity, size, name, **kwargs):
     """
     Returns:
     * Prep kwargs (username, password, token, & name)

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -175,7 +175,7 @@ def monitor_machines_for(provider_id, print_logs=False, dry_run=False):
 
     account_driver = get_account_driver(provider)
     cloud_machines = account_driver.list_all_images()
-
+    db_machines = []
     # ASSERT: All non-end-dated machines in the DB can be found in the cloud
     # if you do not believe this is the case, you should call 'prune_machines_for'
     for cloud_machine in cloud_machines:
@@ -184,6 +184,7 @@ def monitor_machines_for(provider_id, print_logs=False, dry_run=False):
         owner_project = _get_owner(account_driver, cloud_machine)
         #STEP 1: Get the application, version, and provider_machine registered in Atmosphere
         (db_machine, created) = convert_glance_image(cloud_machine, provider.uuid, owner_project)
+        db_machines.append(db_machine)
         #STEP 2: For any private cloud_machine, convert the 'shared users' as known by cloud
         update_image_membership(account_driver, cloud_machine, db_machine)
 
@@ -198,7 +199,7 @@ def monitor_machines_for(provider_id, print_logs=False, dry_run=False):
 
     if print_logs:
         _exit_stdout_logging(console_handler)
-    return
+    return db_machines
 
 def _get_owner(accounts, cloud_machine):
     """
@@ -533,6 +534,34 @@ def make_machines_public(application, account_drivers={}, dry_run=False):
         application.save()
 
 
+@task(name="monitor_resources")
+def monitor_resources():
+    """
+    Update instances for each active provider.
+    """
+    for p in Provider.get_active():
+        monitor_resources_for.apply_async(args=[p.id])
+
+
+@task(name="monitor_resources_for")
+def monitor_resources_for(provider_id, users=None, print_logs=False):
+    """
+    Run the set of tasks related to monitoring all cloud resources for a provider.
+    """
+    resources = {}
+    machines = monitor_machines_for(provider_id, print_logs=print_logs)
+    sizes = monitor_sizes_for(provider_id, print_logs=print_logs)
+    instances = monitor_instances_for(provider_id, users=users, print_logs=print_logs)
+    volumes = monitor_volumes_for(provider_id, print_logs=print_logs)
+    resources.update({
+        'instances': instances,
+        'machines': machines,
+        'sizes': sizes,
+        'volumes': volumes,
+    })
+    return resources
+
+
 @task(name="monitor_instances")
 def monitor_instances():
     """
@@ -589,15 +618,13 @@ def monitor_instances_for(provider_id, users=None,
 
     if print_logs:
         console_handler = _init_stdout_logging()
-
+    seen_instances = []
     # DEVNOTE: Potential slowdown running multiple functions
     # Break this out when instance-caching is enabled
-    running_total = 0
     if not settings.ENFORCING:
         celery_logger.debug('Settings dictate allocations are NOT enforced')
     for username in sorted(instance_map.keys()):
         running_instances = instance_map[username]
-        running_total += len(running_instances)
         identity = _get_identity_from_tenant_name(provider, username)
         if identity and running_instances:
             try:
@@ -609,6 +636,7 @@ def monitor_instances_for(provider_id, users=None,
                         identity.provider.uuid,
                         identity.uuid,
                         identity.created_by) for inst in running_instances]
+                seen_instances.extend(core_running_instances)
             except Exception as exc:
                 celery_logger.exception(
                     "Could not convert running instances for %s" %
@@ -627,7 +655,7 @@ def monitor_instances_for(provider_id, users=None,
                 print_logs, start_date, end_date)
     if print_logs:
         _exit_stdout_logging(console_handler)
-    return running_total
+    return seen_instances
 
 
 @task(name="monitor_volumes")
@@ -684,6 +712,7 @@ def monitor_volumes_for(provider_id, print_logs=False):
 
     if print_logs:
         _exit_stdout_logging(console_handler)
+    return seen_volumes
 
 
 @task(name="monitor_sizes")
@@ -744,7 +773,7 @@ def monitor_sizes_for(provider_id, print_logs=False):
 
     if print_logs:
         _exit_stdout_logging(console_handler)
-
+    return seen_sizes
 
 @task(name="monthly_allocation_reset")
 def monthly_allocation_reset():

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -549,10 +549,10 @@ def monitor_resources_for(provider_id, users=None, print_logs=False):
     Run the set of tasks related to monitoring all cloud resources for a provider.
     """
     resources = {}
-    machines = monitor_machines_for(provider_id, print_logs=print_logs)
     sizes = monitor_sizes_for(provider_id, print_logs=print_logs)
-    instances = monitor_instances_for(provider_id, users=users, print_logs=print_logs)
     volumes = monitor_volumes_for(provider_id, print_logs=print_logs)
+    machines = monitor_machines_for(provider_id, print_logs=print_logs)
+    instances = monitor_instances_for(provider_id, users=users, print_logs=print_logs)
     resources.update({
         'instances': instances,
         'machines': machines,

--- a/service/volume.py
+++ b/service/volume.py
@@ -224,7 +224,7 @@ def create_bootable_volume(
     # Return source or raises an Exception
     source = _retrieve_source(driver, new_source_alias, source_hint)
 
-    core_instance = boot_volume_instance(driver, identity,
+    core_instance = boot_volume_instance(driver, user, identity,
                                          source, size, name, **kwargs)
 
     return core_instance


### PR DESCRIPTION
## Solution:
 Improve the "Bootable volume" support for Atmosphere monitoring

## Highlights
- Monitor instances no longer fails when bootable volume encountered
- Monitoring tasks return all converted cloud resources
- Created one `monitor_resources` monitoring task to rule them all
- APIs wont fail when volume is encountered, No errors encountered in troposphere after API failures resolved.
- Update requirements.txt to latest version of rtwo **REQUIRED**

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
