### PR TITLE
Problem: 'Redeploy' InstanceAction created incorrectly in migrations

### DIFF
--- a/core/migrations/0071_provider_more_instance_actions.py
+++ b/core/migrations/0071_provider_more_instance_actions.py
@@ -15,6 +15,7 @@ def copy_data_to_new_models(apps, schema_editor):
 def add_instance_actions(Provider, InstanceAction, ProviderInstanceAction):
     InstanceAction.objects.get_or_create(
         name="Redeploy",
+        key="Redeploy",
         description="""Redeploy to an instance when it is in ANY active state""")
 
     instance_actions = InstanceAction.objects.all()


### PR DESCRIPTION
## Solution:

Include the 'redeploy' key in the migration. 

Have you already applied this migration? Go ahead and run these lines:
```
from core.models import InstanceAction
action = InstanceAction.objects.get(name='Redeploy')
action.key = 'Redeploy'
action.save()
```