### PR TITLE
Changing  `only_current` query for `start_date` to be less restrictive (for Instances)

### DIFF
--- a/core/query.py
+++ b/core/query.py
@@ -200,7 +200,7 @@ def only_current(now_time=None, restrict_start=False):
         now_time = timezone.now()
     query = (Q(end_date=None) | Q(end_date__gt=now_time))
     if restrict_start:
-        query &= Q(providermachine__instance_source__start_date__lt=now_time)
+        query &= Q(start_date__lt=now_time)
     return query
 
 


### PR DESCRIPTION
Specifically, the only_current queries related to Instance.
In the future, we may move to less restrictive queries
_for all_ cloud resources, to avoid 'time sync' errors/issues

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.