### PR TITLE
Add a missing lib used in user_driver

### DIFF
--- a/service/instance.py
+++ b/service/instance.py
@@ -16,6 +16,7 @@ from rtwo.models.provider import AWSProvider, AWSUSEastProvider,\
 from rtwo.exceptions import LibcloudBadResponseError
 from rtwo.driver import OSDriver
 from rtwo.drivers.openstack_user import UserManager
+from rtwo.drivers.common import _token_to_keystone_scoped_project
 from service.driver import AtmosphereNetworkManager
 from service.mock import AtmosphereMockDriver, AtmosphereMockNetworkManager
 from rtwo.models.machine import Machine


### PR DESCRIPTION
Simple fix. The `_token_to_keystone_scoped_project` used in the L1584 never got imported. 