### PR TITLE
Sanity test cases for the v2 API

### DIFF
--- a/api/tests/factories/provider_machine_factory.py
+++ b/api/tests/factories/provider_machine_factory.py
@@ -1,4 +1,5 @@
 import factory
+import uuid
 from core.models import ProviderMachine, InstanceSource
 from .version_factory import ApplicationVersionFactory
 from .image_factory import ImageFactory
@@ -7,14 +8,18 @@ from .image_factory import ImageFactory
 class ProviderMachineFactory(factory.DjangoModelFactory):
 
     @staticmethod
-    def create_provider_machine(user, identity):
-        application = ImageFactory.create(
-            created_by_identity=identity,
-            created_by=user)
-        version = ApplicationVersionFactory.create(
-            application=application,
-            created_by_identity=identity,
-            created_by=user)
+    def create_provider_machine(user, identity, application=None, version=None):
+        if version and not application:
+            application = version.application
+        if not application:
+            application = ImageFactory.create(
+                created_by_identity=identity,
+                created_by=user)
+        if not version:
+            version = ApplicationVersionFactory.create(
+                application=application,
+                created_by_identity=identity,
+                created_by=user)
         source = InstanceSourceFactory.create(
             provider=identity.provider,
             created_by_identity=identity,
@@ -33,4 +38,4 @@ class InstanceSourceFactory(factory.DjangoModelFactory):
     class Meta:
         model = InstanceSource
 
-
+    identifier = factory.Sequence(lambda n: uuid.uuid4())

--- a/api/tests/factories/tag_factory.py
+++ b/api/tests/factories/tag_factory.py
@@ -7,5 +7,5 @@ class TagFactory(factory.DjangoModelFactory):
     class Meta:
         model = Tag
 
-    name = 'tag-name'
+    name = factory.Sequence(lambda n: 'tag-name-%d' % n)
     description = 'Tag description'

--- a/api/tests/factories/version_factory.py
+++ b/api/tests/factories/version_factory.py
@@ -5,6 +5,18 @@ from .image_factory import ImageFactory
 
 class ApplicationVersionFactory(factory.DjangoModelFactory):
 
+    @staticmethod
+    def create_version(user, identity, application=None):
+        if not application:
+            application = ImageFactory.create(
+                created_by_identity=identity,
+                created_by=user)
+        version = ApplicationVersionFactory.create(
+            application=application,
+            created_by_identity=identity,
+            created_by=user)
+        return version
+
     class Meta:
         model = ApplicationVersion
 

--- a/api/tests/v2/base.py
+++ b/api/tests/v2/base.py
@@ -1,0 +1,70 @@
+from django.core.urlresolvers import reverse
+
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+
+
+class APISanityTestCase(object):
+    url_route = None
+    user = None
+
+    def test_list_response_is_paginated(self):
+        """
+        Sanity test -- this should 'just work'
+        """
+        factory = APIRequestFactory()
+        url_route = self.url_route + "-list"
+        list_url = reverse(url_route)
+        self.list_request = factory.get(list_url)
+        force_authenticate(self.list_request, user=self.user)
+        list_response = self.list_view(self.list_request)
+        self.assertIn(
+            'count', list_response.data,
+            "Expected list response to be paginated, received: %s"
+            % list_response.data)
+        self.assertIn(
+            'results', list_response.data,
+            "Expected list response to be paginated, received: %s"
+            % list_response.data)
+
+    def test_detail_endpoints_invalid_data(self):
+        """
+        This preliminary set of tests will ensure that
+        a v2 endpoint will not fail due to invalid inputs
+        """
+        url_route = self.url_route + "-detail"
+        self.assertTrue(
+            url_route,
+            "APISanityTestCase expects a `url_route` to be defined")
+        self.assertTrue(
+            self.user,
+            "APISanityTestCase expects a `self.user` to be defined")
+
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        null_url = reverse(url_route, args=("null",))
+        response = client.get(null_url)
+        self.assertEquals(response.status_code, 404)
+
+        url = null_url.replace("null", "1.234")
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)
+
+        url = null_url.replace("null", "1.2.3.4")
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)
+
+        url = reverse(url_route, args=("1234",))
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)
+
+        url = reverse(url_route, args=("1-2-3-4",))
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)
+
+        url = reverse(url_route, args=("beefbeefbeef",))
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)
+
+        url = reverse(url_route, args=("deadbeef-dead-dead-dead-beefbeefbeef",))
+        response = client.get(url)
+        self.assertEquals(response.status_code, 404)

--- a/api/tests/v2/test_allocation_sources.py
+++ b/api/tests/v2/test_allocation_sources.py
@@ -8,14 +8,18 @@ from api.tests.factories import (
     UserFactory, AnonymousUserFactory, IdentityFactory, ProviderFactory, AllocationSourceFactory,
     UserAllocationSourceFactory
 )
+from .base import APISanityTestCase
 from api.v2.views import AllocationSourceViewSet as ViewSet
 
 
-class AllocationSourceTests(APITestCase):
+class AllocationSourceTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:allocationsource'
+
     def setUp(self):
         self.anonymous_user = AnonymousUserFactory()
         self.user_without_sources = UserFactory.create(username='test-username')
         self.user_with_sources = UserFactory.create(username='test-username-with-sources')
+        self.user = self.user_with_sources
         self.provider = ProviderFactory.create()
         self.user_identity = IdentityFactory.create_identity(
             created_by=self.user_without_sources,

--- a/api/tests/v2/test_allocation_sources.py
+++ b/api/tests/v2/test_allocation_sources.py
@@ -16,6 +16,9 @@ class AllocationSourceTests(APITestCase, APISanityTestCase):
     url_route = 'api:v2:allocationsource'
 
     def setUp(self):
+        self.list_view = ViewSet.as_view({'get': 'list'})
+        self.detailed_view = ViewSet.as_view({'get': 'retrieve'})
+
         self.anonymous_user = AnonymousUserFactory()
         self.user_without_sources = UserFactory.create(username='test-username')
         self.user_with_sources = UserFactory.create(username='test-username-with-sources')

--- a/api/tests/v2/test_identities.py
+++ b/api/tests/v2/test_identities.py
@@ -1,80 +1,21 @@
 from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
 from api.v2.views import IdentityViewSet as ViewSet
+from .base import APISanityTestCase
 from api.tests.factories import UserFactory, AnonymousUserFactory,\
     IdentityFactory, ProviderFactory, GroupFactory,\
     IdentityMembershipFactory, QuotaFactory, AllocationFactory
 from django.core.urlresolvers import reverse
-from core.models import Identity
+
 
 EXPECTED_FIELD_COUNT = 12
 
-class GetListTests(APITestCase):
+
+class IdentityTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:identity'
 
     def setUp(self):
-        self.view = ViewSet.as_view({'get': 'list'})
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.staff_user = UserFactory.create(is_staff=True)
-
-        self.provider = ProviderFactory.create()
-        self.quota = QuotaFactory.create()
-        self.identity = IdentityFactory.create(
-            provider=self.provider,
-	    quota=self.quota,
-            created_by=self.user)
-        self.allocation = AllocationFactory.create()
-        IdentityMembershipFactory.create(
-            member=self.group,
-            identity=self.identity
-        )
-
-        factory = APIRequestFactory()
-        url = reverse('api:v2:identity-list')
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request)
-
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
-        self.assertEquals(response.status_code, 403)
-
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
-        self.assertEquals(response.status_code, 200)
-
-    def test_response_is_paginated(self):
-        response = self.response
-        self.assertIn('count', response.data)
-        self.assertIn('results', response.data)
-
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
-        data = response.data.get('results')
-        self.assertTrue(data, "Response contained no results")
-        identity_data = data[0]
-
-        self.assertEquals(len(identity_data), EXPECTED_FIELD_COUNT, "The number of arguments has changed for GET /identity (%s!=%s)" % (len(identity_data), EXPECTED_FIELD_COUNT))
-        self.assertIn('id', identity_data)
-        self.assertIn('uuid', identity_data)
-        self.assertIn('url', identity_data)
-        self.assertIn('quota', identity_data)
-        self.assertIn('allocation', identity_data)
-        self.assertIn('provider', identity_data)
-        self.assertIn('user', identity_data)
-        self.assertIn('key', identity_data)
-        self.assertIn('credentials', identity_data)
-        self.assertIn('is_leader', identity_data)
-        self.assertIn('members', identity_data)
-
-
-class GetDetailTests(APITestCase):
-
-    def setUp(self):
-        self.view = ViewSet.as_view({'get': 'retrieve'})
+        self.list_view = ViewSet.as_view({'get': 'list'})
+        self.detailed_view = ViewSet.as_view({'get': 'retrieve'})
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create()
         self.group = GroupFactory.create(name=self.user.username)
