### PR TITLE
New configuration option: Django debug toolbar (2)

### DIFF
--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -134,8 +134,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.gzip.GZipMiddleware',
-    #For profile/debugging
-    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -406,6 +406,32 @@ INSTALLED_APPS += (
     'sslserver',
 )
 {% endif %}
+{% if DJANGO_DEBUG_TOOLBAR %}
+# Include django-debug-toolbar
+INSTALLED_APPS += (
+    'debug_toolbar',
+)
+SHOW_TOOLBAR_CALLBACK = True
+MIDDLEWARE_CLASSES += (
+    #For profile/debugging
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+)
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    # 'debug_toolbar.panels.settings.SettingsPanel',
+    # 'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    # 'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    # 'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    # 'debug_toolbar.panels.redirects.RedirectsPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
+]
+{% endif %}
 
 {% if USE_JETSTREAM_PLUGIN %}
 INSTALLED_APPS += (

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -411,7 +411,14 @@ INSTALLED_APPS += (
 INSTALLED_APPS += (
     'debug_toolbar',
 )
-SHOW_TOOLBAR_CALLBACK = True
+
+#
+# Read more about this config option here:
+# http://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
+#
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": (lambda request: True),
+}
 MIDDLEWARE_CLASSES += (
     #For profile/debugging
     'debug_toolbar.middleware.DebugToolbarMiddleware',

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -63,6 +63,7 @@ DATABASE_HOST = localhost # remote.postgres-server.com
 DATABASE_PORT = 5432
 DATABASE_CONN_MAX_AGE = 60 # in seconds
 DJANGO_DEBUG =  True # Boolean required
+DJANGO_DEBUG_TOOLBAR =  False # Boolean required
 ENFORCING =  False # Boolean required #NOTE: DO NOT SET TO TRUE UNLESS YOU ARE PRODUCTION!
 SSLSERVER =  False # Boolean required
 ENABLE_PROJECT_SHARING =  True # Boolean required


### PR DESCRIPTION
## Description

Django-debug-toolbar can be useful for profiling your API calls.
This configuration will enable django-debug-toolbar for your requests.

## Checklist before merging Pull Requests
- [ ] Create a Clank PR that adds the new variable `DJANGO_DEBUG_TOOLBAR` to `atmosphere:local.py`
- [ ] Reviewed and approved by at least one other contributor.
