### PR TITLE
Enable enforcing hotfix

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -155,39 +155,44 @@ CELERYBEAT_SCHEDULE["{{task_key}}"]["{{task_opt}}"] = {{task_opt_value}}
 {% if USE_JETSTREAM_PLUGIN %}
 ALLOCATION_SOURCE_WARNINGS = [10, 25, 50, 75, 90]
 JETSTREAM_CELERYBEAT_SCHEDULE = {
-  "report_allocations_to_tas":{
-        "task":"report_allocations_to_tas",
-        "schedule" : timedelta(minutes=60),
-        "options" : {"expires": 30 * 60,"time_limit": 30 * 60}
+    "report_allocations_to_tas": {
+        "task": "report_allocations_to_tas",
+        "schedule": timedelta(minutes=60),
+        "options": {"expires": 30 * 60, "time_limit": 30 * 60}
     },
-  "update_snapshot":{
-	"task":"update_snapshot",
-        "schedule":timedelta(minutes=30),
-	"options" : {"expires":20*60 , "time_limit":20*60}
+    "update_snapshot": {
+        "task": "update_snapshot",
+        "schedule": timedelta(minutes=30),
+        "options": {"expires": 20 * 60, "time_limit": 20 * 60}
     },
-  "monitor_jetstream_allocation_sources":{
-	"task":"monitor_jetstream_allocation_sources",
+    "monitor_jetstream_allocation_sources": {
+        "task": "monitor_jetstream_allocation_sources",
         # Every 60 minutes, no longer than 45 minutes
         "schedule": crontab(minute="*/60"),
-        "options" : {"expires": 45 * 60,"time_limit": 45 * 60}
-  }
+        "options": {"expires": 45 * 60, "time_limit": 45 * 60}
+    },
+    "monitor_allocation_sources": {
+        "task": "monitor_allocation_sources",
+        # Every 15 minutes
+        "schedule": timedelta(minutes=15),
+        "options": {"expires": 15 * 60, "time_limit": 15 * 60}
+    }
 }
 CELERYBEAT_SCHEDULE.update(JETSTREAM_CELERYBEAT_SCHEDULE)
 {% else %}
 ALLOCATIONS_CELERYBEAT_SCHEDULE = {
-  "update_snapshot_cyverse":{
-	"task":"update_snapshot_cyverse",
+    "update_snapshot_cyverse": {
+        "task": "update_snapshot_cyverse",
         # Every 15 minutes
         "schedule": timedelta(minutes=15),
-        "options" : {"expires": 15 * 60,"time_limit": 15 * 60}
-  },
-  "monitor_allocation_sources":{
-	"task":"monitor_allocation_sources",
+        "options": {"expires": 15 * 60, "time_limit": 15 * 60}
+    },
+    "monitor_allocation_sources": {
+        "task": "monitor_allocation_sources",
         # Every 15 minutes
         "schedule": timedelta(minutes=15),
-        "options" : {"expires": 15 * 60,"time_limit": 15 * 60}
-  },
-
+        "options": {"expires": 15 * 60, "time_limit": 15 * 60}
+    },
 }
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
 {% endif %}

--- a/service/monitoring.py
+++ b/service/monitoring.py
@@ -468,10 +468,14 @@ def filter_allocation_source_instances(allocation_source, user, esh_instances):
 
 
 def allocation_source_overage_enforcement_for(allocation_source, user, identity):
+    logger.debug("allocation_source_overage_enforcement_for - allocation_source: %s, user: %s, identity: %s",
+                 allocation_source, user, identity)
     provider = identity.provider
     action = provider.over_allocation_action
+    logger.debug("allocation_source_overage_enforcement_for - provider.over_allocation_action: %s",
+                 provider.over_allocation_action)
     if not action:
-        logger.debug("No 'over_allocation_action' provided for %s" % provider)
+        logger.debug("No 'over_allocation_action' provided for %s", provider)
         return []  # Over_allocation was not attempted
     if not settings.ENFORCING:
         logger.info("Settings dictate that ENFORCING = False. Returning..")

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -587,7 +587,8 @@ def monitor_allocation_sources(usernames=()):
             celery_logger.debug('monitor_allocation_sources - user: %s, over_allocation: %s', user, over_allocation)
             if not over_allocation:
                 continue
-            allocation_source_overage_enforcement_for_user.apply_async(args=(allocation_source.name, user))
+            celery_logger.debug('monitor_allocation_sources - Going to enforce on user user: %s', user)
+            allocation_source_overage_enforcement_for_user.apply_async(args=(allocation_source, user))
 
 
 @task(name="allocation_source_overage_enforcement_for_user")

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -574,13 +574,17 @@ def monitor_allocation_sources(usernames=()):
     """
     Monitor allocation sources, if a snapshot shows that all compute has been used, then enforce as necessary
     """
+    celery_logger.debug('monitor_allocation_sources - usernames: %s', usernames)
     allocation_sources = AllocationSource.objects.all()
     for allocation_source in allocation_sources.order_by('name'):
-        for user in allocation_source.all_users:
+        celery_logger.debug('monitor_allocation_sources - allocation_source: %s', allocation_source)
+        for user in allocation_source.all_users.order_by('username'):
+            celery_logger.debug('monitor_allocation_sources - user: %s', user)
             if usernames and user.username not in usernames:
                 celery_logger.info("Skipping User %s - not in the list" % user.username)
                 continue
             over_allocation = allocation_source.is_over_allocation(user)
+            celery_logger.debug('monitor_allocation_sources - user: %s, over_allocation: %s', user, over_allocation)
             if not over_allocation:
                 continue
             allocation_source_overage_enforcement_for_user.apply_async(args=(allocation_source.name, user))
@@ -588,9 +592,12 @@ def monitor_allocation_sources(usernames=()):
 
 @task(name="allocation_source_overage_enforcement_for_user")
 def allocation_source_overage_enforcement_for_user(allocation_source, user):
+    celery_logger.debug('allocation_source_overage_enforcement_for_user - allocation_source: %s, user: %s',
+                        allocation_source, user)
     user_instances = []
     for identity in user.current_identities:
         try:
+            celery_logger.debug('allocation_source_overage_enforcement_for_user - identity: %s', identity)
             affected_instances = allocation_source_overage_enforcement_for(allocation_source, user, identity)
             user_instances.extend(affected_instances)
         except Exception:


### PR DESCRIPTION
## Description

Problem: Wrong parameter for enforcement function
    
`allocation_source_overage_enforcement_for_user` and all the subsequent
logic expects an allocation source object, but we pass in a string.
    
Solution: Pass in the `allocation_source` instead of
`allocation_source.name`

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