@@ -93,29 +34,64 @@ class GetDetailTests(APITestCase):
         )
 
         factory = APIRequestFactory()
-        url = reverse('api:v2:identity-detail', args=(self.identity.id,))
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request, pk=self.identity.id)
+        detail_url = reverse('api:v2:identity-detail', args=(self.identity.id,))
+        self.detail_request = factory.get(detail_url)
+
+        list_url = reverse('api:v2:identity-list')
+        self.list_request = factory.get(list_url)
 
     def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.identity.id)
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 403)
 
     def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.identity.id)
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.identity.id)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
+        data = response.data.get('results')
+        self.assertTrue(data, "Response contained no results")
+        identity_data = data[0]
+
+        self.assertEquals(
+            len(identity_data), EXPECTED_FIELD_COUNT,
+            "The number of arguments has changed for GET /identity (%s!=%s)"
+            % (len(identity_data), EXPECTED_FIELD_COUNT))
+        self.assertIn('id', identity_data)
+        self.assertIn('uuid', identity_data)
+        self.assertIn('url', identity_data)
+        self.assertIn('quota', identity_data)
+        self.assertIn('allocation', identity_data)
+        self.assertIn('provider', identity_data)
+        self.assertIn('user', identity_data)
+        self.assertIn('key', identity_data)
+        self.assertIn('credentials', identity_data)
+        self.assertIn('is_leader', identity_data)
+        self.assertIn('members', identity_data)
+
+    def test_detail_is_not_public(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detailed_view(self.detail_request, pk=self.identity.id)
+        self.assertEquals(response.status_code, 403)
+
+    def test_detail_is_visible_to_authenticated_user(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detailed_view(self.detail_request, pk=self.identity.id)
+        self.assertEquals(response.status_code, 200)
+
+    def test_detail_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detailed_view(self.detail_request, pk=self.identity.id)
         data = response.data
 
         self.assertEquals(
             len(data), EXPECTED_FIELD_COUNT,
-            "The number of arguments has changed for GET /identity/%s (%s!=%s)" % (self.identity.id, len(data), EXPECTED_FIELD_COUNT)
+            "The number of arguments has changed for GET /identity/%s (%s!=%s)"
+            % (self.identity.id, len(data), EXPECTED_FIELD_COUNT)
         )
         self.assertIn('id', data)
         self.assertIn('uuid', data)
@@ -129,20 +105,11 @@ class GetDetailTests(APITestCase):
         self.assertIn('is_leader', data)
         self.assertIn('members', data)
 
-
-class CreateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_create_does_not_exist(self):
         self.assertTrue('post' not in ViewSet.http_method_names)
 
-
-class UpdateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_update_does_not_exist(self):
         self.assertTrue('put' not in ViewSet.http_method_names)
 
-
-class DeleteTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_delete_does_not_exist(self):
         self.assertTrue('delete' not in ViewSet.http_method_names)

--- a/api/tests/v2/test_image_metrics.py
+++ b/api/tests/v2/test_image_metrics.py
@@ -11,11 +11,14 @@ from api.tests.factories import (
     UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory,
     ProviderMachineFactory, IdentityFactory, ProviderFactory
 )
+from .base import APISanityTestCase
 
 from core.metrics.application import get_application_metrics
 
 
-class InstanceTests(APITestCase):
+class ImageMetricsTest(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:applicationmetric'
+
     def setUp(self):
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create(username='test-username')
@@ -157,13 +160,13 @@ class InstanceTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        list_url = reverse('api:v2:applicationmetric-list')
+        list_url = reverse(self.url_route+'-list')
         list_response = client.get(list_url)
         self.assertEquals(list_response.status_code, 200)
         list_data = list_response.data['results']
         self.assertEquals(list_data, [])
 
-        url = reverse('api:v2:applicationmetric-detail', args=(self.application.uuid,))
+        url = reverse(self.url_route+'-detail', args=(self.application.uuid,))
         response = client.get(url)
         self.assertEquals(response.status_code, 404)
 
@@ -173,7 +176,7 @@ class InstanceTests(APITestCase):
         client.force_authenticate(user=self.staff_user)
         expected_metrics = {'active': 1, 'total': 4}
 
-        url = reverse('api:v2:applicationmetric-detail', args=(self.application.uuid,))
+        url = reverse(self.url_route+'-detail', args=(self.application.uuid,))
         response = client.get(url)
         self.assertEquals(response.status_code, 200)
         data = response.data

--- a/api/tests/v2/test_image_metrics.py
+++ b/api/tests/v2/test_image_metrics.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from rest_framework.test import APITestCase
+from api.v2.views import ImageMetricViewSet as ViewSet
 from api.tests.factories import (
     UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory,
     ProviderMachineFactory, IdentityFactory, ProviderFactory
@@ -20,6 +21,9 @@ class ImageMetricsTest(APITestCase, APISanityTestCase):
     url_route = 'api:v2:applicationmetric'
 
     def setUp(self):
+        self.list_view = ViewSet.as_view({'get': 'list'})
+        self.detailed_view = ViewSet.as_view({'get': 'retrieve'})
+
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create(username='test-username')
         self.staff_user = UserFactory.create(username='test-staffuser', is_staff=True, is_superuser=True)

--- a/api/tests/v2/test_images.py
+++ b/api/tests/v2/test_images.py
@@ -1,117 +1,145 @@
 from rest_framework.test import APITestCase, APIRequestFactory,\
     force_authenticate
 from api.v2.views import ImageViewSet as ViewSet
-from api.tests.factories import UserFactory, AnonymousUserFactory, ImageFactory
+from .base import APISanityTestCase
+from api.tests.factories import (
+    AnonymousUserFactory,
+    ApplicationVersionFactory,
+    ProviderFactory,
+    IdentityFactory,
+    ImageFactory,
+    ProviderMachineFactory,
+    UserFactory
+)
 from django.core.urlresolvers import reverse
 
-from unittest import skip
-
-# class GetListTests(APITestCase):
-# 
-#     def setUp(self):
-#         self.view = ViewSet.as_view({'get': 'list'})
-#         self.anonymous_user = AnonymousUserFactory()
-#         self.user = UserFactory.create()
-#         self.staff_user = UserFactory.create(is_staff=True)
-# 
-#         self.image = ImageFactory.create(created_by=self.user)
-# 
-#         factory = APIRequestFactory()
-#         url = reverse('api:v2:application-list')
-#         self.request = factory.get(url)
-#         force_authenticate(self.request, user=self.user)
-#         self.response = self.view(self.request)
-# 
-#     def test_is_public(self):
-#         force_authenticate(self.request, user=self.anonymous_user)
-#         response = self.view(self.request)
-#         self.assertEquals(response.status_code, 200)
-# 
-#     def test_is_visible_to_authenticated_user(self):
-#         force_authenticate(self.request, user=self.user)
-#         response = self.view(self.request)
-#         self.assertEquals(response.status_code, 200)
-# 
-#     def test_response_is_paginated(self):
-#         response = self.response
-#         self.assertIn('count', response.data)
-#         self.assertIn('results', response.data)
-# 
-#     def test_response_contains_expected_fields(self):
-#         force_authenticate(self.request, user=self.user)
-#         response = self.view(self.request)
-#         data = response.data.get('results')[0]
-# 
-#         self.assertEquals(len(data), 12, "Unexepcted # of arguments in API endpoint")
-#         self.assertIn('id', data)
-#         self.assertIn('url', data)
-#         self.assertIn('uuid', data)
-#         self.assertIn('name', data)
-#         self.assertIn('description', data)
-#         self.assertIn('is_public', data)
-#         self.assertIn('icon', data)
-#         self.assertIn('tags', data)
-#         self.assertIn('created_by', data)
-#         self.assertIn('start_date', data)
-#         self.assertIn('end_date', data)
-# 
-# 
-# class GetDetailTests(APITestCase):
-# 
-#     def setUp(self):
-#         self.view = ViewSet.as_view({'get': 'retrieve'})
-#         self.anonymous_user = AnonymousUserFactory()
-#         self.user = UserFactory.create()
-# 
-#         self.image = ImageFactory.create(created_by=self.user)
-# 
-#         factory = APIRequestFactory()
-#         url = reverse('api:v2:application-detail', args=(self.user.id,))
-#         self.request = factory.get(url)
-# 
-#     @skip("Broken as of 30b3e784a0fdf82db51c0f0a08dd3b8c3a8d4aec")
-#     def test_is_public(self):
-#         force_authenticate(self.request, user=self.anonymous_user)
-#         response = self.view(self.request, pk=self.image.id)
-#         self.assertEquals(response.status_code, 200)
-# 
-#     def test_is_visible_to_authenticated_user(self):
-#         force_authenticate(self.request, user=self.user)
-#         response = self.view(self.request, pk=self.image.id)
-#         self.assertEquals(response.status_code, 200)
-# 
-#     def test_response_contains_expected_fields(self):
-#         force_authenticate(self.request, user=self.user)
-#         response = self.view(self.request, pk=self.image.id)
-#         data = response.data
-# 
-#         self.assertEquals(len(data), 12, "Unexepcted # of arguments in API endpoint")
-#         self.assertIn('id', data)
-#         self.assertIn('url', data)
-#         self.assertIn('uuid', data)
-#         self.assertIn('name', data)
-#         self.assertIn('description', data)
-#         self.assertIn('is_public', data)
-#         self.assertIn('icon', data)
-#         self.assertIn('tags', data)
-#         self.assertIn('created_by', data)
-#         self.assertIn('start_date', data)
-#         self.assertIn('end_date', data)
+EXPECTED_FIELD_COUNT = 13
 
 
-class CreateTests(APITestCase):
+class ApplicationTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:application'
 
-    def test_endpoint_does_not_exist(self):
+    def setUp(self):
+        factory = APIRequestFactory()
+        self.anonymous_user = AnonymousUserFactory()
+        self.user = UserFactory.create()
+        self.provider = ProviderFactory.create()
+        self.user_identity = IdentityFactory.create_identity(
+            created_by=self.user,
+            provider=self.provider)
+        self.private_image = ImageFactory.create(
+            created_by=self.user,
+            private=True)
+        self.private_version = ApplicationVersionFactory.create_version(
+            self.user, self.user_identity,
+            application=self.private_image
+        )
+        self.private_machine = ProviderMachineFactory.create_provider_machine(
+            self.user, self.user_identity,
+            application=self.private_image,
+            version=self.private_version)
+
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.staff_user_identity = IdentityFactory.create_identity(
+            created_by=self.staff_user,
+            provider=self.provider)
+        self.public_image = ImageFactory.create(
+            created_by=self.staff_user,
+            private=False)
+        self.public_version = ApplicationVersionFactory.create_version(
+            self.staff_user, self.staff_user_identity,
+            application=self.public_image
+        )
+        self.public_machine = ProviderMachineFactory.create_provider_machine(
+            self.staff_user, self.staff_user_identity,
+            application=self.public_image,
+            version=self.public_version)
+
+        self.list_view = ViewSet.as_view({'get': 'list'})
+        list_url = reverse(self.url_route+'-list')
+        self.list_request = factory.get(list_url)
+
+        self.detail_view = ViewSet.as_view({'get': 'retrieve'})
+        detail_url = reverse(self.url_route+'-detail', args=(self.user.id,))
+        self.detail_request = factory.get(detail_url)
+
+        # force_authenticate(self.list_request, user=self.user)
+        # force_authenticate(self.detail_request, user=self.user)
+
+    def test_list_is_public(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
+        self.assertEquals(response.status_code, 200)
+
+    def test_list_is_visible_to_authenticated_user(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
+        self.assertEquals(response.status_code, 200)
+
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
+        self.assertTrue(response.data.get('results'), "Expected paginated results in list_view: %s" % response.data)
+        data = response.data.get('results')[0]
+
+        self.assertEquals(
+            len(data), EXPECTED_FIELD_COUNT,
+            "The number of arguments has changed for GET /application (%s!=%s)"
+            % (len(data), EXPECTED_FIELD_COUNT))
+        self.assertIn('id', data)
+        self.assertIn('url', data)
+        self.assertIn('uuid', data)
+        self.assertIn('name', data)
+        self.assertIn('metrics_url', data)
+        self.assertIn('created_by', data)
+        self.assertIn('description', data)
+        self.assertIn('end_date', data)
+        self.assertIn('is_public', data)
+        self.assertIn('icon', data)
+        self.assertIn('start_date', data)
+        self.assertIn('tags', data)
+        self.assertIn('versions', data)
+
+    def test_details_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.private_image.id)
+        data = response.data
+
+        self.assertEquals(
+            len(data), EXPECTED_FIELD_COUNT,
+            "The number of arguments has changed for GET /application/%s (%s!=%s)"
+            % (self.private_image.id, data.keys(), EXPECTED_FIELD_COUNT))
+        self.assertIn('id', data)
+        self.assertIn('url', data)
+        self.assertIn('uuid', data)
+        self.assertIn('name', data)
+        self.assertIn('metrics_url', data)
+        self.assertIn('created_by', data)
+        self.assertIn('description', data)
+        self.assertIn('end_date', data)
+        self.assertIn('is_public', data)
+        self.assertIn('icon', data)
+        self.assertIn('start_date', data)
+        self.assertIn('tags', data)
+        self.assertIn('versions', data)
+
+    def test_details_is_visible_to_anonymous_user(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.public_image.id)
+        self.assertEquals(response.status_code, 404)
+
+    def test_details_is_visible_to_authenticated_user(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.public_image.id)
+        self.assertEquals(response.status_code, 200)
+        response = self.detail_view(self.detail_request, pk=self.private_image.id)
+        self.assertEquals(response.status_code, 200)
+
+    def test_create_endpoint_does_not_exist(self):
         self.assertTrue('post' not in ViewSet.http_method_names)
 
-
-class UpdateTests(APITestCase):
-
-    def test_endpoint_does_exist(self):
+    def test_update_endpoint_does_exist(self):
         self.assertTrue('put' in ViewSet.http_method_names)
 
-
-class DeleteTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_delete_endpoint_does_not_exist(self):
         self.assertTrue('delete' not in ViewSet.http_method_names)

--- a/api/tests/v2/test_instances.py
+++ b/api/tests/v2/test_instances.py
@@ -20,6 +20,8 @@ class InstanceTests(APITestCase, APISanityTestCase):
     url_route = 'api:v2:instance'
 
     def setUp(self):
+        self.list_view = InstanceViewSet.as_view({'get': 'list'})
+        self.detailed_view = InstanceViewSet.as_view({'get': 'retrieve'})
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create(username='test-username')
         self.admin_user = UserFactory.create(username='admin', is_superuser=True, is_staff=True)

--- a/api/tests/v2/test_instances.py
+++ b/api/tests/v2/test_instances.py
@@ -11,11 +11,14 @@ from api.tests.factories import (
     GroupFactory, UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory,
     ImageFactory, ApplicationVersionFactory, InstanceSourceFactory, ProviderMachineFactory, IdentityFactory, ProviderFactory,
     IdentityMembershipFactory, QuotaFactory)
+from .base import APISanityTestCase
 from api.v2.views import InstanceViewSet
 from core.models import AtmosphereUser
 
 
-class InstanceTests(APITestCase):
+class InstanceTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:instance'
+
     def setUp(self):
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create(username='test-username')
@@ -88,7 +91,7 @@ class InstanceTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        url = reverse('api:v2:instance-detail', args=(self.networking_instance.provider_alias,))
+        url = reverse(self.url_route+"-detail", args=(self.networking_instance.provider_alias,))
         response = client.get(url)
         self.assertEquals(response.status_code, 200)
         data = response.data
@@ -100,7 +103,7 @@ class InstanceTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        url = reverse('api:v2:instance-detail', args=(self.deploying_instance.provider_alias,))
+        url = reverse(self.url_route+"-detail", args=(self.deploying_instance.provider_alias,))
         response = client.get(url)
         self.assertEquals(response.status_code, 200)
         data = response.data
@@ -112,7 +115,7 @@ class InstanceTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        url = reverse('api:v2:instance-detail', args=(self.deploy_error_instance.provider_alias,))
+        url = reverse(self.url_route+"-detail", args=(self.deploy_error_instance.provider_alias,))
         response = client.get(url)
         self.assertEquals(response.status_code, 200)
         data = response.data
@@ -124,7 +127,7 @@ class InstanceTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.user)
 
-        url = reverse('api:v2:instance-detail', args=(self.active_instance.provider_alias,))
+        url = reverse(self.url_route+"-detail", args=(self.active_instance.provider_alias,))
         response = client.get(url)
         self.assertEquals(response.status_code, 200, "Non-200 response returned: (%s) %s" % (response.status_code, response.data))
         data = response.data

--- a/api/tests/v2/test_platform_types.py
+++ b/api/tests/v2/test_platform_types.py
@@ -2,12 +2,13 @@ from rest_framework.test import APITestCase, APIRequestFactory, force_authentica
 from api.v2.views import PlatformTypeViewSet as ViewSet
 from api.tests.factories import UserFactory, AnonymousUserFactory, GroupFactory, PlatformTypeFactory
 from django.core.urlresolvers import reverse
+from .base import APISanityTestCase
 
 
-class GetListTests(APITestCase):
+class PlatformTypeTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:platformtype'
 
     def setUp(self):
-        self.view = ViewSet.as_view({'get': 'list'})
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create()
         self.group = GroupFactory.create(name=self.user.username)
@@ -16,29 +17,30 @@ class GetListTests(APITestCase):
         self.platform_type = PlatformTypeFactory.create()
 
         factory = APIRequestFactory()
-        url = reverse('api:v2:platformtype-list')
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request)
 
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        self.detail_view = ViewSet.as_view({'get': 'retrieve'})
+        detail_url = reverse(
+            self.url_route+'-detail', args=(self.platform_type.id,))
+        self.detail_request = factory.get(detail_url)
+
+        self.list_view = ViewSet.as_view({'get': 'list'})
+        list_url = reverse(
+            self.url_route+'-list')
+        self.list_request = factory.get(list_url)
+
+    def test_list_is_not_public(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_is_visible_to_authenticated_user(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_is_paginated(self):
-        response = self.response
-        self.assertIn('count', response.data)
-        self.assertIn('results', response.data)
-
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')[0]
 
         self.assertEquals(len(data), 5)
@@ -48,41 +50,19 @@ class GetListTests(APITestCase):
         self.assertIn('start_date', data)
         self.assertIn('end_date', data)
 
-
-class GetDetailTests(APITestCase):
-
-    def setUp(self):
-        self.view = ViewSet.as_view({'get': 'retrieve'})
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.staff_user = UserFactory.create(is_staff=True)
-
-        self.platform_type = PlatformTypeFactory.create()
-
-        factory = APIRequestFactory()
-        url = reverse(
-            'api:v2:platformtype-detail',
-            args=(
-                self.platform_type.id,
-            ))
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request, pk=self.platform_type.id)
-
     def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.platform_type.id)
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.platform_type.id)
         self.assertEquals(response.status_code, 403)
 
     def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.platform_type.id)
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.platform_type.id)
         self.assertEquals(response.status_code, 200)
 
     def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.platform_type.id)
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.platform_type.id)
         data = response.data
 
         self.assertEquals(len(data), 5)
