### PR TITLE
Problem: "Image" is not an availalbe action for shutoff instances

### DIFF
--- a/core/models/instance_action.py
+++ b/core/models/instance_action.py
@@ -134,10 +134,11 @@ class InstanceAction(models.Model):
             all_actions.append('Reboot')
             all_actions.append('Hard Reboot')
         elif last_status == "shutoff":
-            # Suspended instances can be started + <Basic Actions>
+            # Stopped instances can be started, imaged + <Basic Actions>
             all_actions.append('Reboot')
             all_actions.append('Hard Reboot')
             all_actions.append('Start')
+            all_actions.append('Imaging')
         elif last_status == "shelved":
             # Shelved instances can be unshelved, offloaded, or terminated
             if not last_activity:


### PR DESCRIPTION
## Description

In the current documentation for Jetstream, authoring an Image while an
instance is in Active or Stopped state is _encouraged_ [\[0\]](https://iujetstream.atlassian.net/wiki/display/JWT/Customizing+and+saving+a+VM). However, we
currently only offer "Start" along with **basic** actions for a shutoff
instance [\[1\]](https://iujetstream.atlassian.net/browse/JETSTREAM-149).

[0] https://iujetstream.atlassian.net/wiki/display/JWT/Customizing+and+saving+a+VM
[1] https://iujetstream.atlassian.net/browse/JETSTREAM-149

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation]~(https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
