### PR TITLE
application_to_provider.py cleans images with Chromogenic

### DIFF
--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -24,9 +24,11 @@ provider by doing any/all of the following as needed:
 
 - Creates Glance image
 - Populates Glance image metadata
-- Transfers image data from existing provider
+- Optionally, uses Chromogenic library to remove undesired state from images
+  which were created from Atmosphere(1) instances
+- Transfers image data from existing provider to new provider, one of two ways:
   - Using Glance API (default)
-  - Optionally, using iRODS (Atmosphere(0)-specific feature)
+  - Using iRODS (Atmosphere(0)-specific feature), see below
 - If Application uses an AMI-style image, ensures the
   kernel (AKI) and ramdisk (ARI) images are also present on destination
   provider, and sets appropriate properties
@@ -42,6 +44,8 @@ If a non-public application has or more members without identities on the
 destination provider, script will exit with error unless
 --ignore_missing_members is set.
 
+## iRODS Transfer Information
+
 The iRODS transfer feature was developed for CyVerse Atmosphere(0); may be of
 limited use elsewhere. In order to use it:
 - Source and destination providers must use the iRODS storage backend for
@@ -51,6 +55,7 @@ limited use elsewhere. In order to use it:
   must all be defined
 - Credentials passed in --irods-conn must have write access to both source and
   destination collections
+- --clean cannot be used with iRODS transfer
 
 Considerations when using iRODS transfer:
 - The credentials passed in --irods-conn will be used to populate the image
@@ -487,6 +492,10 @@ def _parse_args():
                         action="store_true",
                         help="Transfer image if application is private and member(s) have no identity on destination "
                              "provider")
+    parser.add_argument("--clean",
+                        action="store_true",
+                        help="Use Chromogenic library to remove undesired state from images which were created from "
+                             "Atmosphere(1) instances (cannot be used with iRODS transfer)")
     parser.add_argument("--persist-local-cache",
                         action="store_true",
                         help="If image download succeeds but upload fails, keep local cached copy for subsequent "

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -205,22 +205,12 @@ def main():
                          ", new objects will be created")
 
         # Get or create Glance image
-        # Look for image matching identifier stored in InstanceSource for dprov
         """
         todo corner case: we have existing InstanceSource with wrong image UUID?
         Do we correct it later (good) or end up creating a duplicate (maybe bad)?
         this logic may also need refactor
         """
-        if dprov_instance_source is not None:
-            try:
-                dprov_glance_image = dprov_glance_client.images.get(dprov_instance_source.identifier)
-            except glanceclient.exc.HTTPNotFound:
-                pass
-            else:
-                if dprov_glance_image is not None:
-                    logging.info("Found Glance image from InstanceSource for destination provider, re-using it")
-        else:
-            dprov_glance_image = get_or_create_glance_image(dprov_glance_client, sprov_img_uuid)
+        dprov_glance_image = get_or_create_glance_image(dprov_glance_client, sprov_img_uuid)
 
         # Get or create AKI+ARI Glance images for AMI-based image
         if ami:

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -375,7 +375,7 @@ def migrate_or_verify_image_data(img_uuid, src_glance_client, dst_glance_client,
             migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irods_dst_coll, img_uuid)
         else:
             migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, local_path, persist_local_cache,
-                                      clean)
+                                      clean=clean)
     elif dst_img.get("status") == "active":
         if irods:
             if src_img.get("size") != dst_img.get("size"):

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -391,7 +391,6 @@ def migrate_or_verify_image_data(img_uuid, src_glance_client, dst_glance_client,
     return True
 
 
-
 def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, local_path, persist_local_cache=True,
                               max_tries=3, clean=False):
     """

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -323,6 +323,11 @@ def get_or_create_glance_image(glance_client, img_uuid):
     """
     try:
         glance_image = glance_client.images.get(img_uuid)
+    except glanceclient.exc.HTTPConflict:
+        raise Exception("Could not create Glance image with specified UUID, possibly because there is already a "
+                        "deleted image with the same UUID stored in the destination provider. If this is the case "
+                        "(look in Glance database on destination provider), then run a `glance-manage db purge` to "
+                        "free up the UUID.")
     except glanceclient.exc.HTTPNotFound:
         logging.debug("Could not locate glance image in specified provider")
         logging.info("Creating new Glance image")

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -437,6 +437,7 @@ def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, lo
     if clean:
         # TODO is this a reasonable mount point or should we create one in /tmp?
         mount_and_clean(local_path, "/mnt")
+        logger.info("Cleaned image using Chromogenic")
     local_img_checksum = file_md5(local_path)
 
     # Upload image to destination provider, keep trying until checksums match

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -437,7 +437,7 @@ def migrate_image_data_glance(src_glance_client, dst_glance_client, img_uuid, lo
     if clean:
         # TODO is this a reasonable mount point or should we create one in /tmp?
         mount_and_clean(local_path, "/mnt")
-        logger.info("Cleaned image using Chromogenic")
+        logging.info("Cleaned image using Chromogenic")
     local_img_checksum = file_md5(local_path)
 
     # Upload image to destination provider, keep trying until checksums match


### PR DESCRIPTION
## Description
`--clean` argument uses Chromogenic library to remove undesired state from images which were created from Atmosphere(1) instances. Uses `mount_and_clean()` function of Chromogenic library. Resolves [ATMO-1843](https://pods.iplantcollaborative.org/jira/browse/ATMO-1843) and moves toward resolution of [ATMO-1825](https://pods.iplantcollaborative.org/jira/browse/ATMO-1825).

Also, when we decide whether to attempt migrating image data between providers, we'll now use image status in the destination provider (rather than size/checksum) to determine if Glance will allow image data upload (i.e. status is "queued"). If Glance image is already in active status, we compare sizes/checksums and log a warning if they don't match (though this may be expected in some cases).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
  - New feature documented in script built-in help
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md

## Checklist after merging
- [ ] Cherrypick to X-release