@@ -92,20 +72,11 @@ class GetDetailTests(APITestCase):
         self.assertIn('start_date', data)
         self.assertIn('end_date', data)
 
-
-class CreateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_create_endpoint_does_not_exist(self):
         self.assertTrue('post' not in ViewSet.http_method_names)
 
-
-class UpdateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_update_endpoint_does_not_exist(self):
         self.assertTrue('put' not in ViewSet.http_method_names)
 
-
-class DeleteTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_delete_endpoint_does_not_exist(self):
         self.assertTrue('delete' not in ViewSet.http_method_names)

--- a/api/tests/v2/test_projects.py
+++ b/api/tests/v2/test_projects.py
@@ -1,54 +1,92 @@
 from rest_framework.test import APITestCase, APIRequestFactory,\
     force_authenticate
 from api.v2.views import ProjectViewSet
+from .base import APISanityTestCase
 from api.tests.factories import ProjectFactory, UserFactory,\
     AnonymousUserFactory, GroupFactory, GroupMembershipFactory
 from django.core.urlresolvers import reverse
 from core.models import Project
 
+EXPECTED_FIELD_COUNT = 15
 
-class GetProjectListTests(APITestCase):
+
+class ProjectTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:project'
 
     def setUp(self):
-        self.expected_field_count = 15
         self.anonymous_user = AnonymousUserFactory()
