### PR TITLE
Fix requirements workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@
     - sudo pg_lsclusters # For testing purposes
 
   install:
-    - pip install -U pip
-    - pip install pip-tools # Necessary for ./travis/check_properly_generated_requirements.sh
+    # setuptools and pip-tools are necessary for ./travis/check_properly_generated_requirements.sh
+    - pip install -U pip setuptools pip-tools
     - pip install -r dev_requirements.txt
 
   before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@
   # https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
   group: deprecated-2017Q2
 
+  cache: pip
+
   language: python
   python:
     - 2.7


### PR DESCRIPTION
## Description

The `./travis/check_properly_generated_requirements.sh` was failing in the clank build. pip-compile could not work with the existing really old setuptools. So an upgrade to setuptools fixed the clank build. Additionally I added caching for pip in travis, which sped up installs from ~4min to about ~1min of pip installs.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
