### PR TITLE
Problem: Can't use Jetstream when TAS API is unreachable

### DIFF
--- a/features/jetstream.features/login_tas_api_failover.feature
+++ b/features/jetstream.features/login_tas_api_failover.feature
@@ -1,0 +1,46 @@
+Feature: Should be able to use Jetstream, even when Atmosphere can't reach TAS API
+  As long as:
+  - They have logged in before
+  - They were valid the last time we were able to check with the TAS API
+  Note: New Jetstream users who have never logged into Atmosphere will be disabled until we can check the TAS API
+
+  Scenario Outline: Log in and check whether the user is valid or not
+    Given a dummy browser
+    And a TAS API driver
+    And a current time of '2017-02-15T05:00:00Z'
+    And we clear the local cache
+    And we set up the TAS API failover scenario example
+      | index   | user   | is_tas_up   | has_tas_account   | has_valid_allocation   | has_local_allocation   | user_is_valid   |
+      | <index> | <user> | <is_tas_up> | <has_tas_account> | <has_valid_allocation> | <has_local_allocation> | <user_is_valid> |
+
+    When we get all projects
+    And we fill user allocation sources from TAS
+
+    Given "<user>" as the persona
+    When I set "username" to "<user>"
+    And I set "password" to "some-very-long-string"
+
+    When I try to log in with valid XSEDE project required
+    Then the login attempt should succeed
+
+    When we ensure local allocation is created or deleted
+
+    Then the user should be valid - <user_is_valid>
+    Examples:
+      | index | user    | is_tas_up | has_tas_account | has_valid_allocation | has_local_allocation | user_is_valid |
+      | 0     | user300 | No        | No              | No                   | No                   | No            |
+      | 1     | user301 | No        | No              | No                   | Yes                  | Yes           |
+      | 2     | user302 | No        | No              | Yes                  | Yes                  | Yes           |
+      | 3     | user303 | No        | No              | Yes                  | No                   | No            |
+      | 4     | user304 | No        | Yes             | Yes                  | No                   | No            |
+      | 5     | user305 | No        | Yes             | Yes                  | Yes                  | Yes           |
+      | 6     | user306 | No        | Yes             | No                   | Yes                  | Yes           |
+      | 7     | user307 | No        | Yes             | No                   | No                   | No            |
+      | 8     | user308 | Yes       | Yes             | No                   | No                   | No            |
+      | 9     | user309 | Yes       | Yes             | No                   | Yes                  | No            |
+      | 10    | user310 | Yes       | Yes             | Yes                  | Yes                  | Yes           |
+      | 11    | user311 | Yes       | Yes             | Yes                  | No                   | Yes           |
+      | 12    | user312 | Yes       | No              | Yes                  | No                   | No            |
+      | 13    | user313 | Yes       | No              | Yes                  | Yes                  | No            |
+      | 14    | user314 | Yes       | No              | No                   | Yes                  | No            |
+      | 15    | user315 | Yes       | No              | No                   | No                   | No            |

--- a/jetstream/exceptions.py
+++ b/jetstream/exceptions.py
@@ -5,8 +5,22 @@ Jetstream exceptions
 
 class TASAPIException(Exception):
     """
-    This exception is raised when something has changed with TAS API
-    that results in the failure of a TASAllocationReport
+    This is a general exception when communicating with TAS API
+    """
+    pass
+
+
+class NoTaccUserForXsedeException(TASAPIException):
+    """
+    This exception is raised when TAS API can't find a TACC user account for an XSEDE username
+    """
+    pass
+
+
+class NoAccountForUsernameException(TASAPIException):
+    """
+    This exception is raised when we try to get projects or allocations for a TACC username which does not map to a
+    TACC account
     """
     pass
 

--- a/jetstream/tests/tas_api_mock_utils.py
+++ b/jetstream/tests/tas_api_mock_utils.py
@@ -1,7 +1,7 @@
 from jetstream import exceptions as jetstream_exceptions
 
 
-def _make_mock_tacc_api_post(context):
+def _make_mock_tacc_api_post(context, is_tas_up=True):
     def _mock_tacc_api_post(*args, **kwargs):
         raise NotImplementedError
 
@@ -33,7 +33,13 @@ def _get_user_projects(context, url):
     return data
 
 
-def _make_mock_tacc_api_get(context):
+def _make_mock_tacc_api_get(context, is_tas_up=True):
+    def _mock_tacc_api_get_down(*args, **kwargs):
+        raise jetstream_exceptions.TASAPIException('503 Service Unavailable')
+
+    if not is_tas_up:
+        return _mock_tacc_api_get_down
+
     def _mock_tacc_api_get(*args, **kwargs):
         url = args[0]
         assert isinstance(url, basestring)
@@ -50,3 +56,9 @@ def _make_mock_tacc_api_get(context):
         return None, data
 
     return _mock_tacc_api_get
+
+
+def reset_mock_tas_fixtures(context):
+    context.xsede_to_tacc_username_mapping = {}
+    context.tacc_username_to_tas_project_mapping = {}
+    context.tas_projects = []


### PR DESCRIPTION
Solution: Modified the `XsedeProjectRequired` validation plugin to have
a fallback strategy when the TAS API is unavailable.

The strategy is to check whether the user has existing allocation
sources in the database.

In order to achieve this I had to make a clear distinction between:

1. TAS API is unavailable or throwing bad errors
2. TAS API is available, and:
  a. There really is no TACC account for an XSEDE username
  b. We try to find allocations or projects for an invalid TACC account

We were conflating all of these before.

This means that existing Jetstream users can log in and use Atmosphere
as long as:

- They have logged in before
- They were valid the last time we were able to check with the TAS API

Note: New Jetstream users who have never logged into Atmosphere will be
disabled until we can check them against the TAS API at least once.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
