### PR TITLE
Problem: DeviceBusyException method references uninitialized attribute

### DIFF
--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -119,6 +119,7 @@ class OverQuotaError(ServiceException):
 class DeviceBusyException(ServiceException):
 
     def __init__(self, mount_loc, process_list):
+        self.process_list = process_list
         proc_str = ''
         for proc_name, pid in process_list:
             proc_str += '\nProcess name:%s process id:%s' % (proc_name, pid)

--- a/service/tests/test_exceptions.py
+++ b/service/tests/test_exceptions.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+import service.exceptions
+
+
+class ExceptionTest(TestCase):
+    def setUp(self):
+        pass
+
+    def test_device_busy_exception(self):
+        mount_point = '/vol1'
+        process_list = [('/bin/bash', 1067), ('/bin/vim', 2129)]
+
+        new_exception = service.exceptions.DeviceBusyException(mount_point, process_list)
+        expected_message = 'Volume mount location is: /vol1\nRunning processes that are accessing that directory ' \
+                           'must be closed before unmounting. All offending processes names and IDs are listed ' \
+                           'below:\nProcess name:/bin/bash process id:1067\nProcess name:/bin/vim process id:2129'
+        self.assertEqual(new_exception.message, expected_message)
+
+        expected_str = "Volume mount location is: /vol1\nRunning processes that are accessing that directory must be " \
+                       "closed before unmounting. All offending processes names and IDs are listed below:\n" \
+                       "Process name:/bin/bash process id:1067\nProcess name:/bin/vim process id:2129:\n" \
+                       "[('/bin/bash', 1067), ('/bin/vim', 2129)]"
+        self.assertEqual(str(new_exception), expected_str)


### PR DESCRIPTION
## Description
Problem: DeviceBusyException method references uninitialized attribute

This caused an exception when printing the exception. Very meta.

Solution: Set the missing attribute (`process_list`)

Fixes #360

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
