### PR TITLE
ATMO 1911: Failing test cases because of missing Allocation Source…

### DIFF
--- a/core/hooks/allocation_source.py
+++ b/core/hooks/allocation_source.py
@@ -335,6 +335,15 @@ def listen_for_allocation_source_created_or_renewed(sender, instance, created, *
             defaults={'compute_allowed': compute_allowed}
         )
 
+        allocation_source = AllocationSource.objects.get(name=allocation_source_name)
+
+        AllocationSourceSnapshot.objects.update_or_create(
+            allocation_source=allocation_source,
+            defaults={"compute_allowed": compute_allowed,
+                      "global_burn_rate": 0,
+                      "compute_used": 0.0,
+                      "updated": event.timestamp})
+
     logger.info('object_updated: %s, created: %s' % (object_updated, created,))
 
 

--- a/core/migrations/0084_create_and_assign_allocationsource_to_users.py
+++ b/core/migrations/0084_create_and_assign_allocationsource_to_users.py
@@ -6,6 +6,7 @@ import uuid
 
 from django.db import migrations
 from django.db.models.signals import post_save
+from django.conf import settings
 
 from core.hooks.allocation_source import (
     listen_for_instance_allocation_changes,
@@ -73,6 +74,8 @@ def _assign_instance_allocation_source(allocation_source_name, username, instanc
 
 
 def create_and_assign_allocationsource(apps, schema_editor):
+    if 'jetstream' in settings.INSTALLED_APPS:
+        return
     AllocationSourceTable = apps.get_model('core', 'AllocationSource')
     UserAllocationSourceTable = apps.get_model('core', 'UserAllocationSource')
     InstanceAllocationSourceTable = apps.get_model('core', 'InstanceAllocationSourceSnapshot')

--- a/core/migrations/0084_create_and_assign_allocationsource_to_users.py
+++ b/core/migrations/0084_create_and_assign_allocationsource_to_users.py
@@ -74,7 +74,9 @@ def _assign_instance_allocation_source(allocation_source_name, username, instanc
 
 
 def create_and_assign_allocationsource(apps, schema_editor):
-    if 'jetstream' in settings.INSTALLED_APPS:
+    JETSTREAM_INSTALLED = apps.is_installed('jetstream')
+    if JETSTREAM_INSTALLED:
+        print "Jetstream installed -- Skipping migration 0084...",
         return
     AllocationSourceTable = apps.get_model('core', 'AllocationSource')
     UserAllocationSourceTable = apps.get_model('core', 'UserAllocationSource')


### PR DESCRIPTION
… snapshot (Jetstream)

## Description

Allocation Source snapshot creation in Jetstream takes places after update_snapshot is run 

The test cases where Allocation Source is created and it's compute allowed is changed before running update_snapshot fail for this reason

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
