### PR TITLE
Atmo 1854 : TASAllocationReport creation for deleted user's unaccounted allocation usage

### DIFF
--- a/jetstream/features/create_report_test_after_user_deleted.feature
+++ b/jetstream/features/create_report_test_after_user_deleted.feature
@@ -2,30 +2,30 @@ Feature: Testing create_report task after user deleted from allocation source
 
   Scenario Outline: testing create_reports task
 
-      Given Allocation Source
+    Given Allocation Source
 
-      When Allocation Source is assigned to Users
+    When Allocation Source is assigned to Users
       | number of users assigned to allocation source |
-      |       <number_of_users_assigned>              |
+      | <number_of_users_assigned>                    |
 
-      And All Users run an instance on Allocation Source for indefinite duration
+    And All Users run an instance on Allocation Source for indefinite duration
       | cpu size of instance |
-      |      <cpu_size>      |
+      | <cpu_size>           |
 
-      And create_reports task is run for the first time
-      | task runs every x minutes         |
-      |    <task_interval_time_minutes>   |
+    And create_reports task is run for the first time
+      | task runs every x minutes    |
+      | <task_interval_time_minutes> |
 
-      And Users are deleted from Allocation Source after first create_reports run
-      | number of users deleted from allocation source |  users deleted x minutes after the first create_reports run  |
-      |        <number_of_users_deleted>               |                   <minutes_used_by_deleted_user>             |
+    And Users are deleted from Allocation Source after first create_reports run
+      | number of users deleted from allocation source | users deleted x minutes after the first create_reports run |
+      | <number_of_users_deleted>                      | <minutes_used_by_deleted_user>                             |
 
-      Then Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run
-      |    total expected allocation usage in minutes           |
-      |    <total_allocation_usage_minutes>                     |
+    Then Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run
+      | total expected allocation usage in minutes |
+      | <total_allocation_usage_minutes>           |
 
-  Examples: create_report accuracy test
+    Examples: create_report accuracy test
 
-      | number_of_users_assigned | cpu_size |   task_interval_time_minutes   | number_of_users_deleted | minutes_used_by_deleted_user | total_allocation_usage_minutes  |
-      |  10                      |   1      |          15                    |          1              | 10                           | 295                             |
-      |  5                       |   4      |          15                    |          4              | 5                            | 440                             |
+      | number_of_users_assigned | cpu_size | task_interval_time_minutes | number_of_users_deleted | minutes_used_by_deleted_user | total_allocation_usage_minutes |
+      | 10                       | 1        | 15                         | 1                       | 10                           | 295                            |
+      | 5                        | 4        | 15                         | 4                       | 5                            | 440                            |

--- a/jetstream/features/create_report_test_after_user_deleted.feature
+++ b/jetstream/features/create_report_test_after_user_deleted.feature
@@ -1,0 +1,31 @@
+Feature: Testing create_report task after user deleted from allocation source
+
+  Scenario Outline: testing create_reports task
+
+      Given Allocation Source
+
+      When Allocation Source is assigned to Users
+      | number of users assigned to allocation source |
+      |       <number_of_users_assigned>              |
+
+      And All Users run an instance on Allocation Source for indefinite duration
+      | cpu size of instance |
+      |      <cpu_size>      |
+
+      And create_reports task is run for the first time
+      | task runs every x minutes         |
+      |    <task_interval_time_minutes>   |
+
+      And Users are deleted from Allocation Source after first create_reports run
+      | number of users deleted from allocation source |  users deleted x minutes after the first create_reports run  |
+      |        <number_of_users_deleted>               |                   <minutes_used_by_deleted_user>             |
+
+      Then Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run
+      |    total expected allocation usage in minutes           |
+      |    <total_allocation_usage_minutes>                     |
+
+  Examples: create_report accuracy test
+
+      | number_of_users_assigned | cpu_size |   task_interval_time_minutes   | number_of_users_deleted | minutes_used_by_deleted_user | total_allocation_usage_minutes  |
+      |  10                      |   1      |          15                    |          1              | 10                           | 295                             |
+      |  5                       |   4      |          15                    |          4              | 5                            | 440                             |

--- a/jetstream/features/steps/create_report_test_after_user_deleted.py
+++ b/jetstream/features/steps/create_report_test_after_user_deleted.py
@@ -1,26 +1,29 @@
-import uuid
 import logging
-from django.utils import timezone
+import uuid
 from datetime import timedelta
