### PR TITLE
Problem: Missing UserAllocationSources (and more!)

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -179,6 +179,7 @@ JETSTREAM_CELERYBEAT_SCHEDULE = {
     }
 }
 CELERYBEAT_SCHEDULE.update(JETSTREAM_CELERYBEAT_SCHEDULE)
+ALLOCATION_SOURCE_PLUGINS = ['jetstream.plugins.allocation_source.JetstreamAllocationSourcePlugin',]
 {% else %}
 ALLOCATIONS_CELERYBEAT_SCHEDULE = {
     "update_snapshot_cyverse": {
@@ -195,6 +196,7 @@ ALLOCATIONS_CELERYBEAT_SCHEDULE = {
     },
 }
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
+ALLOCATION_SOURCE_PLUGINS = ['cyverse_allocation.plugins.allocation_source.FlexibleAllocationSourcePlugin',]
 {% endif %}
 # Logging
 LOGGING_LEVEL = {{ LOGGING_LEVEL | default("logging.INFO") }}

--- a/cyverse_allocation/plugins/allocation_source.py
+++ b/cyverse_allocation/plugins/allocation_source.py
@@ -1,0 +1,93 @@
+import uuid
+
+from django.core.exceptions import ObjectDoesNotExist
+from threepio import logger
+
+from core.models import EventTable, AllocationSource, AtmosphereUser, UserAllocationSource
+
+
+class FlexibleAllocationSourcePlugin(object):
+    def ensure_user_allocation_source(self, user, provider=None):
+        """Ensures that a user has valid allocation sources.
+
+        Will create a new one and/or assign an existing one to the user
+
+        :param user: The user to check
+        :type user: core.models.AtmosphereUser
+        :param provider: A provider (not used by FlexibleAllocationSourcePlugin)
+        :type provider: core.models.Provider
+        :return: Whether the user has valid allocation sources
+        :rtype: bool
+        """
+
+        return _ensure_user_allocation_source(user)
+
+
+def _ensure_user_allocation_source(user):
+    """Ensures that a user has valid allocation sources.
+
+    Will create a new one and/or assign an existing one to the user
+
+    :param user: The user to check
+    :type user: core.models.AtmosphereUser
+    :return: Whether the user has valid allocation sources
+    :rtype: bool
+    """
+
+    # Safety valve: Don't try to create an AllocationSource and UserAllocationSource if the AtmosphereUser does
+    # not exist. You *will* get into an inconsistent state if this happens - the AllocationSource and the
+    # `user_allocation_source_created` event will exist, but with no matching UserAllocationSource
+    assert isinstance(user, AtmosphereUser)
+    allocation_source_name = user.username
+
+    try:
+        allocation_source = AllocationSource.objects.get(name=allocation_source_name)
+    except ObjectDoesNotExist:
+        logger.debug('No AllocationSource with name %s found. Creating a new AllocationSource.',
+                     allocation_source_name)
+        _create_allocation_source(allocation_source_name)
+        allocation_source = AllocationSource.objects.get(name=allocation_source_name)
+    else:
+        logger.debug('AllocationSource with name %s exists. Skipping creation step.', allocation_source_name)
+    try:
+        user_allocation_source = UserAllocationSource.objects.get(user=user,
+                                                                  allocation_source=allocation_source)
+    except ObjectDoesNotExist:
+        logger.debug('No UserAllocationSource with name %s found. Assigning allocation source to user.',
+                     allocation_source_name)
+        _assign_user_allocation_source(allocation_source, user)
+    else:
+        logger.debug('UserAllocationSource with name %s exists: %s Skipping creation step.',
+                     allocation_source_name, user_allocation_source)
+    return True
+
+
+def _create_allocation_source(name):
+    payload = {
+        'uuid': str(uuid.uuid4()),
+        'allocation_source_name': name,
+        'compute_allowed': 168,  # TODO: Make this configurable
+        'renewal_strategy': 'default'
+    }
+    event = EventTable(
+        name='allocation_source_created_or_renewed',
+        entity_id=name,
+        payload=payload
+    )
+    event.save()
+
+
+def _assign_user_allocation_source(source_to_assign, user_to_assign):
+    assert isinstance(source_to_assign, AllocationSource)
+    assert isinstance(user_to_assign, AtmosphereUser)
+    username_to_assign = user_to_assign.username
+    payload = {'allocation_source_name': source_to_assign.name}
+    event = EventTable(
+        name='user_allocation_source_created',
+        entity_id=username_to_assign,
+        payload=payload
+    )
+    event.save()
+
+
+__all__ = ['FlexibleAllocationSourcePlugin']

--- a/jetstream/plugins/allocation_source.py
+++ b/jetstream/plugins/allocation_source.py
@@ -1,0 +1,16 @@
+class JetstreamAllocationSourcePlugin(object):
+    def ensure_user_allocation_source(self, user, provider=None):
+        """Ensures that a user has valid allocation sources.
+
+        Will check the TAS API and mirror what it finds in the AllocationSource & UserAllocationSource tables locally.
+
+        :param user: The user to check
+        :type user: core.models.AtmosphereUser
+        :param provider: A provider (not used by JetstreamAllocationSourcePlugin)
+        :type provider: core.models.Provider
+        :return: Whether the user has valid allocation sources
+        :rtype: bool
+        """
+        return True  # TODO: Implement this
+
+__all__ = ['JetstreamAllocationSourcePlugin']


### PR DESCRIPTION
*Problem 1*

Users reported being unable to launch instances because they had no
 allocation sources. On investigation it turned that the
 `AllocationSources` with their names did exist, but not the
 `UserAllocationSources` which were used to link their `AtmosphereUser`
 accounts to the allocation sources.

We also found that the `user_allocation_source_created` events which
 should trigger the creation of the `UserAllocationSources` did exist.

The process for creating a `UserAllocationSource` relies on an
 `AtmosphereUser` already existing, and happens as part of creating an
 identity on a provider - in the
 `service.accounts.openstack_manager.AccountDriver#create_account`.
 Normally this happens when the user logs in and we know that the
 `AtmosphereUser` exists.

We found another another place where `create_account` is called.

The `add_new_accounts.py` script is called by a cron job, looks up
 new LDAP accounts with Atmosphere access, and creates identities on a
 provider using `create_account`. It doesn't create an `AtmosphereUser`
 before it calls `create_account`.

As a result `create_account` would fail when creating the
 `UserAllocationSource`, but not before it creates an `AllocationSource`
 matching the user name. Any calls to `create_account` also check if an
 `AllocationSource` exists with the same name as the username so that it
 does not create duplicate `AllocationSources`. It also does not try to
 create (the now missing) `UserAllocationSource`.

This is how we ended up with an `AllocationSource` for a username as
 well as an `user_allocation_source_created` event, but no
 `UserAllocationSource`.

Solution: In `add_new_accounts.py`, before calling `create_account`
 ensure that the AtmosphereUser exists by calling
 `core.models.Group.create_usergroup`

Also add a 'safety valve'/'eject button' in
 `service.accounts.openstack_manager.AccountDriver#create_account` to
 throw an exception if is called with a username that is not present
 in the system.

*Problem 2*

In `create_account` these allocation sources for usernames are also
 being created on Jetstream. This is not good. Fortunately they are
 being deleted as soon as they are created because of the TAS
 'mirroring' logic, but still...

Solution: Created an AllocationSourcePluginManager

There are two plugins to start with:

- `jetstream.plugins.allocation_source.JetstreamAllocationSource`
- `cyverse_allocation.plugins.allocation_source.FlexibleAllocationSource`

Currently the only required method for a plugin of this type is:
 `ensure_user_allocation_source` and it should return a boolean.

This will ensure that the user has a valid allocation source,
 potentially creating it in the case of the `FlexibleAllocationSource`.

I still have to implement the logic for `JetstreamAllocationSource`, and
 it just returns `True` for now.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~If necessary, include a snippet in CHANGELOG.md~
