### PR TITLE
[ATMO-1916] Track redeploy and reboot in InstanceStatusHistory

### DIFF
--- a/api/tests/factories/__init__.py
+++ b/api/tests/factories/__init__.py
@@ -8,7 +8,7 @@ from .identity_factory import IdentityFactory
 from .identity_membership_factory import IdentityMembershipFactory
 from .image_factory import ImageFactory
 from .instance_factory import InstanceFactory
-from .instance_history_factory import InstanceHistoryFactory, InstanceStatusFactory, InstanceSizeFactory
+from .instance_history_factory import InstanceHistoryFactory, InstanceStatusFactory
 from .version_factory import ApplicationVersionFactory
 from .quota_factory import QuotaFactory
 from .allocation_factory import AllocationFactory

--- a/api/tests/factories/instance_history_factory.py
+++ b/api/tests/factories/instance_history_factory.py
@@ -1,17 +1,13 @@
 import factory
 
 import core.models
-from core.models.instance_history import InstanceStatusHistory, InstanceStatus
+from core.models.instance_history import InstanceStatusHistory
+from .size_factory import SizeFactory
 
 
 class InstanceStatusFactory(factory.DjangoModelFactory):
     class Meta:
-        model = InstanceStatus
-
-
-class InstanceSizeFactory(factory.DjangoModelFactory):
-    class Meta:
-        model = core.models.Size
+        model = core.models.InstanceStatus
 
 
 class InstanceHistoryFactory(factory.DjangoModelFactory):
@@ -19,3 +15,4 @@ class InstanceHistoryFactory(factory.DjangoModelFactory):
         model = InstanceStatusHistory
 
     status = factory.SubFactory(InstanceStatusFactory)
+    size = factory.SubFactory(SizeFactory)

--- a/api/tests/factories/provider_factory.py
+++ b/api/tests/factories/provider_factory.py
@@ -1,5 +1,7 @@
 import factory
+
 from core.models import Provider
+
 from .provider_type_factory import ProviderTypeFactory
 from .platform_type_factory import PlatformTypeFactory
 

--- a/api/tests/factories/size_factory.py
+++ b/api/tests/factories/size_factory.py
@@ -1,5 +1,8 @@
 import factory
+
 from core.models import Size
+
+from .provider_factory import ProviderFactory
 
 
 class SizeFactory(factory.DjangoModelFactory):
@@ -9,3 +12,8 @@ class SizeFactory(factory.DjangoModelFactory):
 
     alias = factory.Sequence(lambda n: 'size_alias%d' % n)
     name = factory.Sequence(lambda n: 'size%d' % n)
+    cpu = 1
+    disk= 0
+    root= 0
+    mem= 1
+    provider = factory.SubFactory(ProviderFactory)

--- a/api/tests/v2/test_instance_actions.py
+++ b/api/tests/v2/test_instance_actions.py
@@ -33,10 +33,12 @@ class InstanceActionTests(APITestCase):
             created_by=self.user,
             created_by_identity=self.user_identity,
             start_date=start_date)
+        self.size_small = SizeFactory.create(provider=self.provider, cpu=2, disk=20, root=0, mem=128)
         self.status_active = InstanceStatusFactory.create(name='active')
         delta_time = timezone.timedelta(minutes=2)
         InstanceHistoryFactory.create(
                 status=self.status_active,
+                size=self.size_small,
                 activity="",
                 instance=self.active_instance,
                 start_date=start_date + delta_time*3)
@@ -55,17 +57,15 @@ class InstanceActionTests(APITestCase):
             created_by=self.user,
             created_by_identity=self.user_identity,
             start_date=start_date_second)
-        self.status_active_second = InstanceStatusFactory.create(name='active')
         delta_time = timezone.timedelta(minutes=2)
         self.size_small = SizeFactory.create(provider=self.provider, cpu=2, disk=20, root=0, mem=128)
         self.size_large = SizeFactory.create(provider=self.provider, cpu=4, disk=40, root=0, mem=256)
         InstanceHistoryFactory.create(
-                status=self.status_active_second,
+                status=self.status_active,
                 size=self.size_small,
                 activity="",
                 instance=self.active_instance_second,
                 start_date=start_date_second + delta_time*3)
-        self.mock_driver_second = get_esh_driver(self.user_identity)
         self.mock_driver.add_core_instance(self.active_instance_second)
 
     # For resize, I will add a size in InstanceStatusHistory. for stop, we don't have to have
