### PR TITLE
Enable sftp for all Guacamole connection protocols

### DIFF
--- a/api/v2/views/web_token.py
+++ b/api/v2/views/web_token.py
@@ -114,6 +114,9 @@ class WebTokenView(RetrieveAPIView):
                           + '&guac.sftp-directory=/home/' + atmo_username
                           + '&guac.enable-sftp=true')
 
+        if protocol == "ssh":
+            request_string += "guac.color-scheme=white-black"
+
         # Send request to Guacamole backend and record the result
         response = requests.post(guac_server + '/api/tokens', data=request_string)
         logger.info("Response status from server: %s" % (response.status_code))

--- a/api/v2/views/web_token.py
+++ b/api/v2/views/web_token.py
@@ -109,13 +109,10 @@ class WebTokenView(RetrieveAPIView):
                           + '&guac.protocol=' + protocol
                           + '&signature=' + signature
                           + '&guac.hostname=' + ip_address
-                          + '&id=' + conn_id)
-
-        # SFTP is only enabled for SSH because when using SSH, the user enters their password,
-        # while for a VNC connection, the user doesn't. On VNC connections this causes a connection
-        # error because Guacamole cannot login to SFTP.
-        if protocol == 'ssh':
-            request_string += '&guac.enable-sftp=true'
+                          + '&id=' + conn_id
+                          + '&guac.sftp-username=' + atmo_username
+                          + '&guac.sftp-directory=/home/' + atmo_username
+                          + '&guac.enable-sftp=true')
 
         # Send request to Guacamole backend and record the result
         response = requests.post(guac_server + '/api/tokens', data=request_string)


### PR DESCRIPTION
## Description

This PR adds parameters for SFTP connections. I modified [guacamole-auth-hmac](https://github.com/calvinmclean/guacamole-auth-hmac) to use public/private keys for SSH. This also allows us to use the keys in VNC connections to enable drag/drop SFTP! These changes will rely on changes to atmosphere-ansible and atmosphere secret repos. The changes to atmosphere-ansible will use the `gateone-gen-sshkey` role to create SSH keys on Guacamole server as well since the Guacamole server looks for keys locally so they are not sent in web requests.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
- [x] Reviewed and approved by at least one other contributor.
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
~~- [ ] New variables supported in Clank~~
- [x] New variables committed to secrets repos