-from jetstream.exceptions import TASPluginException
-from core.models.allocation_source import total_usage
-from django.db.models import Sum
+
 from behave import *
-from core.models import *
-from jetstream.models import *
+from django.db.models import Sum
+
 from api.tests.factories import (
     UserFactory, InstanceFactory, IdentityFactory, InstanceStatusFactory,
     ProviderFactory, ProviderMachineFactory, InstanceHistoryFactory)
+from core.models import *
+from core.models.allocation_source import total_usage
+from jetstream.exceptions import TASPluginException
+from jetstream.models import *
 
 logger = logging.getLogger(__name__)
+
 
 @given('Allocation Source')
 def step_impl(context):
     context.current_time = timezone.now()
-    name,compute_allowed = "testSource",1000
-    context.allocation_source = AllocationSource.objects.create(name=name,compute_allowed=compute_allowed)
-   # source = AllocationSource.objects.filter(name=name)
-    assert(len(AllocationSource.objects.filter(name=name))>0)
+    name, compute_allowed = "testSource", 1000
+    context.allocation_source = AllocationSource.objects.create(name=name, compute_allowed=compute_allowed)
+    # source = AllocationSource.objects.filter(name=name)
+    assert (len(AllocationSource.objects.filter(name=name)) > 0)
+
 
 @when('Allocation Source is assigned to Users')
 def step_impl(context):
@@ -32,8 +35,9 @@ def step_impl(context):
     for i in range(number_of_users):
         user = UserFactory.create(date_joined=context.current_time)
         context.users.append(user)
-        UserAllocationSource.objects.create(allocation_source = context.allocation_source, user = user)
-        assert(len(UserAllocationSource.objects.filter(user=user,allocation_source=context.allocation_source))>0)
+        UserAllocationSource.objects.create(allocation_source=context.allocation_source, user=user)
+        assert (len(UserAllocationSource.objects.filter(user=user, allocation_source=context.allocation_source)) > 0)
+
 
 @when('All Users run an instance on Allocation Source for indefinite duration')
 def step_impl(context):
@@ -44,15 +48,16 @@ def step_impl(context):
     for user in context.users:
         alias = launch_instance(user, context.current_time, cpu_size)
         payload = {}
-        payload["instance_id"]=str(alias)
-        payload["allocation_source_name"]=context.allocation_source.name
+        payload["instance_id"] = str(alias)
+        payload["allocation_source_name"] = context.allocation_source.name
 
         EventTable.objects.create(name="instance_allocation_source_changed",
                                   payload=payload,
                                   entity_id=user.username,
                                   timestamp=context.current_time)
 
-        assert(len(InstanceStatusHistory.objects.filter(instance__created_by=user))==1)
+        assert (len(InstanceStatusHistory.objects.filter(instance__created_by=user)) == 1)
+
 
 @when('create_reports task is run for the first time')
 def step_impl(context):
@@ -60,20 +65,23 @@ def step_impl(context):
         interval_time = int(row['task runs every x minutes'])
         context.interval_time = interval_time
 
-    report_end_date = context.current_time+timedelta(minutes=interval_time)
+    report_end_date = context.current_time + timedelta(minutes=interval_time)
 
     create_reports(end_date=report_end_date)
 
-    assert(len(TASAllocationReport.objects.all()) > 0)
-    assert(TASAllocationReport.objects.last().end_date == report_end_date)
-    assert(TASAllocationReport.objects.last().start_date == context.current_time)
+    assert (len(TASAllocationReport.objects.all()) > 0)
+    assert (TASAllocationReport.objects.last().end_date == report_end_date)
+    assert (TASAllocationReport.objects.last().start_date == context.current_time)
 
-    expected_initial_usage =context.cpu_size*context.interval_time*context.number_of_users
-    calculated_initial_usage = float(TASAllocationReport.objects.filter(project_name=context.allocation_source.name).aggregate(Sum('compute_used'))['compute_used__sum'])*60
+    expected_initial_usage = context.cpu_size * context.interval_time * context.number_of_users
+    calculated_initial_usage = float(
+        TASAllocationReport.objects.filter(project_name=context.allocation_source.name).aggregate(Sum('compute_used'))[
+            'compute_used__sum']) * 60
 
-    assert(round(calculated_initial_usage,2)==expected_initial_usage)
+    assert (round(calculated_initial_usage, 2) == expected_initial_usage)
 
     context.current_time = context.current_time + timedelta(minutes=interval_time)