+
         self.user = UserFactory.create()
         self.group = GroupFactory.create(name=self.user.username)
         self.membership = GroupMembershipFactory.create(
             user=self.user,
             group=self.group,
             is_leader=True)
+        self.group.user_set.add(self.user)
         self.project = ProjectFactory.create(owner=self.group, created_by=self.user)
 
-        user2 = UserFactory.create()
-        group2 = GroupFactory.create(name=user2.username)
-        project2 = ProjectFactory.create(owner=group2, created_by=user2)
+        self.user2 = UserFactory.create()
+        self.group2 = GroupFactory.create(name=self.user2.username)
+        self.membership2 = GroupMembershipFactory.create(
+            user=self.user2,
+            group=self.group2,
+            is_leader=True)
+        self.group2.user_set.add(self.user2)
+        self.project2 = ProjectFactory.create(owner=self.group2, created_by=self.user2)
 
-        self.view = ProjectViewSet.as_view({'get': 'list'})
-        factory = APIRequestFactory()
-        url = reverse('api:v2:project-list')
-        self.request = factory.get(url)
+        self.not_user = UserFactory.create()
+        self.not_group = GroupFactory.create(name=self.not_user.username)
+        self.not_membership = GroupMembershipFactory.create(
+            user=self.not_user,
+            group=self.not_group,
+            is_leader=True)
+        self.not_group.user_set.add(self.not_user)
+        self.not_project = ProjectFactory.create(owner=self.not_group, created_by=self.not_user)
 
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        self.unsaved_project = ProjectFactory.build(owner=self.group, created_by=self.user)
+
+        list_url = reverse('api:v2:project-list')
+        detail_url = reverse('api:v2:project-detail', args=(self.project.id,))
+
+        self.create_view = ProjectViewSet.as_view({'post': 'create'})
+        self.delete_view = ProjectViewSet.as_view({'delete': 'destroy'})
+        self.detail_view = ProjectViewSet.as_view({'get': 'retrieve'})
+        self.list_view = ProjectViewSet.as_view({'get': 'list'})
+        self.update_view = ProjectViewSet.as_view({'patch': 'partial_update'})
+
+        self.factory = APIRequestFactory()
+        self.bad_create_request = self.factory.post(list_url)
+        self.create_request = self.factory.post(list_url, {
+            'name': self.unsaved_project.name,
+            'description': self.unsaved_project.description,
+            'owner': self.group.name
+        })
+        self.delete_request = self.factory.delete(detail_url)
+        self.detail_request = self.factory.get(detail_url)
+        self.list_request = self.factory.get(list_url)
+        self.updated_project_data = {
+            'name': 'updated name',
+            'description': 'updated description'
+        }
+        self.update_request = self.factory.patch(detail_url, self.updated_project_data)
+
+    def test_list_is_not_public(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_response_is_paginated(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
-        self.assertEquals(response.data['count'], 1)
-        self.assertEquals(len(response.data.get('results')), 1)
-
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')
         self.assertTrue(data, "Response contained no results")
         project_data = data[0]
 
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(len(project_data), self.expected_field_count, "Number of fields does not match (%s != %s)" % (len(project_data), self.expected_field_count))
+        self.assertEquals(
+            len(project_data), EXPECTED_FIELD_COUNT,
+            "Number of fields does not match (%s != %s)"
+            % (len(project_data), EXPECTED_FIELD_COUNT))
         self.assertEquals(project_data['id'], self.project.id)
         self.assertIn('url', project_data)
         self.assertEquals(project_data['name'], self.project.name)
@@ -65,41 +103,20 @@ class GetProjectListTests(APITestCase):
         self.assertIn('start_date', project_data)
         self.assertIn('end_date', project_data)
 
-
-class GetProjectDetailTests(APITestCase):
-
-    def setUp(self):
-        self.expected_field_count = 15
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.membership = GroupMembershipFactory.create(
-            user=self.user,
-            group=self.group,
-            is_leader=True)
-        self.project = ProjectFactory.create(owner=self.group, created_by=self.user)
-
-        user2 = UserFactory.create()
-        group2 = GroupFactory.create(name=user2.username)
-        ProjectFactory.create(owner=group2, created_by=user2)
-
-        self.view = ProjectViewSet.as_view({'get': 'retrieve'})
-        factory = APIRequestFactory()
-        url = reverse('api:v2:project-detail', args=(self.project.id,))
-        self.request = factory.get(url)
-
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.project.id)
+    def test_detail_is_not_public(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.project.id)
         self.assertEquals(response.status_code, 403)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.project.id)