@@ -81,7 +81,8 @@ class InstanceActionTests(APITestCase):
         force_authenticate(request, user=self.user)
         response = self.view(request, str(self.active_instance.provider_alias))
         data = response.data.get('result')
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, 200,
+            "Expected a 200, received %s: %s" % (response.status_code, response.data) )
         self.assertEquals('success', data)
 
     def test_start_instance_action(self):
@@ -133,7 +134,8 @@ class InstanceActionTests(APITestCase):
         request = factory.post(self.url, data)
         force_authenticate(request, user=self.user)
         response = self.view(request, str(self.active_instance.provider_alias))
-        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.status_code, 200,
+            "Expected a 200, received %s: %s" % (response.status_code, response.data) )
         data = response.data.get('result')
         self.assertEquals('success', data)
 '''

--- a/api/tests/v2/test_instances.py
+++ b/api/tests/v2/test_instances.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 
 from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
 from api.tests.factories import (
-    GroupFactory, UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory,
+    GroupFactory, UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory, SizeFactory,
     ImageFactory, ApplicationVersionFactory, InstanceSourceFactory, ProviderMachineFactory, IdentityFactory, ProviderFactory,
     IdentityMembershipFactory, QuotaFactory)
 from api.v2.views import InstanceViewSet
@@ -62,6 +62,7 @@ class InstanceTests(APITestCase):
         networking = InstanceStatusFactory.create(name='networking')
         deploying = InstanceStatusFactory.create(name='deploying')
         deploy_error = InstanceStatusFactory.create(name='deploy_error')
+
         InstanceHistoryFactory.create(
                 status=deploy_error,
                 activity="",

--- a/core/admin.py
+++ b/core/admin.py
@@ -550,13 +550,11 @@ class MachineRequestAdmin(admin.ModelAdmin):
 @admin.register(models.InstanceStatusHistory)
 class InstanceStatusHistoryAdmin(admin.ModelAdmin):
     search_fields = ["instance__created_by__username",
-                     "instance__source__identifier",
-                     "instance__provider_alias", "status__name"]
-    list_display = ["instance_alias", "machine_alias", "instance_owner", "instance_ip_address", "status", "start_date",
-                    "end_date"]
+                     "instance__provider_alias"]
+    list_display = ["status", "start_date",
+                    "end_date", "instance_alias", "instance_owner"]
     list_filter = ["instance__source__provider__location",
-                   "status__name",
-                   "instance__created_by__username"]
+                   "status__name"]
     ordering = ('-start_date',)
 
     def instance_owner(self, model):

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -32,6 +32,7 @@ from core.models.size import (
 from core.models.tag import Tag
 from core.models.managers import ActiveInstancesManager
 from atmosphere import settings
+from service.mock import MockInstance
 
 class Instance(models.Model):
     """
@@ -427,7 +428,7 @@ class Instance(models.Model):
         return status_name
 
     def esh_status(self):
-        if self.esh:
+        if self.esh and type(self.esh) != MockInstance:
             return self.esh.get_status()
         last_history = self.get_last_history()
         if last_history:
@@ -595,6 +596,7 @@ OPENSTACK_TASK_STATUS_MAP = {
     'spawning': 'build',
     # Atmosphere Task-specific lines
     'networking': 'networking',
+    'redeploying': 'redeploy',
     'deploying': 'deploying',
     'running_boot_script': 'deploying',
     'deploy_error': 'deploy_error',

--- a/features/jetstream.features/enforcing.feature
+++ b/features/jetstream.features/enforcing.feature
@@ -62,7 +62,7 @@ Feature: Enforcing allocation usage on Jetstream
       | entity_id | name | payload | timestamp |
 
 
-  @wip
+  @skip-if-cyverse
   Scenario: Test basic enforcing
     Given "Admin" as the persona
     When I set "username" to "admin"

--- a/features/steps/api_with_persona_steps.py
+++ b/features/steps/api_with_persona_steps.py
@@ -302,7 +302,7 @@ def create_active_instance(context):
                                                                  start_date=django.utils.timezone.now())
 
     active_status = api.tests.factories.InstanceStatusFactory.create(name='active')
-    single_cpu_size = api.tests.factories.InstanceSizeFactory.create(
+    single_cpu_size = api.tests.factories.SizeFactory.create(
         name='single_cpu_size',
         provider=provider,
         cpu=1,

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -23,7 +23,7 @@ from django_cyverse_auth.protocol import ldap
 
 from core.core_logging import create_instance_logger
 from core.models.ssh_key import get_user_ssh_keys
-from core.models import Provider, Identity, Instance, SSHKey
+from core.models import Provider, Identity, Instance, SSHKey, AtmosphereUser
 
 from service.exceptions import AnsibleDeployException
 
@@ -58,7 +58,7 @@ def ansible_deployment(
         extra_vars.update({
             "TIMEZONE": time_zone,
         })
-    shared_users = User.users_for_instance(instance_id).values_list('username', flat=True)
+    shared_users = AtmosphereUser.users_for_instance(instance_id).values_list('username', flat=True)
     if not shared_users:
         shared_users = [username]
     if username not in shared_users:

--- a/service/instance.py
+++ b/service/instance.py
@@ -107,11 +107,17 @@ def reboot_instance(
         _permission_to_act(identity_uuid, "Reboot")
     else:
         _permission_to_act(identity_uuid, "Hard Reboot")
-    size = _get_size(esh_driver, esh_instance)
+    core_identity = CoreIdentity.objects.get(uuid=identity_uuid)
     esh_driver.reboot_instance(esh_instance, reboot_type=reboot_type)
+    update_status(
+        esh_driver,
+        esh_instance.id,
+        core_identity.provider.uuid,
+        core_identity.uuid,
+        user)
     # reboots take very little time..
     core_identity = CoreIdentity.objects.get(uuid=identity_uuid)
-    redeploy_init(esh_driver, esh_instance, core_identity)
+    redeploy_instance(esh_driver, esh_instance, core_identity, user=user, status_update=False)
 
 
 def resize_instance(esh_driver, esh_instance, size_alias,
@@ -396,41 +402,48 @@ def resize_and_redeploy(esh_driver, esh_instance, core_identity_uuid):
 
 
 def redeploy_instance(
-        core_identity,
         esh_driver,
         esh_instance,
-        username,
-        force_redeploy=False):
+        core_identity,
+        user=None,
+        status_update=True):
     """
-    EXPERIMENTAL.
-
-    Starts redeployment of an instance using the tmp_status metadata.
-
-    NOTE: Not used by API. See redeploy_init.
+    Starts redeployment of an instance using the tmp_status metadata,
+    including:
+    - networking (Floating IP assignment)
+    - deploying (Standard instance deployment)
+    - image-defined boot scripts
+    - user SSH keys
+    - user-defined boot scripts
     """
     from service.tasks.driver import get_idempotent_deploy_chain
-    if force_redeploy or esh_instance.extra.get('metadata').get(
-            'tmp_status',
-            None) == "":
-        esh_instance.extra['metadata']['tmp_status'] = "initializing"
-    deploy_chain = get_idempotent_deploy_chain(
-        esh_driver.__class__, esh_driver.provider, esh_driver.identity,
-        esh_instance, core_identity, username)
-    return deploy_chain.apply_async()
 
+    status = esh_instance.extra['status']
 
-def redeploy_init(esh_driver, esh_instance, core_identity):
-    """
-    Use this function to kick off the async task when you ONLY want to deploy
-    (No add fixed, No add floating)
-    """
-    from service.tasks.driver import deploy_init_to
+    # Future-TODO:
+    # if user:
+    #     ensure user has the ability to act on this instance.
+    if status not in ['active', 'redeploying', 'reboot', 'hard_reboot']:
+        raise Exception("Cannot redeploy to an instance in a non-active state. (Current state: %s)" % status)
+
+    # Force a specific history update
+    if status_update:
+        esh_instance.extra['task'] = None
+        esh_instance.extra['metadata']['tmp_status'] = "redeploying"
+        # Convert & Update status to redeploying
+        convert_esh_instance(esh_driver,
+                             esh_instance,
+                             str(core_identity.provider.uuid),
+                             str(core_identity.uuid),
+                             core_identity.created_by)
+
     if type(esh_driver) == AtmosphereMockDriver:
         return
-    logger.info("Add floating IP and Deploy")
-    deploy_init_to.s(esh_driver.__class__, esh_driver.provider,
-                     esh_driver.identity, esh_instance.id,
-                     core_identity, redeploy=True).apply_async()
+    # Start deployment chain based on the instance above
+    deploy_chain = get_idempotent_deploy_chain(
+        esh_driver.__class__, esh_driver.provider, esh_driver.identity,
+        esh_instance, core_identity, core_identity.created_by.username)
+    return deploy_chain.apply_async()
 
 
 def restore_ip_chain(esh_driver, esh_instance, redeploy=False,
@@ -787,19 +800,6 @@ def update_status(esh_driver, instance_id, provider_uuid, identity_uuid, user):
                                          provider_uuid,
                                          identity_uuid,
                                          user)
-
-
-def get_core_instances(identity_uuid):
-    identity = CoreIdentity.objects.get(uuid=identity_uuid)
-    driver = get_cached_driver(identity=identity)
-    instances = driver.list_instances()
-    core_instances = [convert_esh_instance(driver,
-                                           esh_instance,
-                                           identity.provider.uuid,
-                                           identity.uuid,
-                                           identity.created_by)
-                      for esh_instance in instances]
-    return core_instances
 
 
 def _pre_launch_validation(
@@ -2018,7 +2018,7 @@ def run_instance_action(user, identity, instance_id, action_type, action_params)
     elif 'revert_resize' == action_type:
         result_obj = esh_driver.revert_resize_instance(esh_instance)
     elif 'redeploy' == action_type:
-        result_obj = redeploy_init(esh_driver, esh_instance, identity)
+        result_obj = redeploy_instance(esh_driver, esh_instance, identity, user=user)
     elif 'resume' == action_type:
         result_obj = resume_instance(esh_driver, esh_instance,
                                      provider_uuid, identity_uuid,

--- a/service/mock.py
+++ b/service/mock.py
@@ -6,6 +6,7 @@ import uuid
 from threepio import logger
 
 from rtwo.models.instance import Instance
+from rtwo.models.size import MockSize
 from rtwo.driver import MockDriver
 from rtwo.drivers.openstack_network import NetworkManager
 from rtwo.drivers.common import _connect_to_keystone_v3, _token_to_keystone_scoped_project
@@ -193,15 +194,18 @@ class AtmosphereMockNetworkManager(NetworkManager):
 
 
 class MockInstance(Instance):
-    def __init__(self, id=None, provider=None, source=None, ip=None, extra={}, *args, **kwargs):
+    def __init__(self, id=None, provider=None, source=None, ip=None, size=None, extra={}, *args, **kwargs):
         identifier = id
         if not identifier:
             identifier = kwargs.get('uuid', uuid.uuid4())
+        if not size:
+            size = MockSize("Unknown", provider)
         if not ip:
             ip = '0.0.0.0'
         self.id = identifier
         self.alias = identifier
         self.provider = provider
+        self.size = size
         self.name = kwargs.get('name', "Mock instance %s" % identifier)
         self.source = source
         self.ip = ip
@@ -227,6 +231,11 @@ class AtmosphereMockDriver(MockDriver):
         """
         return True
 
+    def _get_size(self, alias):
+        size = MockSize("Unknown", self.providerCls() )
+        return size
+
+
     def list_all_volumes(self, *args, **kwargs):
         """
         Return the InstanceClass representation of a libcloud node
@@ -251,12 +260,14 @@ class AtmosphereMockDriver(MockDriver):
 
     def add_core_instance(self, core_instance):
         extra = {}
-        extra['metadata'] = {'iplant_suspend_fix': False}
-        return self.create_instance(
+        extra['metadata'] = {'iplant_suspend_fix': False, 'tmp_status': ''}
+        extra['status'] = core_instance.get_last_history().status.name
+        esh_instance = self.create_instance(
             id=str(core_instance.provider_alias),
             ip=core_instance.ip_address,
             name=core_instance.name,
             extra=extra)
+        return esh_instance
 
     def list_instances(self, **kwargs):
         """

--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -567,7 +567,7 @@ def get_idempotent_deploy_chain(
             core_identity,
             username=username,
             redeploy=False)
-    elif tmp_status in ['deploying', 'deploy_error']:
+    elif tmp_status in ['', 'redeploying', 'deploying', 'deploy_error']:
         celery_logger.info(
             "Instance %s contains the 'deploying' metadata - Redeploy will include deploy ONLY!." %
             instance.id)
@@ -581,7 +581,7 @@ def get_idempotent_deploy_chain(
             redeploy=False)
     else:
         raise Exception(
-            "Instance has a tmp_status that is NOT: [initializing, networking, deploying] - %s" %
+            "Instance has a tmp_status that is NOT: [initializing, networking, deploying, redeploying] - %s" %
             tmp_status)
     return start_task
 


### PR DESCRIPTION
## Problem
Instance does not keep track of user-initiated redeploy, reboot, and hard reboot via instance actions.

## Solution
Ensure that a new `Instance Status History` entry is created for each of the three previously mentioned states. 

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