+
 
 @when('Users are deleted from Allocation Source after first create_reports run')
 def step_impl(context):
@@ -91,34 +99,37 @@ def step_impl(context):
             entity_id=user.username,
             timestamp=context.current_time + timedelta(minutes=users_deleted_after_time))
 
-        assert(len(UserAllocationSource.objects.filter(user=user,allocation_source=context.allocation_source))==0)
+        assert (len(UserAllocationSource.objects.filter(user=user, allocation_source=context.allocation_source)) == 0)
 
-@then('Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run')
+
+@then(
+    'Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run')
 def step_impl(context):
     for row in context.table:
         total_expected_usage = int(row['total expected allocation usage in minutes'])
 
-    report_end_date = context.current_time+timedelta(minutes=context.interval_time)
+    report_end_date = context.current_time + timedelta(minutes=context.interval_time)
     create_reports(end_date=report_end_date)
 
-    assert (len(TASAllocationReport.objects.all()) == 2*context.number_of_users)
+    assert (len(TASAllocationReport.objects.all()) == 2 * context.number_of_users)
     assert (TASAllocationReport.objects.last().start_date == context.current_time)
 
     calculated_initial_usage = float(
         TASAllocationReport.objects.filter(project_name=context.allocation_source.name).aggregate(Sum('compute_used'))[
             'compute_used__sum']) * 60
 
-    logging.info("\n\n expected:%s  actual:%s \n\n" % (total_expected_usage,int(calculated_initial_usage)))
+    logging.info("\n\n expected:%s  actual:%s \n\n" % (total_expected_usage, int(calculated_initial_usage)))
 
     # just for the purpose of these test cases, we require time in minutes
     # conversion from microseconds to hours and then hours to minutes with rounding results in loss of time
     # therefore instead of comparing exact values, we check if the difference is not more than a minute (or two)
 
-    assert(abs(total_expected_usage-int(calculated_initial_usage))<2)
+    assert (abs(total_expected_usage - int(calculated_initial_usage)) < 2)
+
 
 #### Helpers ####
 
-def launch_instance(user,time_created,cpu):
+def launch_instance(user, time_created, cpu):
     # context.user is admin and regular user
     provider = ProviderFactory.create()
     from core.models import IdentityMembership, Identity
@@ -140,12 +151,11 @@ def launch_instance(user,time_created,cpu):
     status = InstanceStatusFactory.create(name='active')
 
     instance_state = InstanceFactory.create(
-    provider_alias=uuid.uuid4(),
-    source=machine.instance_source,
-    created_by=user,
-    created_by_identity=user_identity,
-    start_date=time_created)
-
+        provider_alias=uuid.uuid4(),
+        source=machine.instance_source,
+        created_by=user,
+        created_by_identity=user_identity,
+        start_date=time_created)
 
     size = Size(alias=uuid.uuid4(), name='small', provider=provider, cpu=cpu, disk=1, root=1, mem=1)
     size.save()
@@ -153,8 +163,8 @@ def launch_instance(user,time_created,cpu):
         status=status,
         activity="",
         instance=instance_state,
-        start_date = time_created,
-        end_date=time_created+timedelta(minutes=30),
+        start_date=time_created,
+        end_date=time_created + timedelta(minutes=30),
         size=size
     )
 
@@ -175,20 +185,20 @@ def create_reports(end_date=False):
     last_report_date = TASAllocationReport.objects.order_by('end_date')
 
     if not last_report_date:
-        last_report_date=end_date
+        last_report_date = end_date
     else:
-        last_report_date=last_report_date.last().end_date
+        last_report_date = last_report_date.last().end_date
 
     for item in user_allocation_list:
         allocation_name = item.allocation_source.name
-        #CHANGED LINE
-        project_report = _create_reports_for(item.user,allocation_name,end_date)
+        # CHANGED LINE
+        project_report = _create_reports_for(item.user, allocation_name, end_date)
         if project_report:
             all_reports.append(project_report)
 
     # Take care of Deleted Users
 
-    #filter user_allocation_source_removed events which are created after the last report date
+    # filter user_allocation_source_removed events which are created after the last report date
 
     for event in EventTable.objects.filter(name="user_allocation_source_deleted", timestamp__gte=last_report_date):
 
@@ -201,14 +211,14 @@ def create_reports(end_date=False):
     return all_reports
 
 
