### PR TITLE
Problem: Premature end-dating of instances on api calls to DELETE

### DIFF
--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -5,7 +5,7 @@ from api.v2.views.mixins import MultipleFieldLookup
 from api.v2.views.instance_action import InstanceActionViewSet
 
 from core.exceptions import ProviderNotActive
-from core.models import Instance, Identity, UserAllocationSource, Project
+from core.models import Instance, Identity, UserAllocationSource, Project, AllocationSource
 from core.models.boot_script import _save_scripts_to_instance
 from core.models.instance import find_instance
 from core.models.instance_action import InstanceAction
@@ -167,30 +167,33 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
 
     def perform_destroy(self, instance):
         user = self.request.user
-        identity_uuid = instance.created_by_identity.uuid
+        identity_uuid = str(instance.created_by_identity.uuid)
         identity = Identity.objects.get(uuid=identity_uuid)
+        provider_uuid = str(identity.provider.uuid)
         try:
-            # Test that there is not an attached volume BEFORE we destroy
-            #NOTE: Although this is a task we are calling and waiting for response..
-            core_instance = destroy_instance(
-                user,
-                identity_uuid,
-                instance.provider_alias)
-            serialized_instance = InstanceSerializer(
-                core_instance, context={
+            # Test that there is not an attached volume and destroy is ASYNC
+            destroy_instance.delay(
+                instance.provider_alias, user, identity_uuid)
+            # NOTE: Task to delete has been queued, return 204
+            serializer = InstanceSerializer(
+                instance, context={
                     'request': self.request},
                 data={}, partial=True)
-            if not serialized_instance.is_valid():
-                return Response(serialized_instance.data,
+            if not serializer.is_valid():
+                return Response("Errors encountered during delete: %s" % serializer.errors,
                                 status=status.HTTP_400_BAD_REQUEST)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except VolumeAttachConflict as exc:
             message = exc.message
             return failure_response(status.HTTP_409_CONFLICT, message)
         except (socket_error, ConnectionFailure):
-            return connection_failure(identity)
+            return connection_failure(provider_uuid, identity_uuid)
         except LibcloudInvalidCredsError:
-            return invalid_creds(identity)
+            return invalid_creds(provider_uuid, identity_uuid)
+        except InstanceDoesNotExist as dne:
+            return failure_response(
+                status.HTTP_404_NOT_FOUND,
+                'Instance %s no longer exists' % (dne.message,))
         except Exception as exc:
             logger.exception("Encountered a generic exception. "
                              "Returning 409-CONFLICT")

--- a/service/instance.py
+++ b/service/instance.py
@@ -668,36 +668,10 @@ def destroy_instance(user, core_identity_uuid, instance_alias):
         core_identity_uuid, instance_alias)
     if not success and esh_instance:
         raise Exception("Instance could not be destroyed")
-    elif esh_instance:
-        os_cleanup_networking(core_identity_uuid)
-        core_instance = end_date_instance(
-            user, esh_instance, core_identity_uuid)
-        return core_instance
-    else:
-        # Edge case - If you attempt to delete more than once...
-        core_instance = find_instance(instance_alias)
-        return core_instance
-
-
-def end_date_instance(user, esh_instance, core_identity_uuid):
-    # Retrieve the 'hopefully now deleted' instance and end date it.
-    identity = CoreIdentity.objects.get(uuid=core_identity_uuid)
-    esh_driver = get_cached_driver(identity=identity)
-    try:
-        core_instance = convert_esh_instance(esh_driver, esh_instance,
-                                             identity.provider.uuid,
-                                             identity.uuid,
-                                             user)
-        #NOTE: We may want to ensure instances are *actually* terminated prior to end dating them.
-        if core_instance:
-            core_instance.end_date_all()
-        return core_instance
-    except (socket_error, ConnectionFailure):
-        logger.exception("connection failure during destroy instance")
-        return None
-    except LibcloudInvalidCredsError:
-        logger.exception("LibcloudInvalidCredsError during destroy instance")
-        return None
+    os_cleanup_networking(core_identity_uuid)
+    core_instance = find_instance(instance_alias)
+    core_instance.end_date_all()
+    return core_instance
 
 
 def os_cleanup_networking(core_identity_uuid):

--- a/service/task.py
+++ b/service/task.py
@@ -58,7 +58,7 @@ def add_floating_ip_task(driver, instance, *args, **kwargs):
 
 def destroy_instance_task(user, instance, identity_uuid, *args, **kwargs):
     if not instance:
-        raise InstanceDoesNotExist(instance_id=identity_uuid)
+        raise InstanceDoesNotExist(instance_id=instance.alias)
     return destroy_instance.delay(
         instance.alias, user, identity_uuid, *args, **kwargs)
 


### PR DESCRIPTION
## Solution

Change logic so that 'end_date_all' happens inside the delete instance task, thereby avoiding premature end-dating of instances.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Reviewed and approved by at least one other contributor.
