### PR TITLE
Added monitor_allocation_sources task to celerybeat schedule in local…

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -180,7 +180,14 @@ ALLOCATIONS_CELERYBEAT_SCHEDULE = {
         # Every 15 minutes
         "schedule": timedelta(minutes=15),
         "options" : {"expires": 15 * 60,"time_limit": 15 * 60}
-  }
+  },
+  "monitor_allocation_sources":{
+	"task":"monitor_allocation_sources",
+        # Every 15 minutes
+        "schedule": timedelta(minutes=15),
+        "options" : {"expires": 15 * 60,"time_limit": 15 * 60}
+  },
+
 }
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
 {% endif %}

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -585,8 +585,13 @@ def monitor_allocation_sources(usernames=()):
 def allocation_source_overage_enforcement_for_user(allocation_source, user):
     user_instances = []
     for identity in user.current_identities:
-        affected_instances = allocation_source_overage_enforcement_for(allocation_source, user, identity)
-        user_instances.extend(affected_instances)
+        try:
+            affected_instances = allocation_source_overage_enforcement_for(allocation_source, user, identity)
+            user_instances.extend(affected_instances)
+        except Exception:
+            celery_logger.exception(
+                'allocation_source_overage_enforcement_for allocation_source: %s, user: %s, and identity: %s',
+                allocation_source, user, identity)
     return user_instances
 
 


### PR DESCRIPTION
….py.j2

Modified monitor_allocation_sources task to catch all exceptions thrown by provider

## Description

Added code in "monitor_allocation_sources" task to catch the exception and continue if there is an exception raised by any provider

"monitor_allocation_sources" task is added to the celerybeat schedule in local.py.j2 . This task is responsible for enforcement


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