+    def test_detail_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.project.id)
         data = response.data
 
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(len(data), self.expected_field_count, "Number of fields does not match (%s != %s)" % (len(data), self.expected_field_count))
+        self.assertEquals(
+            len(data), EXPECTED_FIELD_COUNT,
+            "Number of fields does not match (%s != %s)" % (len(data), EXPECTED_FIELD_COUNT))
         self.assertEquals(data['id'], self.project.id)
         self.assertIn('url', data)
         self.assertEquals(data['name'], self.project.name)
@@ -116,38 +133,14 @@ class GetProjectDetailTests(APITestCase):
         self.assertIn('start_date', data)
         self.assertIn('end_date', data)
 
-
-class CreateProjectTests(APITestCase):
-
-    def setUp(self):
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.group.user_set.add(self.user)
-        self.membership = GroupMembershipFactory.create(
-            user=self.user,
-            group=self.group,
-            is_leader=True)
-        self.project = ProjectFactory.build(owner=self.group, created_by=self.user)
-
-        self.view = ProjectViewSet.as_view({'post': 'create'})
-        self.factory = APIRequestFactory()
-        self.url = reverse('api:v2:project-list')
-        self.request = self.factory.post(self.url, {
-            'name': self.project.name,
-            'description': self.project.description,
-            'owner': self.group.name
-        })
-
-    def test_anonymous_user_cannot_create_project(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+    def test_create_project_fails_for_anonymous_user(self):
+        force_authenticate(self.create_request, user=self.anonymous_user)
+        response = self.create_view(self.create_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_required_fields(self):
-        bad_request = self.factory.post(self.url)
-        force_authenticate(bad_request, user=self.user)
-        response = self.view(bad_request)
+    def test_create_project_validation(self):
+        force_authenticate(self.bad_create_request, user=self.user)
+        response = self.create_view(self.bad_create_request)
         data = response.data
 
         self.assertEquals(response.status_code, 400)
@@ -167,105 +160,54 @@ class CreateProjectTests(APITestCase):
             data['name'], [u'This field is required.'],
             "Unexpected error response: %s" % data)
 
-    def test_authenticated_user_can_create_project(self):
-        self.assertEquals(Project.objects.count(), 0)
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
-        self.assertEquals(response.status_code, 201,
+    def test_create_project_as_authenticated_user(self):
+        current_count = Project.objects.count()
+        force_authenticate(self.create_request, user=self.user)
+        response = self.create_view(self.create_request)
+        self.assertEquals(
+            response.status_code, 201,
             "Response did not result in a 201-created: (%s) %s"
             % (response.status_code, response.data))
-        self.assertEquals(Project.objects.count(), 1)
-        project = Project.objects.first()
-        self.assertEquals(project.owner, self.group)
+        self.assertEquals(Project.objects.count(), current_count + 1)
 
-
-class UpdateProjectTests(APITestCase):
-
-    def setUp(self):
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.membership = GroupMembershipFactory.create(
-            user=self.user,
-            group=self.group,
-            is_leader=True)
-        self.project = ProjectFactory.create(owner=self.group, created_by=self.user)
-
-        self.not_user = UserFactory.create()
-        self.not_group = GroupFactory.create(name=self.not_user.username)
-        self.not_project = ProjectFactory.create(owner=self.not_group, created_by=self.not_user)
-
-        self.updated_project_data = {
-            'name': 'updated name',
-            'description': 'updated description'
-        }
-
-        self.factory = APIRequestFactory()
-        self.url = reverse('api:v2:project-detail', args=(self.project.id,))
-        self.request = self.factory.patch(self.url, {
-            'name': self.updated_project_data['name'],
-            'description': self.updated_project_data['description']
-        })
-
-        self.view = ProjectViewSet.as_view({'patch': 'partial_update'})
-
-    def test_anonymous_user_cannot_update_project(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+    def test_update_project_fails_for_anonymous_user(self):
+        force_authenticate(self.update_request, user=self.anonymous_user)
+        response = self.update_view(self.update_request)
         self.assertEquals(response.status_code, 403)
 
     def test_authenticated_user_cannot_update_project_they_do_not_own(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.not_project.id)
-        self.assertEquals(response.status_code, 404,
-            "Encountered an unexpected status_code: (%s) %s" % (response.status_code, response.data))
+        force_authenticate(self.update_request, user=self.user)
+        response = self.update_view(self.update_request, pk=self.not_project.id)
+        self.assertEquals(
+            response.status_code, 404,
+            "Encountered an unexpected status_code: (%s) %s"
+            % (response.status_code, response.data))
 
-    def test_user_can_update_project(self):
-        self.assertEquals(Project.objects.count(), 2)
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.project.id)
+    def test_update_project_for_valid_user(self):
+        current_count = Project.objects.count()
+        force_authenticate(self.update_request, user=self.user)
+        response = self.update_view(self.update_request, pk=self.project.id)
         self.assertEquals(
             response.status_code, 200,
             "Project update failed: (%s) %s" % (response.status_code, response.data))
-        self.assertEquals(Project.objects.count(), 2)
+        self.assertEquals(Project.objects.count(), current_count)
         project = Project.objects.first()
         self.assertEquals(project.name, self.updated_project_data['name'])
         self.assertEquals(
             project.description,
             self.updated_project_data['description'])
 
-
-class DeleteProjectTests(APITestCase):
-
-    def setUp(self):
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.membership = GroupMembershipFactory.create(
-            user=self.user,
-            group=self.group,
-            is_leader=True)
-        self.project = ProjectFactory.create(owner=self.group, created_by=self.user)
-
-        self.not_user = UserFactory.create()
-        self.not_group = GroupFactory.create(name=self.not_user.username)
-
-        self.view = ProjectViewSet.as_view({'delete': 'destroy'})
-        self.factory = APIRequestFactory()
-        self.url = reverse('api:v2:project-detail', args=(self.project.id,))
-        self.request = self.factory.delete(self.url)
-
     def test_anonymous_user_cannot_delete_project(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        force_authenticate(self.delete_request, user=self.anonymous_user)
+        response = self.delete_view(self.delete_request)
         self.assertEquals(response.status_code, 403)
 
     def test_user_cannot_delete_project_they_do_not_own(self):
-        force_authenticate(self.request, user=self.not_user)
-        response = self.view(self.request, pk=self.project.id)
+        force_authenticate(self.delete_request, user=self.not_user)
+        response = self.delete_view(self.delete_request, pk=self.project.id)
         self.assertEquals(response.status_code, 404)
 
     def test_user_can_delete_project_they_own(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.project.id)
+        force_authenticate(self.delete_request, user=self.user)
+        response = self.delete_view(self.delete_request, pk=self.project.id)
         self.assertEquals(response.status_code, 204)

--- a/api/tests/v2/test_provider_types.py
+++ b/api/tests/v2/test_provider_types.py
@@ -1,13 +1,15 @@
+from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
 from api.v2.views import ProviderTypeViewSet as ViewSet
 from api.tests.factories import UserFactory, AnonymousUserFactory, GroupFactory, ProviderTypeFactory
-from django.core.urlresolvers import reverse
+
+from .base import APISanityTestCase
 
 
-class GetListTests(APITestCase):
+class ProviderTypeTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:providertype'
 
     def setUp(self):
-        self.view = ViewSet.as_view({'get': 'list'})
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create()
         self.group = GroupFactory.create(name=self.user.username)
@@ -16,29 +18,33 @@ class GetListTests(APITestCase):
         self.provider_type = ProviderTypeFactory.create()
 
         factory = APIRequestFactory()
-        url = reverse('api:v2:providertype-list')
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request)
 
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        self.detail_view = ViewSet.as_view({'get': 'retrieve'})
+        self.list_view = ViewSet.as_view({'get': 'list'})
+
+        detail_url = reverse(
+            self.url_route + '-detail',
+            args=(
+                self.provider_type.id,
+            ))
+        list_url = reverse(self.url_route + '-list')
+
+        self.detail_request = factory.get(detail_url)
+        self.list_request = factory.get(list_url)
+
+    def test_list_is_not_public(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_is_visible_to_authenticated_user(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_is_paginated(self):
-        response = self.response
-        self.assertIn('count', response.data)
-        self.assertIn('results', response.data)
-
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')[0]
 
         self.assertEquals(len(data), 5)
@@ -48,41 +54,19 @@ class GetListTests(APITestCase):
         self.assertIn('start_date', data)
         self.assertIn('end_date', data)
 
-
-class GetDetailTests(APITestCase):
-
-    def setUp(self):
-        self.view = ViewSet.as_view({'get': 'retrieve'})
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.group = GroupFactory.create(name=self.user.username)
-        self.staff_user = UserFactory.create(is_staff=True)
-
-        self.provider_type = ProviderTypeFactory.create()
-
-        factory = APIRequestFactory()
-        url = reverse(
-            'api:v2:providertype-detail',
-            args=(
-                self.provider_type.id,
-            ))
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request, pk=self.provider_type.id)
-
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.provider_type.id)
+    def test_detail_is_not_public(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.provider_type.id)
         self.assertEquals(response.status_code, 403)
 
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.provider_type.id)
+    def test_detail_is_visible_to_authenticated_user(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.provider_type.id)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.provider_type.id)
+    def test_detail_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.provider_type.id)
         data = response.data
 
         self.assertEquals(len(data), 5)
