### PR TITLE
Problem: Not resetting allocation sources

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -506,12 +506,6 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=120),
         "options": {"expires": 60 * 60}
     },
-    "monthly_allocation_reset": {
-        "task": "monthly_allocation_reset",
-        # Every month, first of the month.
-        "schedule": crontab(0, 0, day_of_month=1, month_of_year="*"),
-        "options": {"expires": 5 * 60, "time_limit": 5 * 60}
-    },
     "remove_empty_networks": {
         "task": "remove_empty_networks",
         # Every two hours.. midnight/2am/4am/...

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -193,6 +193,11 @@ ALLOCATIONS_CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=15),
         "options": {"expires": 15 * 60, "time_limit": 15 * 60}
     },
+    "renew_allocation_sources": {
+        "task": "renew_allocation_sources",
+        "schedule": crontab(0, 0, day_of_month='1'),
+        "options": {"expires": 15 * 60, "time_limit": 15 * 60}
+    },
 }
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
 {% endif %}

--- a/features/allocation.features/alternate_story.feature
+++ b/features/allocation.features/alternate_story.feature
@@ -41,7 +41,7 @@ Feature: Testing an Alternate story
     And User instance runs for some days
     | username     | instance_id  | days  | status       |
     | amitj        |      1       |   1   | active       |
-    | julainp      |      2       |   1   | active       |
+    | julianp      |      2       |   1   | active       |
 
     ## NOTE: Currently, the rules engine is set to renew in every 3 days. After every renewal the compute used is reset and remaining compute is carried over
 
@@ -54,8 +54,9 @@ Feature: Testing an Alternate story
     | allocation_source_id | new_compute_allowed |
     |          1           |    400              |
 
-    # test that one off renewal task does not reset EVERY allocation source to the original compute allowed value
+    # test that one off renewal task does reset EVERY allocation source to the original compute allowed value
+    # This is new behavior
     And One off Renewal task is run without rules engine
     | current compute used | current compute allowed | allocation_source_id |
-    | 0                    | 400                     | 1                    |
+    | 0                    | 168                     | 1                    |
     | 0                    | 168                     | 2                    |


### PR DESCRIPTION
Solution: Re-use `cyverse_allocation.tasks.renew_allocation_sources`,
but simplified for a simple reset of the allocation source which does
not require the rules engine.

Next: Use the rules engine.

Note: Depends on PR #406 "User allocation snapshots not resetting" for proper functioning.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
