### PR TITLE
Problem: Failing tests

### DIFF
--- a/features/instance.features/edit_instance.feature
+++ b/features/instance.features/edit_instance.feature
@@ -1,3 +1,4 @@
+@skip-if-jetstream
 Feature: Launching & editing of an instance
 
   Background:
@@ -12,7 +13,6 @@ Feature: Launching & editing of an instance
     And we make the current identity the admin on provider "MockProvider"
 
 
-  @skip-if-jetstream
   Scenario: Launch instance and assign allocation source
     Given "user407" as the persona
     When I set "username" to "user407"
@@ -20,7 +20,7 @@ Feature: Launching & editing of an instance
     And we create a new user
     Given a current time of '2017-02-16T06:00:00Z' with tick = False
     When I log in
-    And we create an account for the current persona on provider "MockProvider"
+    And we create an identity for the current persona on provider "MockProvider"
     And we ensure that the user has an allocation source
     Then I should have the following quota on provider "MockProvider"
       | key               | value |
@@ -137,7 +137,7 @@ Feature: Launching & editing of an instance
     And we create a new user
     Given a current time of '2017-02-16T06:00:00Z' with tick = False
     When I log in
-    And we create an account for the current persona on provider "MockProvider"
+    And we create an identity for the current persona on provider "MockProvider"
     And we ensure that the user has an allocation source
     Given a current time of '2017-02-16T07:00:00Z' with tick = False
     When we create a provider machine for current persona

--- a/features/steps/api_with_persona_steps.py
+++ b/features/steps/api_with_persona_steps.py
@@ -242,13 +242,18 @@ def set_up_provider(context, provider_location):
 
 
 @step('we create an account for the current persona on provider "{provider_location}"')
-def create_account(context, provider_location):
+def create_jetstream_account(context, provider_location):
     """This does not use the factory
     
     We want to test the default quota plugin.
+
+    NOTE: At the moment this step only works with Jetstream and TAS API
     """
     assert context.persona
     import core.models
+    context.test.assertIn('jetstream', django.conf.settings.INSTALLED_APPS,
+                          'Step only works with Jetstream setup. '
+                          'Please use "we create an identity for the current persona ..."')
     provider = core.models.Provider.objects.get(location=provider_location)
     user = context.persona['user']
     with mock.patch('service.driver.get_account_driver', autospec=True) as mock_get_account_driver:


### PR DESCRIPTION
`edit_instance.feature` was using a step to create an identity in a way
that would only work when using the correct setup for Jetstream & TAS

Solution:
1. Use the correct step,
2. Document it in the step,
3. Add an `assert` to catch it in the future, and
4. Skip all these scenarios if running in Jetstream distribution

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