@@ -92,20 +76,11 @@ class GetDetailTests(APITestCase):
         self.assertIn('start_date', data)
         self.assertIn('end_date', data)
 
-
-class CreateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_create_endpoint_does_not_exist(self):
         self.assertTrue('post' not in ViewSet.http_method_names)
 
-
-class UpdateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_update_endpoint_does_not_exist(self):
         self.assertTrue('put' not in ViewSet.http_method_names)
 
-
-class DeleteTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_delete_endpoint_does_not_exist(self):
         self.assertTrue('delete' not in ViewSet.http_method_names)

--- a/api/tests/v2/test_sizes.py
+++ b/api/tests/v2/test_sizes.py
@@ -1,15 +1,18 @@
 from rest_framework.test import APITestCase, APIRequestFactory,\
     force_authenticate
 
+from django.core.urlresolvers import reverse
+from core.models import Size
 from api.v2.views import SizeViewSet
 from api.tests.factories import ProviderFactory, UserFactory,\
     AnonymousUserFactory, SizeFactory, IdentityFactory
 
-from django.core.urlresolvers import reverse
-from core.models import Size
+from .base import APISanityTestCase
 
 
-class GetSizeListTests(APITestCase):
+class SizeTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:size'
+
     def setUp(self):
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create()
@@ -22,25 +25,26 @@ class GetSizeListTests(APITestCase):
                                        disk=20,
                                        root=0,
                                        mem=126)
