### PR TITLE
Problem: Too many requests from UI in workshops

### DIFF
--- a/api/v1/urls.py
+++ b/api/v1/urls.py
@@ -2,6 +2,7 @@
 """
 Routes for api v1 endpoints
 """
+import django.views.decorators.cache
 from django.conf.urls import url
 
 from rest_framework.urlpatterns import format_suffix_patterns
@@ -111,7 +112,7 @@ urlpatterns = format_suffix_patterns([
         '(?P<instance_id>%s)/action$' % uuid_match,
         views.InstanceAction.as_view(), name='instance-action'),
     url(identity_specific + r'/instance/(?P<instance_id>%s)$' % uuid_match,
-        views.Instance.as_view(), name='instance-detail'),
+        django.views.decorators.cache.cache_page(60 * 1)(views.Instance.as_view()), name='instance-detail'),
     url(identity_specific + r'/instance$',
         views.InstanceList.as_view(), name='instance-list'),
 

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -500,3 +500,10 @@ WEB_DESKTOP = {
         'SALT': '{{ WEB_DESKTOP_FP_SALT }}'
     }
 }
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/var/tmp/django_cache',
+    }
+}

--- a/service/quota.py
+++ b/service/quota.py
@@ -238,10 +238,17 @@ def _set_compute_quota(user_quota, identity):
     admin_driver = ad.admin_driver
     #FIXME: Remove 'use_tenant_id' when legacy clouds are no-longer in use.
     try:
+        result = admin_driver._connection.ex_update_quota(tenant_id, compute_values, use_tenant_id=use_tenant_id)
+    except Exception:
+        logger.exception("Could not set a user-quota, trying to set tenant-quota")
+        raise
+    #FIXME: For jetstream, return result here.
+    #       For CyVerse old clouds, run the top method. don't use try/except.
+    try:
         result = admin_driver._connection.ex_update_quota_for_user(
             tenant_id, ks_user.id, compute_values, use_tenant_id=use_tenant_id)
     except Exception:
         logger.exception("Could not set a user-quota, trying to set tenant-quota")
-        result = admin_driver._connection.ex_update_quota(tenant_id, compute_values, use_tenant_id=use_tenant_id)
+        raise
     logger.info("Updated quota for %s to %s" % (username, result))
     return result


### PR DESCRIPTION
When the same account is being used by many people the UI polls the
API too frequently, causing problems for the server.

Solution: Temporarily add a short-lived cache to the most heavily used
endpoint.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
