### PR TITLE
Populate Glance image metadata application_tags with valid JSON

### DIFF
--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -2,6 +2,7 @@
 
 import argparse
 import hashlib
+import json
 import logging
 import os
 import sys
@@ -213,7 +214,7 @@ def main():
                                           application_version=app_version.name,
                                           application_description=app.description,
                                           application_owner=app_creator_uname,
-                                          application_tags=str(app_tags),
+                                          application_tags=json.dumps(app_tags),
                                           application_uuid=str(app.uuid),
                                           # Todo min_disk? min_ram? Do we care?
                                           )


### PR DESCRIPTION
## Description
Problem: application_tags Glance metadata field was not populated with valid JSON
Solution: `json.dumps()` the app_tags list when setting application_tags in Glance image

Tested this and confirmed that now application_tags is set properly in Glance:
`application_tags='["bioconductor", "R", "Ubuntu", "edgeR", "RStudio", "base", "ggplot2", "ubuntu1404", "xfce"]'`

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md

## Checklist after merging
- [ ] Trickle-down merge to master
- [ ] Deploy to production and re-run `application_to_provider.py` to fix Glance image metadata for applications/images that were already migrated