### PR TITLE
Problem: User allocation snapshots not resetting

### DIFF
--- a/core/hooks/allocation_source.py
+++ b/core/hooks/allocation_source.py
@@ -320,6 +320,7 @@ def listen_for_allocation_source_created_or_renewed(sender, instance, created, *
         )
 
         allocation_source = get_allocation_source_object(payload['uuid'])
+        assert isinstance(allocation_source, AllocationSource)
 
         AllocationSourceSnapshot.objects.update_or_create(
             allocation_source=allocation_source,
@@ -328,6 +329,9 @@ def listen_for_allocation_source_created_or_renewed(sender, instance, created, *
                       "compute_used": 0.0,
                       "updated": event.timestamp})
 
+        for user_allocation_snapshot in allocation_source.user_allocation_snapshots.all():
+            user_allocation_snapshot.compute_used = 0.0
+            user_allocation_snapshot.save()
     else:
         # Jetstream
         object_updated, created = AllocationSource.objects.update_or_create(


### PR DESCRIPTION
Solution: When we reset `compute_used` on `AllocationSourceSnapshot` we
also reset the corresponding `UserAllocationSnapshot` objects.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
