### PR TITLE
Problem: unused Nginx location present in atmo.conf.j2

### DIFF
--- a/extras/nginx/locations/atmo.conf.j2
+++ b/extras/nginx/locations/atmo.conf.j2
@@ -6,10 +6,6 @@ location /robots.txt {
    alias {{ ATMOSPHERE_PATH }}/static/templates/robots.txt;
 }
 
-location ~ "^/shell/(?<ipaddress>(\d{1,3}\.){3}\d{1,3})$" {
-        rewrite "^/shell/(?<ipaddress>(\d{1,3}\.){3}\d{1,3})$" https://atmo-proxy.iplantcollaborative.org/?ssh=ssh://$ipaddress:22 permanent;
-}
-
 location / {
    # Redirect to home page
    if ($request_uri ~ "^/$") {


### PR DESCRIPTION
## Description

The web server for `atmo` still defines a location for `/shell`. This dates back to the Airport/cloudfront era of user interface. The web shell is hosted within Troposphere now.

No _external_ ticket available for reference.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
