### PR TITLE
Problem: Renaming instance doesn't work

### DIFF
--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -264,6 +264,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
                                 status=status.HTTP_400_BAD_REQUEST)
             instance.change_allocation_source(user_source.allocation_source)
 
+        if data.has_key('name') and data['name']:
+            instance.name = data['name']
+            instance.save()
+
         serialized_instance = InstanceSerializer(
                 instance, context={'request': self.request})
 

--- a/features/instance.features/edit_instance.feature
+++ b/features/instance.features/edit_instance.feature
@@ -1,0 +1,200 @@
+Feature: Launching & editing of an instance
+
+  Background:
+    Given a dummy browser
+    And a current time of '2017-02-15T05:00:00Z' with tick = False
+    And "Admin" as the persona
+    When I set "username" to "admin"
+    And I set "password" to "very-clever-admin-password"
+    And we create a new admin user
+    And we create a provider "MockProvider"
+    And we create an identity for the current persona on provider "MockProvider"
+    And we make the current identity the admin on provider "MockProvider"
+
+
+  @skip-if-jetstream
+  Scenario: Launch instance and assign allocation source
+    Given "user407" as the persona
+    When I set "username" to "user407"
+    And I set "password" to "some-very-long-string"
+    And we create a new user
+    Given a current time of '2017-02-16T06:00:00Z' with tick = False
+    When I log in
+    And we create an account for the current persona on provider "MockProvider"
+    And we ensure that the user has an allocation source
+    Then I should have the following quota on provider "MockProvider"
+      | key               | value |
+      | cpu               | 16    |
+      | memory            | 128   |
+      | storage           | 10    |
+      | storage_count     | 10    |
+      | instance_count    | 10    |
+      | snapshot_count    | 10    |
+      | floating_ip_count | 10    |
+      | port_count        | 10    |
+    And we should have the following user allocation sources
+      | atmosphere_username | allocation_source |
+      | user407             | user407           |
+    When we update CyVerse snapshots
+    Then we should have the following allocation source snapshots
+      | name    | compute_used |
+      | user407 | 0            |
+    And we should have the following user allocation source snapshots
+      | atmosphere_username | allocation_source | compute_used | burn_rate |
+      | user407             | user407           | 0.000        | 0.000     |
+    When I get my allocation sources from the API I should see
+      | name    | compute_allowed | start_date               | end_date | compute_used | global_burn_rate | updated                  | renewal_strategy | user_compute_used | user_burn_rate | user_snapshot_updated    |
+      | user407 | 168             | 2017-02-16 06:00:00+0000 | None     | 0.000        | 0.000            | 2017-02-16 06:00:00+0000 | default          | 0.000             | 0.000          | 2017-02-16 06:00:00+0000 |
+    Given a current time of '2017-02-16T07:00:00Z' with tick = False
+    When we create a provider machine for current persona
+    And we create an active instance
+    And we get the details for the active instance via the API
+    Then the API response code is 200
+    And the API response contains
+    """
+    {
+      "usage": 0.0,
+      "start_date": "2017-02-16T07:00:00Z",
+      "status": "active",
+      "shell": false,
+      "vnc": false,
+      "end_date": null,
+      "scripts": [],
+      "ip_address": null,
+      "projects": [],
+      "name": "Instance in active",
+      "allocation_source": null,
+      "activity": ""
+    }
+    """
+    # Assign the allocation source to the instance
+    Given a current time of '2017-02-16T07:01:00Z' with tick = False
+    When I assign allocation source "user407" to active instance
+    Then the API response code is 201
+    When we get the details for the active instance via the API
+    Then the API response code is 200
+    And the API response contains
+    """
+    {
+      "usage": 0.0,
+      "start_date": "2017-02-16T07:00:00Z",
+      "status": "active",
+      "shell": false,
+      "vnc": false,
+      "end_date": null,
+      "scripts": [],
+      "ip_address": null,
+      "projects": [],
+      "name": "Instance in active",
+      "activity": ""
+    }
+    """
+    And I set "response_data" to attribute "data" of "response"
+    And I set "allocation_source" to key "allocation_source" of "response_data"
+    Then "allocation_source" contains
+    """
+    {
+      "name": "user407",
+      "renewal_strategy": "default",
+      "compute_allowed": 168,
+      "start_date": "2017-02-16T06:00:00Z"
+    }
+    """
+    And I set "instance01" to another variable "active_instance"
+    # Check usage immediately after launching instance
+    Given a current time of '2017-02-16T07:02:00Z' with tick = False
+    When we update CyVerse snapshots
+    Then we should have the following allocation source snapshots
+      | name    | compute_used |
+      | user407 | 0.020        |
+    And we should have the following user allocation source snapshots
+      | atmosphere_username | allocation_source | compute_used | burn_rate |
+      | user407             | user407           | 0.020        | 1.000     |
+    # TODO: Fix global_burn_rate
+    When I get my allocation sources from the API I should see
+      | name    | compute_allowed | start_date               | end_date | compute_used | global_burn_rate | updated                  | renewal_strategy | user_compute_used | user_burn_rate | user_snapshot_updated    |
+      | user407 | 168             | 2017-02-16 06:00:00+0000 | None     | 0.020        | 0.000            | 2017-02-16 07:02:00+0000 | default          | 0.020             | 1.000          | 2017-02-16 07:02:00+0000 |
+    # Check usage after an hour
+    Given a current time of '2017-02-16T08:00:00Z' with tick = False
+    When we update CyVerse snapshots
+    Then we should have the following allocation source snapshots
+      | name    | compute_used |
+      | user407 | 0.980        |
+    And we should have the following user allocation source snapshots
+      | atmosphere_username | allocation_source | compute_used | burn_rate |
+      | user407             | user407           | 0.980        | 1.000     |
+
+    # TODO: Fix global_burn_rate
+    When I get my allocation sources from the API I should see
+      | name    | compute_allowed | start_date               | end_date | compute_used | global_burn_rate | updated                  | renewal_strategy | user_compute_used | user_burn_rate | user_snapshot_updated    |
+      | user407 | 168             | 2017-02-16 06:00:00+0000 | None     | 0.980        | 0.000            | 2017-02-16 08:00:00+0000 | default          | 0.980             | 1.000          | 2017-02-16 08:00:00+0000 |
+
+
+  Scenario: Launch instance and edit name
+    Given "user408" as the persona
+    When I set "username" to "user408"
+    And I set "password" to "some-very-long-string"
+    And we create a new user
+    Given a current time of '2017-02-16T06:00:00Z' with tick = False
+    When I log in
+    And we create an account for the current persona on provider "MockProvider"
+    And we ensure that the user has an allocation source
+    Given a current time of '2017-02-16T07:00:00Z' with tick = False
+    When we create a provider machine for current persona
+    And we create an active instance
+    And we get the details for the active instance via the API
+    Then the API response code is 200
+    And the API response contains
+    """
+    {
+      "usage": 0.0,
+      "start_date": "2017-02-16T07:00:00Z",
+      "status": "active",
+      "shell": false,
+      "vnc": false,
+      "end_date": null,
+      "scripts": [],
+      "ip_address": null,
+      "projects": [],
+      "name": "Instance in active",
+      "allocation_source": null,
+      "activity": ""
+    }
+    """
+    When I change the name of the active instance to "My New Instance Name"
+    # TODO: Should really be 201...
+    Then the API response code is 200
+    And the API response contains
+    """
+    {
+      "usage": 0.0,
+      "start_date": "2017-02-16T07:00:00Z",
+      "status": "active",
+      "shell": false,
+      "vnc": false,
+      "end_date": null,
+      "scripts": [],
+      "ip_address": null,
+      "projects": [],
+      "name": "My New Instance Name",
+      "activity": ""
+    }
+    """
+    When we get the details for the active instance via the API
+    Then the API response code is 200
+    And the API response contains
+    """
+    {
+      "usage": 0.0,
+      "start_date": "2017-02-16T07:00:00Z",
+      "status": "active",
+      "shell": false,
+      "vnc": false,
+      "end_date": null,
+      "scripts": [],
+      "ip_address": null,
+      "projects": [],
+      "name": "My New Instance Name",
+      "activity": ""
+    }
+    """

--- a/features/jetstream.features/create_report_test_after_user_deleted.feature
+++ b/features/jetstream.features/create_report_test_after_user_deleted.feature
@@ -1,5 +1,6 @@
 Feature: Testing create_report task after user deleted from allocation source
 
+  @skip-if-cyverse
   Scenario Outline: testing create_reports task
 
     Given a test Allocation Source

--- a/features/jetstream.features/special_allocation.feature
+++ b/features/jetstream.features/special_allocation.feature
@@ -1,3 +1,4 @@
+@skip-if-cyverse
 Feature: Special Allocations
   Test special (_sub_) allocations
 


### PR DESCRIPTION
## Description

Anything other than changing allocation sources were explicitly omitted.
    
Solution: Added some logic in the `api/v2/views/instance.py` to handle 
renaming.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
