### PR TITLE
Revert 'Not resetting allocation sources'

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -193,11 +193,6 @@ ALLOCATIONS_CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=15),
         "options": {"expires": 15 * 60, "time_limit": 15 * 60}
     },
-    "renew_allocation_sources": {
-        "task": "renew_allocation_sources",
-        "schedule": crontab(0, 0, day_of_month='1'),
-        "options": {"expires": 15 * 60, "time_limit": 15 * 60}
-    },
 }
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
 {% endif %}

--- a/cyverse_allocation/tasks.py
+++ b/cyverse_allocation/tasks.py
@@ -98,7 +98,6 @@ def allocation_threshold_check():
 
 
 # Renew all allocation sources or a specific renewal strategy without waiting for rules engine
-@task(name="renew_allocation_sources")
 def renew_allocation_sources(renewal_strategy=False, current_time=False):
     current_time = timezone.now() if not current_time else current_time
 
@@ -112,6 +111,21 @@ def renew_allocation_sources(renewal_strategy=False, current_time=False):
 
 
 def renew_allocation_source_for(compute_allowed, allocation_source, current_time):
+    source_snapshot = AllocationSourceSnapshot.objects.filter(allocation_source=allocation_source)
+    if not source_snapshot:
+        raise Exception('Allocation Source %s cannot be renewed because no snapshot is available' % (
+            allocation_source.name))
+    source_snapshot = source_snapshot.last()
+
+    # carryover logic
+    # remaining_compute = 0 if source_snapshot.compute_allowed - source_snapshot.compute_used < 0 else source_snapshot.compute_allowed - source_snapshot.compute_used
+    # total_compute_allowed = float(remaining_compute + compute_allowed)
+
+    snapshot_compute_allowed = float(source_snapshot.compute_allowed)
+    total_compute_allowed = compute_allowed if snapshot_compute_allowed <= compute_allowed else snapshot_compute_allowed
+
+    # fire renewal event
+
     renewal_strategy = allocation_source.renewal_strategy
     allocation_source_name = allocation_source.name
     allocation_source_uuid = allocation_source.uuid
@@ -120,7 +134,7 @@ def renew_allocation_source_for(compute_allowed, allocation_source, current_time
         "uuid": str(allocation_source_uuid),
         "renewal_strategy": renewal_strategy,
         "allocation_source_name": allocation_source_name,
-        "compute_allowed": compute_allowed
+        "compute_allowed": total_compute_allowed
     }
 
     EventTable.objects.create(name='allocation_source_created_or_renewed',

--- a/features/allocation.features/alternate_story.feature
+++ b/features/allocation.features/alternate_story.feature
@@ -41,7 +41,7 @@ Feature: Testing an Alternate story
     And User instance runs for some days
     | username     | instance_id  | days  | status       |
     | amitj        |      1       |   1   | active       |
-    | julianp      |      2       |   1   | active       |
+    | julainp      |      2       |   1   | active       |
 
     ## NOTE: Currently, the rules engine is set to renew in every 3 days. After every renewal the compute used is reset and remaining compute is carried over
 
@@ -54,9 +54,8 @@ Feature: Testing an Alternate story
     | allocation_source_id | new_compute_allowed |
     |          1           |    400              |
 
-    # test that one off renewal task does reset EVERY allocation source to the original compute allowed value
-    # This is new behavior
+    # test that one off renewal task does not reset EVERY allocation source to the original compute allowed value
     And One off Renewal task is run without rules engine
     | current compute used | current compute allowed | allocation_source_id |
-    | 0                    | 168                     | 1                    |
+    | 0                    | 400                     | 1                    |
     | 0                    | 168                     | 2                    |


### PR DESCRIPTION
Reverting 4cb27801076b3fc8b04b6c492315e2cd8f25ec38 because it is not necessary.

```
Problem: Not resetting allocation sources

Solution: Re-use `cyverse_allocation.tasks.renew_allocation_sources`,
but simplified for a simple reset of the allocation source which does
not require the rules engine.

Next: Use the rules engine.
```

Turns out that `cyverse_allocation.tasks.update_snapshot_cyverse`
runs the rules engine which renews the allocation sources.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
