### PR TITLE
Problem: TAS reports are slow

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'django_filters',
     'django_celery_beat',
+    'memoize',
 
     'corsheaders',
     # 3rd party apps (Development Only)

--- a/jetstream/allocation.py
+++ b/jetstream/allocation.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from django.conf import settings
 from django.db import IntegrityError
@@ -11,7 +10,7 @@ from .tas_api import tacc_api_post, tacc_api_get
 from core.models import EventTable
 from core.models.allocation_source import AllocationSource, UserAllocationSource
 
-logger = logging.getLogger(__name__)
+from threepio import logger
 
 
 class TASAPIDriver(object):
@@ -129,9 +128,9 @@ class TASAPIDriver(object):
         }
         path = '/v1/jobs'
         url_match = self.tacc_api + path
-        #logger.debug("TAS_REQ: %s - POST - %s" % (url_match, post_data))
+        # logger.debug("TAS_REQ: %s - POST - %s" % (url_match, post_data))
         resp = tacc_api_post(url_match, post_data, self.tacc_username, self.tacc_password)
-        #logger.debug("TAS_RESP: %s" % resp.__dict__)  # Overkill?
+        # logger.debug("TAS_RESP: %s" % resp.__dict__)  # Overkill?
         try:
             data = resp.json()
             #logger.debug("TAS_RESP - Data: %s" % data)

--- a/jetstream/models.py
+++ b/jetstream/models.py
@@ -52,11 +52,9 @@ class TASAllocationReport(models.Model):
                 driver = TASAPIDriver(BETA_TACC_API_URL, BETA_TACC_API_USER, BETA_TACC_API_PASS)
             else:
                 driver = TASAPIDriver()
-            success = driver.report_project_allocation(
-                self.id, self.username,
-		self.project_name, float(self.compute_used),
-                self.start_date, self.end_date,
-                self.queue_name, self.scheduler_id)
+            success = driver.report_project_allocation(self.id, self.username, self.project_name,
+                                                       float(self.compute_used), self.start_date, self.end_date,
+                                                       self.queue_name, self.scheduler_id)
             self.success = True if success else False
             if self.success:
                 self.report_date = timezone.now()

--- a/jetstream/tas_api.py
+++ b/jetstream/tas_api.py
@@ -1,6 +1,7 @@
 import requests
 
 from django.conf import settings
+from memoize import memoize
 
 from .exceptions import TASAPIException
 
@@ -21,6 +22,7 @@ def tacc_api_post(url, post_data, username=None, password=None):
     return resp
 
 
+@memoize(timeout=300)
 def tacc_api_get(url, username=None, password=None):
     if not username:
         username = settings.TACC_API_USER

--- a/jetstream/tas_api.py
+++ b/jetstream/tas_api.py
@@ -2,22 +2,22 @@ import requests
 
 from django.conf import settings
 
-import logging
 from .exceptions import TASAPIException
-logger = logging.getLogger(__name__)
 
+from threepio import logger
 
 def tacc_api_post(url, post_data, username=None, password=None):
     if not username:
         username = settings.TACC_API_USER
     if not password:
         password = settings.TACC_API_PASS
-    #logger.info("REQ: %s" % url)
-    #logger.info("REQ BODY: %s" % post_data)
+    logger.debug('url: %s', url)
+    # logger.debug("REQ BODY: %s" % post_data)
     resp = requests.post(
         url, post_data,
         auth=(username, password))
-    #logger.info("RESP: %s" % resp.__dict__)
+    logger.debug('resp.status_code: %s', resp.status_code)
+    # logger.debug('resp.__dict__: %s', resp.__dict__)
     return resp
 
 
@@ -26,11 +26,12 @@ def tacc_api_get(url, username=None, password=None):
         username = settings.TACC_API_USER
     if not password:
         password = settings.TACC_API_PASS
-    #logger.info("REQ: %s" % url)
+    logger.debug('url: %s', url)
     resp = requests.get(
         url,
         auth=(username, password))
-    #logger.info("RESP: %s" % resp.__dict__)
+    logger.debug('resp.status_code: %s', resp.status_code)
+    # logger.debug('resp.__dict__: %s', resp.__dict__)
     if resp.status_code != 200:
         raise TASAPIException(
             "Invalid Response - "
@@ -38,7 +39,7 @@ def tacc_api_get(url, username=None, password=None):
     # Expects *ALL* GET calls to return application/json
     try:
         data = resp.json()
-        #logger.info(data)
+        # logger.debug(data)
     except ValueError as exc:
         raise TASAPIException(
             "JSON Decode error -- %s" % exc)

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ Pillow==2.5.3
 PyJWT==1.4.0
 
 python-logstash==0.4.5
-
+django-memoize
 #Theirs
 psycopg2==2.5.4
 python-ldap==2.4.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 amqp==2.1.4               # via kombu
 ansible==2.3.0.0          # via subspace
 apache-libcloud==0.20.1
-appdirs==1.4.3            # via os-client-config, setuptools
+appdirs==1.4.3            # via os-client-config
 asn1crypto==0.22.0        # via cryptography
 babel==2.3.4              # via flower, osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient
 backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud, tornado
@@ -31,6 +31,7 @@ django-celery-beat==1.0.1
 django-cors-headers==0.12.0
 django-cyverse-auth==1.0.13
 django-filter==1.0.1
+django-memoize==2.1.0
 django-redis-cache==0.13.0
 django-sslserver==0.19
 django==1.10.6
@@ -75,7 +76,7 @@ oslo.config==3.23.0       # via python-keystoneclient
 oslo.i18n==3.14.0         # via osc-lib, oslo.config, oslo.utils, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
 oslo.serialization==2.17.0  # via python-keystoneclient, python-neutronclient, python-novaclient
 oslo.utils==3.23.0        # via osc-lib, oslo.serialization, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
-packaging==16.8           # via cryptography, setuptools
+packaging==16.8           # via cryptography
 pandas==0.19.2
 paramiko==2.1.2           # via ansible, fabric
 pbr==2.0.0                # via cliff, debtcollector, keystoneauth1, openstacksdk, osc-lib, oslo.i18n, oslo.serialization, oslo.utils, positional, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, requestsexceptions, rtwo, stevedore
@@ -93,8 +94,6 @@ pyparsing==2.2.0          # via cliff, cmd2, oslo.utils, packaging
 python-cinderclient==1.9.0  # via python-openstackclient, rtwo
 python-dateutil==2.6.0
 python-glanceclient==2.5.0  # via python-openstackclient, rtwo
-# python-irodsclient commented out until https://github.com/irods/python-irodsclient/pull/67 and https://github.com/cyverse/rtwo/pull/10 are merged
-# python-irodsclient==0.4.0  # via rtwo
 python-keystoneclient==3.6.0  # via django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
 python-ldap==2.4.19
 python-logstash==0.4.5
@@ -113,7 +112,7 @@ rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
 rtwo==0.5.10
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
-six==1.10.0               # via cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-swiftclient, setuptools, stevedore, warlock
+six==1.10.0               # via cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, packaging, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-swiftclient, stevedore, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
 subspace==0.4.1
 threepio==0.2.0


### PR DESCRIPTION
## Description

Problem: Generating & sending TAS Allocation Reports is slow.

Solution: Use a few different approaches to speed it up
- Only send reports with non-zero `compute_used`
- Use `django-memoize` to add a cache with a 5 minute timeout for all TAS API `GET` requests
- Use `MAX` aggregation to find last report date, instead of listing all reports by `end_date` and then grabbing the last one.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~If necessary, include a snippet in CHANGELOG.md~
