### PR TITLE
Bugfix: invalid HTTP Host header causes 500

### DIFF
--- a/extras/nginx/site.conf.j2
+++ b/extras/nginx/site.conf.j2
@@ -50,6 +50,15 @@ server {
         text/css
         text/plain;
 
+    # Deny illegal Host headers
+    if ($host !~* ^({{ SERVER_URL }})$ ) {
+        return 444;
+        # 444 == No Response (Nginx):
+        # returns no information to the client
+        # and closes the connection
+        # (useful as a deterrent for malware)
+    }
+
     include /etc/nginx/uwsgi_params;
 
     include locations/*.conf;


### PR DESCRIPTION
## Solution:
 Include nginx snippet to block calls with an invalid host header.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
