### PR TITLE
Problem: Error & Not Found pages have branded favicon

### DIFF
--- a/extras/nginx/locations/atmo.conf.j2
+++ b/extras/nginx/locations/atmo.conf.j2
@@ -1,7 +1,3 @@
-location /favicon.ico {
-    alias {{ ATMOSPHERE_PATH }}/static/images/favicon.ico;
-}
-
 location /robots.txt {
    alias {{ ATMOSPHERE_PATH }}/static/templates/robots.txt;
 }


### PR DESCRIPTION
## Description

With the adoption of Atmosphere growing, it is best to have _"no"_ or generic error/not-found/404 pages. There should be enough "styling" that the web server does not appear to be correctly configured. However, allowing for a favicon complicates the theming efforts,
overall. Here we offer "less" to gain the ability to focus on more.

See also [ATMO-1536](https://pods.iplantcollaborative.org/jira/browse/ATMO-1536)

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation]~(https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
