### PR TITLE
Fix two bugs related to user with 'admin' role

### DIFF
--- a/core/models/provider.py
+++ b/core/models/provider.py
@@ -221,15 +221,15 @@ class Provider(models.Model):
         if not router_distribution:
             router_distribution = self.get_router_distribution()
         minimum = -1
-        minimum_key = None
-        for key, count in router_distribution.items():
+        router_name = None
+        for rtr_name, count in router_distribution.items():
             if minimum == -1:
                 minimum = count
-                minimum_key = key
+                router_name = rtr_name
             elif count < minimum:
                 minimum = count
-                minimum_key = key
-        return minimum_key
+                router_name = rtr_name
+        return router_name
 
     def get_router_distribution(self, router_count_map={}):
         """

--- a/core/models/quota.py
+++ b/core/models/quota.py
@@ -245,8 +245,8 @@ def has_port_count_quota(identity, driver, quota, new_size=0, raise_exc=True):
     except Exception as exc:
         logger.warn("Could not verify quota due to failed call to network_driver.list_ports() - %s" % exc)
         return True
-
-    fixed_ips = [port for port in port_list if 'compute:' in port['device_owner']]
+    project_id = network_driver.get_tenant_id()
+    fixed_ips = [port for port in port_list if 'compute:' in port['device_owner'] and port['project_id'] == project_id]
     total_size = new_size
     total_size += len(fixed_ips)
     if total_size <= quota.port_count:

--- a/core/views.py
+++ b/core/views.py
@@ -54,6 +54,8 @@ def emulate_request(request, username=None):
         if 'emulator' not in request.session:
             original_emulator = request.session['username']
             request.session['emulator'] = original_emulator
+            logger.info("Returning user %s - Emulated as user %s - to api profile "
+                        % (original_emulator, username))
         if 'emulator_token' not in request.session:
             original_token = request.session['token']
             request.session['emulator_token'] = original_token
@@ -63,8 +65,6 @@ def emulate_request(request, username=None):
         request.session['username'] = username
         request.session['token'] = token.key
         request.session.save()
-        logger.info("Returning user %s - Emulated as user %s - to api profile "
-                    % (original_emulator, username))
         logger.info(request.session.__dict__)
         logger.info(request.user)
         return HttpResponseRedirect(settings.REDIRECT_URL + "/api/v1/profile")

--- a/service/networking.py
+++ b/service/networking.py
@@ -13,7 +13,6 @@ from rtwo.exceptions import NeutronClientException, NeutronNotFound
 from atmosphere import settings
 from threepio import logger
 
-
 def topology_list():
     return [
         ExternalNetwork,
@@ -327,6 +326,13 @@ class ExternalRouter(GenericNetworkTopology):
         router_name = identity.get_credential('router_name')
         if not router_name:
             router_name = identity.provider.get_credential('router_name')
+        if not router_name:
+            router_name = identity.provider.select_router()
+            from core.models import Credential
+            Credential.objects.get_or_create(
+                identity=identity,
+                key='router_name',
+                value=router_name)
         if not router_name:
             raise Exception("Unknown Router - Identity %s is missing 'router_name' " % identity)
         self.external_router_name = router_name


### PR DESCRIPTION
Bug 1: 'admin' role users are charged for Fixed IPs they do not own

Solution: Include the project_id as part of the fixed-ip filter.

Bug 2: First account created (admin account) did not have a router_name

Solution: Let ExternalRouterTopology check if a router_name exists
          and include one in a users identity,
          if 'public_routers' is available.


## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.