-def _create_reports_for(user,allocation_name,end_date):
+def _create_reports_for(user, allocation_name, end_date):
     driver = TASAPIDriver()
-    tacc_username = user.username #driver.get_tacc_username(user)
+    tacc_username = user.username  # driver.get_tacc_username(user)
     if not tacc_username:
         logger.error("No TACC username for user: '{}' which came from allocation id: {}".format(user,
                                                                                                 allocation_name))
         return
-    project_name = allocation_name #driver.get_allocation_project_name(allocation_name)
+    project_name = allocation_name  # driver.get_allocation_project_name(allocation_name)
     try:
         project_report = _create_tas_report_for(
             user,
@@ -239,7 +249,7 @@ def _create_tas_report_for(user, tacc_username, tacc_project_name, end_date):
     last_report = TASAllocationReport.objects.filter(
         project_name=tacc_project_name,
         user=user
-        ).order_by('end_date').last()
+    ).order_by('end_date').last()
     if not last_report:
         start_date = user.date_joined
     else:
@@ -253,7 +263,7 @@ def _create_tas_report_for(user, tacc_username, tacc_project_name, end_date):
     if compute_used < 0:
         raise TASPluginException(
             "Compute usage was not accurately calculated for user:%s for start_date:%s and end_date:%s"
-            % (user,start_date,end_date))
+            % (user, start_date, end_date))
 
     new_report = TASAllocationReport.objects.create(
         user=user,

--- a/jetstream/features/steps/create_report_test_after_user_deleted.py
+++ b/jetstream/features/steps/create_report_test_after_user_deleted.py
@@ -1,0 +1,267 @@
+import uuid
+import logging
+from django.utils import timezone
+from datetime import timedelta
+from jetstream.exceptions import TASPluginException
+from core.models.allocation_source import total_usage
+from django.db.models import Sum
+from behave import *
+from core.models import *
+from jetstream.models import *
+from api.tests.factories import (
+    UserFactory, InstanceFactory, IdentityFactory, InstanceStatusFactory,
+    ProviderFactory, ProviderMachineFactory, InstanceHistoryFactory)
+
+logger = logging.getLogger(__name__)
+
+@given('Allocation Source')
+def step_impl(context):
+    context.current_time = timezone.now()
+    name,compute_allowed = "testSource",1000
+    context.allocation_source = AllocationSource.objects.create(name=name,compute_allowed=compute_allowed)
+   # source = AllocationSource.objects.filter(name=name)
+    assert(len(AllocationSource.objects.filter(name=name))>0)
+
+@when('Allocation Source is assigned to Users')
+def step_impl(context):
+    context.users = []
+    for row in context.table:
+        number_of_users = int(row['number of users assigned to allocation source'])
+        context.number_of_users = number_of_users
+
+    for i in range(number_of_users):
+        user = UserFactory.create(date_joined=context.current_time)
+        context.users.append(user)
+        UserAllocationSource.objects.create(allocation_source = context.allocation_source, user = user)
+        assert(len(UserAllocationSource.objects.filter(user=user,allocation_source=context.allocation_source))>0)
+
+@when('All Users run an instance on Allocation Source for indefinite duration')
+def step_impl(context):
+    for row in context.table:
+        cpu_size = int(row['cpu size of instance'])
+        context.cpu_size = cpu_size
+
+    for user in context.users:
+        alias = launch_instance(user, context.current_time, cpu_size)
+        payload = {}
+        payload["instance_id"]=str(alias)
+        payload["allocation_source_name"]=context.allocation_source.name
+
+        EventTable.objects.create(name="instance_allocation_source_changed",
+                                  payload=payload,
+                                  entity_id=user.username,
+                                  timestamp=context.current_time)
+
+        assert(len(InstanceStatusHistory.objects.filter(instance__created_by=user))==1)
+
+@when('create_reports task is run for the first time')
+def step_impl(context):
+    for row in context.table:
+        interval_time = int(row['task runs every x minutes'])
+        context.interval_time = interval_time
+
+    report_end_date = context.current_time+timedelta(minutes=interval_time)
+
+    create_reports(end_date=report_end_date)
+
+    assert(len(TASAllocationReport.objects.all()) > 0)
+    assert(TASAllocationReport.objects.last().end_date == report_end_date)
+    assert(TASAllocationReport.objects.last().start_date == context.current_time)
+
+    expected_initial_usage =context.cpu_size*context.interval_time*context.number_of_users
+    calculated_initial_usage = float(TASAllocationReport.objects.filter(project_name=context.allocation_source.name).aggregate(Sum('compute_used'))['compute_used__sum'])*60
+
+    assert(round(calculated_initial_usage,2)==expected_initial_usage)
+
+    context.current_time = context.current_time + timedelta(minutes=interval_time)
+
+@when('Users are deleted from Allocation Source after first create_reports run')
+def step_impl(context):
+    for row in context.table:
+        users_deleted = int(row['number of users deleted from allocation source'])
+        users_deleted_after_time = int(row['users deleted x minutes after the first create_reports run'])
+
+    for i in range(users_deleted):
+        user = context.users[i]
+        payload = {}
+        payload["allocation_source_name"] = context.allocation_source.name
+        EventTable.objects.create(
+            payload=payload,
+            name="user_allocation_source_deleted",
+            entity_id=user.username,
+            timestamp=context.current_time + timedelta(minutes=users_deleted_after_time))
+
+        assert(len(UserAllocationSource.objects.filter(user=user,allocation_source=context.allocation_source))==0)
+
+@then('Total expected allocation usage for allocation source matches calculated allocation usage from reports after next create_reports run')
+def step_impl(context):
+    for row in context.table:
+        total_expected_usage = int(row['total expected allocation usage in minutes'])
+
+    report_end_date = context.current_time+timedelta(minutes=context.interval_time)
+    create_reports(end_date=report_end_date)
+
+    assert (len(TASAllocationReport.objects.all()) == 2*context.number_of_users)
+    assert (TASAllocationReport.objects.last().start_date == context.current_time)
+
+    calculated_initial_usage = float(
+        TASAllocationReport.objects.filter(project_name=context.allocation_source.name).aggregate(Sum('compute_used'))[
+            'compute_used__sum']) * 60
+
+    logging.info("\n\n expected:%s  actual:%s \n\n" % (total_expected_usage,int(calculated_initial_usage)))
+
+    # just for the purpose of these test cases, we require time in minutes
+    # conversion from microseconds to hours and then hours to minutes with rounding results in loss of time
+    # therefore instead of comparing exact values, we check if the difference is not more than a minute (or two)
+
+    assert(abs(total_expected_usage-int(calculated_initial_usage))<2)
+
+#### Helpers ####
+
+def launch_instance(user,time_created,cpu):
+    # context.user is admin and regular user
+    provider = ProviderFactory.create()
+    from core.models import IdentityMembership, Identity
+    user_group = IdentityMembership.objects.filter(member__name=user.username)
+    if not user_group:
+        user_identity = IdentityFactory.create_identity(
+            created_by=user,
+            provider=provider)
+    else:
+        user_identity = Identity.objects.all().last()
+    admin_identity = user_identity
+
+    provider_machine = ProviderMachine.objects.all()
+    if not provider_machine:
+        machine = ProviderMachineFactory.create_provider_machine(user, user_identity)
+    else:
+        machine = ProviderMachine.objects.all().last()
+
+    status = InstanceStatusFactory.create(name='active')
+
+    instance_state = InstanceFactory.create(
+    provider_alias=uuid.uuid4(),
+    source=machine.instance_source,
+    created_by=user,
+    created_by_identity=user_identity,
+    start_date=time_created)
+
+
+    size = Size(alias=uuid.uuid4(), name='small', provider=provider, cpu=cpu, disk=1, root=1, mem=1)
+    size.save()
+    InstanceHistoryFactory.create(
+        status=status,
+        activity="",
+        instance=instance_state,
+        start_date = time_created,
+        end_date=time_created+timedelta(minutes=30),
+        size=size
+    )
+
+    return instance_state.provider_alias
+
+
+def create_reports(end_date=False):
+    """
+    GO through the list of all users or all providers
+    For each username, get an XSede API map to the 'TACC username'
+    if 'TACC username' includes a jetstream resource, create a report
+    """
+    user_allocation_list = UserAllocationSource.objects.all()
+    all_reports = []
+
+    if not end_date:
+        end_date = timezone.now()
+    last_report_date = TASAllocationReport.objects.order_by('end_date')
+
+    if not last_report_date:
+        last_report_date=end_date
+    else:
+        last_report_date=last_report_date.last().end_date
+
+    for item in user_allocation_list:
+        allocation_name = item.allocation_source.name
+        #CHANGED LINE
+        project_report = _create_reports_for(item.user,allocation_name,end_date)
+        if project_report:
+            all_reports.append(project_report)
+
+    # Take care of Deleted Users
+
+    #filter user_allocation_source_removed events which are created after the last report date
+
+    for event in EventTable.objects.filter(name="user_allocation_source_deleted", timestamp__gte=last_report_date):
+
+        user = AtmosphereUser.objects.get(username=event.entity_id)
+        allocation_name = event.payload['allocation_source_name']
+        end_date = event.timestamp
+        project_report = _create_reports_for(user, allocation_name, end_date)
+        if project_report:
+            all_reports.append(project_report)
+    return all_reports
+
+
+def _create_reports_for(user,allocation_name,end_date):
+    driver = TASAPIDriver()
+    tacc_username = user.username #driver.get_tacc_username(user)
+    if not tacc_username:
+        logger.error("No TACC username for user: '{}' which came from allocation id: {}".format(user,
+                                                                                                allocation_name))
+        return
+    project_name = allocation_name #driver.get_allocation_project_name(allocation_name)
+    try:
+        project_report = _create_tas_report_for(
+            user,
+            tacc_username,
+            project_name,
+            end_date)
+        return project_report
+    except TASPluginException:
+        logger.exception(
+            "Could not create the report because of the error below"
+        )
+        return
+
+
+def _create_tas_report_for(user, tacc_username, tacc_project_name, end_date):
+    """
+    Create a new report
+    """
+    if not end_date:
+        raise TASPluginException("Explicit end date required")
+    if not user:
+        raise TASPluginException("User missing")
+    if not tacc_username:
+        raise TASPluginException("TACC Username missing")
+    if not tacc_project_name:
+        raise TASPluginException("OpenStack/TACC Project missing")
+
+    last_report = TASAllocationReport.objects.filter(
+        project_name=tacc_project_name,
+        user=user
+        ).order_by('end_date').last()
+    if not last_report:
+        start_date = user.date_joined
+    else:
+        start_date = last_report.end_date
+
+    compute_used = total_usage(
+        user.username, start_date,
+        allocation_source_name=tacc_project_name,
+        end_date=end_date)
+
+    if compute_used < 0:
+        raise TASPluginException(
+            "Compute usage was not accurately calculated for user:%s for start_date:%s and end_date:%s"
+            % (user,start_date,end_date))
+
+    new_report = TASAllocationReport.objects.create(
+        user=user,
+        username=tacc_username,
+        project_name=tacc_project_name,
+        compute_used=compute_used,
+        start_date=start_date,
+        end_date=end_date,
+        tacc_api=settings.TACC_API_URL)
+    logger.info("Created New Report:%s" % new_report)
+    return new_report

--- a/jetstream/features/steps/create_report_test_after_user_deleted.py
+++ b/jetstream/features/steps/create_report_test_after_user_deleted.py
@@ -200,7 +200,7 @@ def create_reports(end_date=False):
 
     # filter user_allocation_source_removed events which are created after the last report date
 
-    for event in EventTable.objects.filter(name="user_allocation_source_deleted", timestamp__gte=last_report_date):
+    for event in EventTable.objects.filter(name="user_allocation_source_deleted", timestamp__gte=last_report_date).order_by('timestamp'):
 
         user = AtmosphereUser.objects.get(username=event.entity_id)
         allocation_name = event.payload['allocation_source_name']

--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -14,7 +14,6 @@ from .allocation import (TASAPIDriver, fill_user_allocation_sources, select_vali
 from .exceptions import TASPluginException
 from .models import TASAllocationReport
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -54,7 +53,8 @@ def create_reports():
 
     # filter user_allocation_source_removed events which are created after the last report date
 
-    for event in EventTable.objects.filter(name="user_allocation_source_deleted", timestamp__gte=last_report_date):
+    for event in EventTable.objects.filter(name="user_allocation_source_deleted",
+                                           timestamp__gte=last_report_date).order_by('timestamp'):
 
         user = AtmosphereUser.objects.get(username=event.entity_id)
         allocation_name = event.payload['allocation_source_name']


### PR DESCRIPTION
## Description

.When user is deleted while querying TASApi and before update_snapshot is run, their usage (although negligible) will be ignored. Fix in the TASAllocationReport creation logic takes care of that.

There are tests included with feature - create_report_test_after_user_deleted, which verify that the improvement works as expected and performs calculations correctly

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
