### PR TITLE
Problem: Launch instance script fails - no allocation source

### DIFF
--- a/scripts/launch_instances.py
+++ b/scripts/launch_instances.py
@@ -12,7 +12,7 @@ import libcloud.security
 
 from django.db.models import Count, Q
 from core.models import AtmosphereUser as User
-from core.models import Provider, ProviderMachine, Size, InstanceSource
+from core.models import Provider, ProviderMachine, Size, InstanceSource, AllocationSource
 from core.query import only_current, only_current_source
 
 from service.instance import launch_instance
@@ -184,7 +184,8 @@ def launch(user, name_prefix, provider, machines, size,
            host, skip_deploy, count):
     ident = user.identity_set.get(provider_id=provider.id)
     instances = []
-    kwargs = {}
+    allocation_source = AllocationSource.objects.get(name__exact=user.username)
+    kwargs = {'allocation_source': allocation_source}
     if host:
         kwargs['ex_availability_zone'] = host
     machine_count = 0


### PR DESCRIPTION
The `scripts\launch_instances.py` file calls
`service.instance.launch_instance` - which now expects an allocation
source.

Solution: Look up the allocation source matching the username and pass
that along.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