-        self.view = SizeViewSet.as_view({'get': 'list'})
+        self.list_view = SizeViewSet.as_view({'get': 'list'})
         factory = APIRequestFactory()
-        url = reverse('api:v2:size-list')
-        self.request = factory.get(url)
+
+        list_url = reverse(self.url_route+'-list')
+        self.list_request = factory.get(list_url)
 
     def test_is_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
     def test_response_is_paginated(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.data['count'], 1)
         self.assertEquals(len(response.data.get('results')), 1)
 
     def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')[0]
         self.assertTrue(data, "No results retrieved.")
         self.assertEquals(response.status_code, 200)

--- a/api/tests/v2/test_tags.py
+++ b/api/tests/v2/test_tags.py
@@ -4,35 +4,72 @@ from api.tests.factories import TagFactory, UserFactory, AnonymousUserFactory
 from django.core.urlresolvers import reverse
 from core.models import Tag
 
+from .base import APISanityTestCase
 
-class GetTagListTests(APITestCase):
+EXPECTED_FIELD_COUNT = 6
+
+class TagTests(APITestCase, APISanityTestCase):
+    url_route = "api:v2:tag"
 
     def setUp(self):
         self.tags = TagFactory.create_batch(10)
-        self.view = TagViewSet.as_view({'get': 'list'})
         self.anonymous_user = AnonymousUserFactory()
+        self.user = UserFactory()
+        self.staff_user = UserFactory(is_staff=True)
 
-        factory = APIRequestFactory()
-        url = reverse('api:v2:tag-list')
-        self.request = factory.get(url)
+        self.tag = TagFactory.create()
+        self.unsaved_tag = TagFactory.build()
+        self.updated_tag_data = {
+            'name': 'new-tag-name',
+            'description': 'new tag description'
+        }
 
