### PR TITLE
Problem: Celery sometimes reports 'Too many open files'

### DIFF
--- a/extras/init.d/celeryd.default.dist.j2
+++ b/extras/init.d/celeryd.default.dist.j2
@@ -38,6 +38,9 @@ CELERYD_OPTS="$CELERYD_OPTS -Q:imaging imaging -c:imaging 1 -O:imaging fair"
 
 CELERYD_OPTS="$CELERYD_OPTS -Q:celery_periodic periodic -c:celery_periodic 3 -O:celery_periodic fair"
 CELERYD_OPTS="$CELERYD_OPTS -Q:email email -c:email 1 -O:email fair"
+
+# The format of the CELERYD_ULIMIT variable is something like "-n <max_open_files>"
+CELERYD_ULIMIT="-n 65536"
 {% else %}
 #############
 # Development Settings (Single-Node!)


### PR DESCRIPTION
```
OSError: [Errno 24] Too many open files
```

Solution: Set the `CELERYD_ULIMIT` variable in `celeryd.default` to a
higher number

TODO: Still not sure why this is suddenly causing a problem. Is it
something to do with the new version of Celery we're using?

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
