### PR TITLE
Problem: `rtwo` return includes `glance` now

### DIFF
--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -1152,12 +1152,12 @@ class AccountDriver(BaseAccountDriver):
 
     def get_neutron_client(self, all_creds):
         net_creds = self._build_network_creds(all_creds)
-        neutron = self.network_manager.new_connection(**net_creds)
+        neutron, _ = self.network_manager.new_connection(**net_creds)
         return neutron
 
     def get_user_clients(self, all_creds):
         user_creds = self._build_user_creds(all_creds)
-        (keystone, nova, swift) = self.user_manager.new_connection(
+        (keystone, nova, swift, glance) = self.user_manager.new_connection(
             **user_creds)
         return {
             "keystone": keystone,


### PR DESCRIPTION
Solution: Add a `glance` component in the return tuple

Signed-off-by: Julian Pistorius <julian@julianpistorius.com>

## Checklist before merging Pull Requests
~- [ ] New test(s) included to reproduce the bug/verify the feature~
~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
~- [ ] If necessary, include a snippet in CHANGELOG.md~
~- [ ] New variables supported in Clank~
~- [ ] New variables committed to secrets repos~