-    def test_does_not_require_authenticated_user(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        self.factory = APIRequestFactory()
+
+
+        self.create_view = TagViewSet.as_view({'post': 'create'})
+        self.delete_view = TagViewSet.as_view({'delete': 'destroy'})
+        self.detail_view = TagViewSet.as_view({'get': 'retrieve'})
+        self.list_view = TagViewSet.as_view({'get': 'list'})
+        self.update_view = TagViewSet.as_view({'put': 'update'})
+
+        detail_url = reverse(self.url_route + '-detail', args=(self.tag.id,))
+        list_url = reverse(self.url_route + '-list')
+
+        self.create_request = self.factory.post(list_url, {
+            'name': self.unsaved_tag.name,
+            'description': self.unsaved_tag.description
+        })
+        self.delete_request = self.factory.delete(detail_url)
+        self.detail_request = self.factory.get(detail_url)
+        self.list_request = self.factory.get(list_url)
+        self.update_request = self.factory.put(detail_url, {
+            'name': self.updated_tag_data['name'],
+            'description': self.updated_tag_data['description']
+        })
+
+    def test_list_does_not_require_authenticated_user(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_is_paginated(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
-        self.assertEquals(response.data['count'], len(self.tags))
-        self.assertEquals(len(response.data.get('results')), len(self.tags))
+    def test_list_response_is_paginated(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
+        current_count = Tag.objects.count()
+        self.assertEquals(response.data['count'], current_count)
+        self.assertEquals(len(response.data.get('results')), current_count)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')[0]
 
-        self.assertEquals(len(data), 6)
+        self.assertEquals(
+            len(data), EXPECTED_FIELD_COUNT,
+            "The number of arguments has changed for GET /tags (%s!=%s)"
+            % (len(data), EXPECTED_FIELD_COUNT)
+        )
         self.assertEquals(data['id'], self.tags[0].id)
         self.assertEquals(data['uuid'], str(self.tags[0].uuid))
         self.assertIn('url', data)
@@ -40,28 +77,21 @@ class GetTagListTests(APITestCase):
         self.assertEquals(data['description'], self.tags[0].description)
         self.assertTrue(data['allow_access'])
 
-
-class GetTagDetailTests(APITestCase):
-
-    def setUp(self):
-        self.tag = TagFactory.create()
-        self.view = TagViewSet.as_view({'get': 'retrieve'})
-        self.anonymous_user = AnonymousUserFactory()
-        factory = APIRequestFactory()
-        url = reverse('api:v2:tag-detail', args=(self.tag.id,))
-        self.request = factory.get(url)
-
-    def test_does_not_require_authenticated_user(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.tag.id)
+    def test_detail_does_not_require_authenticated_user(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.tag.id)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.tag.id)
+    def test_detail_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.tag.id)
         data = response.data
 
-        self.assertEquals(len(data), 6)
+        self.assertEquals(
+            len(data), EXPECTED_FIELD_COUNT,
+            "The number of arguments has changed for GET /tags/%s (%s!=%s)"
+            % (self.tag.id, len(data), EXPECTED_FIELD_COUNT)
+        )
         self.assertEquals(data['id'], self.tag.id)
         self.assertEquals(data['uuid'], str(self.tag.uuid))
         self.assertIn('url', data)
@@ -69,116 +99,69 @@ class GetTagDetailTests(APITestCase):
         self.assertEquals(data['description'], self.tag.description)
         self.assertTrue(data['allow_access'])
 
-
-class DeleteTagTests(APITestCase):
-
-    def setUp(self):
-        self.tag = TagFactory.create()
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory()
-        self.staff_user = UserFactory(is_staff=True)
-
-        factory = APIRequestFactory()
-        url = reverse('api:v2:tag-detail', args=(self.tag.id,))
-        self.request = factory.delete(url)
-
-        self.view = TagViewSet.as_view({'delete': 'destroy'})
-
     def test_anonymous_user_cannot_delete_tag(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        force_authenticate(self.delete_request, user=self.anonymous_user)
+        response = self.delete_view(self.delete_request)
         self.assertEquals(response.status_code, 403)
 
     def test_non_staff_user_cannot_delete_tag(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+        force_authenticate(self.delete_request, user=self.user)
+        response = self.delete_view(self.delete_request)
         self.assertEquals(response.status_code, 403)
 
     def test_staff_user_can_delete_tag(self):
-        force_authenticate(self.request, user=self.staff_user)
-        response = self.view(self.request, pk=self.tag.id)
+        force_authenticate(self.delete_request, user=self.staff_user)
+        response = self.delete_view(self.delete_request, pk=self.tag.id)
         self.assertEquals(response.status_code, 204)
 
-
-class CreateTagTests(APITestCase):
-
-    def setUp(self):
-        self.tag = TagFactory.build()
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.staff_user = UserFactory.create(is_staff=True)
-
-        self.factory = APIRequestFactory()
-        self.url = reverse('api:v2:tag-list')
-        self.request = self.factory.post(self.url, {
-            'name': self.tag.name,
-            'description': self.tag.description
-        })
-
-        self.view = TagViewSet.as_view({'post': 'create'})
-
     def test_anonymous_user_cannot_create_tag(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        force_authenticate(self.create_request, user=self.anonymous_user)
+        response = self.create_view(self.create_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_required_fields(self):
-        bad_request = self.factory.post(self.url)
+    def test_required_fields_on_create_tag(self):
+        create_url = reverse(self.url_route + '-list')
+        bad_request = self.factory.post(create_url)
         force_authenticate(bad_request, user=self.user)
-        response = self.view(bad_request)
+        response = self.create_view(bad_request)
         self.assertEquals(response.status_code, 400)
         self.assertEquals(len(response.data), 2)
         self.assertIn('name', response.data)
         self.assertIn('description', response.data)
 
     def test_authenticated_user_can_create_tag(self):
-        self.assertEquals(Tag.objects.count(), 0)
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
-        self.assertEquals(response.status_code, 201)
-        self.assertEquals(Tag.objects.count(), 1)
-        tag = Tag.objects.first()
+        current_count = Tag.objects.count()
+        force_authenticate(self.create_request, user=self.user)
+        response = self.create_view(self.create_request)
+        self.assertEquals(
+            response.status_code, 201,
+            "Expected 201-response. Received (%s): %s"
+            % (response.status_code, response.data))
+        self.assertIn('id', response.data,
+            "Expected new tag ID as part of 201 response. Recieved: %s"
+            % response.data)
+        tag_id = response.data.get('id')
+        self.assertEquals(Tag.objects.count(), current_count + 1)
+        tag = Tag.objects.get(id=tag_id)
         self.assertEquals(tag.user, self.user)
 
-
-class UpdateTagTests(APITestCase):
-
-    def setUp(self):
-        self.tag = TagFactory.create()
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-        self.staff_user = UserFactory.create(is_staff=True)
-        self.updated_tag_data = {
-            'name': 'new-tag-name',
-            'description': 'new tag description'
-        }
-
-        self.factory = APIRequestFactory()
-        self.url = reverse('api:v2:tag-detail', args=(self.tag.id,))
-        self.request = self.factory.put(self.url, {
-            'name': self.updated_tag_data['name'],
-            'description': self.updated_tag_data['description']
-        })
-
-        self.view = TagViewSet.as_view({'put': 'update'})
-
     def test_anonymous_user_cannot_update_tag(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        force_authenticate(self.update_request, user=self.anonymous_user)
+        response = self.update_view(self.update_request)
         self.assertEquals(response.status_code, 403)
 
     def test_authenticated_user_cannot_update_tag(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.tag.id)
+        force_authenticate(self.update_request, user=self.user)
+        response = self.update_view(self.update_request, pk=self.tag.id)
         self.assertEquals(response.status_code, 403)
 
     def test_staff_user_can_update_tag(self):
-        self.assertEquals(Tag.objects.count(), 1)
-        force_authenticate(self.request, user=self.staff_user)
-        response = self.view(self.request, pk=self.tag.id)
+        current_count = Tag.objects.count()
+        force_authenticate(self.update_request, user=self.staff_user)
+        response = self.update_view(self.update_request, pk=self.tag.id)
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(Tag.objects.count(), 1)
-        tag = Tag.objects.first()
+        self.assertEquals(Tag.objects.count(), current_count)
+        tag = Tag.objects.get(id=self.tag.id)
         self.assertEquals(tag.name, self.updated_tag_data['name'])
         self.assertEquals(
             tag.description,

--- a/api/tests/v2/test_users.py
+++ b/api/tests/v2/test_users.py
@@ -2,41 +2,42 @@ from rest_framework.test import APITestCase, APIRequestFactory, force_authentica
 from api.v2.views import UserViewSet
 from api.tests.factories import UserFactory, AnonymousUserFactory
 from django.core.urlresolvers import reverse
-from core.models import AtmosphereUser as User
+
+from .base import APISanityTestCase
 
 
-class GetListTests(APITestCase):
+class UserTests(APITestCase, APISanityTestCase):
+    url_route = 'api:v2:atmosphereuser'
 
     def setUp(self):
-        self.view = UserViewSet.as_view({'get': 'list'})
         self.anonymous_user = AnonymousUserFactory()
         self.user = UserFactory.create()
         self.staff_user = UserFactory.create(is_staff=True)
 
         factory = APIRequestFactory()
-        url = reverse('api:v2:atmosphereuser-list')
-        self.request = factory.get(url)
-        force_authenticate(self.request, user=self.user)
-        self.response = self.view(self.request)
 
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request)
+        self.list_view = UserViewSet.as_view({'get': 'list'})
+        self.detail_view = UserViewSet.as_view({'get': 'retrieve'})
+
+        detail_url = reverse(self.url_route + '-detail', args=(self.user.id,))
+        list_url = reverse(self.url_route + '-list')
+
+        self.detail_request = factory.get(detail_url)
+        self.list_request = factory.get(list_url)
+
+    def test_list_is_not_public(self):
+        force_authenticate(self.list_request, user=self.anonymous_user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 403)
 
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_is_visible_to_authenticated_user(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_is_paginated(self):
-        response = self.response
-        self.assertIn('count', response.data)
-        self.assertIn('results', response.data)
-
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request)
+    def test_list_response_contains_expected_fields(self):
+        force_authenticate(self.list_request, user=self.user)
+        response = self.list_view(self.list_request)
         data = response.data.get('results')[0]
 
         self.assertEquals(len(data), 5)
@@ -46,31 +47,19 @@ class GetListTests(APITestCase):
         self.assertIn('username', data)
         self.assertIn('end_date', data)
 
-
-class GetDetailTests(APITestCase):
-
-    def setUp(self):
-        self.view = UserViewSet.as_view({'get': 'retrieve'})
-        self.anonymous_user = AnonymousUserFactory()
-        self.user = UserFactory.create()
-
-        factory = APIRequestFactory()
-        url = reverse('api:v2:atmosphereuser-detail', args=(self.user.id,))
-        self.request = factory.get(url)
-
-    def test_is_not_public(self):
-        force_authenticate(self.request, user=self.anonymous_user)
-        response = self.view(self.request, pk=self.user.id)
+    def test_detail_is_not_public(self):
+        force_authenticate(self.detail_request, user=self.anonymous_user)
+        response = self.detail_view(self.detail_request, pk=self.user.id)
         self.assertEquals(response.status_code, 403)
 
-    def test_is_visible_to_authenticated_user(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.user.id)
+    def test_detail_is_visible_to_authenticated_user(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.user.id)
         self.assertEquals(response.status_code, 200)
 
-    def test_response_contains_expected_fields(self):
-        force_authenticate(self.request, user=self.user)
-        response = self.view(self.request, pk=self.user.id)
+    def test_detail_response_contains_expected_fields(self):
+        force_authenticate(self.detail_request, user=self.user)
+        response = self.detail_view(self.detail_request, pk=self.user.id)
         data = response.data
 
         self.assertEquals(len(data), 5)
@@ -80,20 +69,11 @@ class GetDetailTests(APITestCase):
         self.assertIn('username', data)
         self.assertIn('end_date', data)
 
-
-class CreateTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_create_endpoint_does_not_exist(self):
         self.assertTrue('post' not in UserViewSet.http_method_names)
 
-
-class UpdateTests(APITestCase):
-
-    def test_endpoint_does_exist(self):
+    def test_update_endpoint_does_exist(self):
         self.assertTrue('put' in UserViewSet.http_method_names)
 
-
-class DeleteTests(APITestCase):
-
-    def test_endpoint_does_not_exist(self):
+    def test_delete_endpoint_does_not_exist(self):
         self.assertTrue('delete' not in UserViewSet.http_method_names)


### PR DESCRIPTION
## Description

There is a subset of tests that should be included in all /v2 API endpoint testing. One example is ensuring that `<key>` in  `/v2/<type_of_resources>/<key>` is invalid, null, or improper type that the application does not "crash" with a 500 error.

This PR can and should be improved prior to merge.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [ ] Reviewed and approved by at least one other contributor.
