### PR TITLE
Problem: shelved instances become shelved_offload and UI cannot act on them

### DIFF
--- a/core/models/instance_action.py
+++ b/core/models/instance_action.py
@@ -117,7 +117,8 @@ class InstanceAction(models.Model):
         elif last_status == "shutoff":
             # Suspended instances can be started + <Basic Actions>
             all_actions.append('Start')
-        elif last_status == "shelved":
+        elif (last_status == "shelved" or
+              last_status == "shelved_offloaded"):
             # Shelved instances can be unshelved or offloaded + <Basic Actions>
             all_actions.append('Shelve Offload')
             all_actions.append('Unshelve')


### PR DESCRIPTION
## Description

When an instance is `shelved_offloaded`, the user interface (Troposphere) cannot perform actions on it. 

Solution - Handle both "shelved" & "shelved_offloaded"

It seems that an instance that has been "shelved" will appear as being "shelved", then after a time (which is configurable) will transition to "shelved_offlanded".  Both states can be handled with the same mapped instance-actions.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
