### PR TITLE
Optimize resource request serialization

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,73 @@
+# HACKING.md
+
+This guide has a collection of tips for developing on Atmosphere.
+
+### Prefetch data in views with nested serializers
+
+If you suspect that a view is making too many database queries, read this tip.
+The solution is to prefetch model instances, so that serializers re-use
+already fetched models, rather than always fetching their own.
+
+Suppose there are 400 Cars. Each Car has a Manufacturer, and the serializer
+for a Car has a single field, ManufacturerSerializer. We want to write an
+efficient view that returns all 400 cars each with its manufacturer.
+
+##### Without prefetching
+During serialization of the view, there will be 1 database query for 400 `Car`s. The Manufacturer serializer will be passed a reference like `car.manufacturer`. If this is the first time that the property has been accessed on the instance, then a database query will fetch the corresponding value from the `Manufacturer` table. Here lies the problem. For each `Car` a `Manufacturer` will be fetched. In total 401 queries will be made. This is an n+1 problem.
+
+##### With prefetching
+There will be 1 query for 400 `Car`s and 1 query for each related `Manufacturer`.
+In this case, the view for Car would override it's `get_queryset` method:
+```python
+def get_queryset(self):
+    queryset = Car.objects.all()
+    return queryset.select_related("manufacturer")
+```
+A Car model returned from this queryset, will have its `manufacturer`
+attribute already fetched.
+
+Caveat:
+`select_related` only works with single-valued relationships (i.e. ForeignKey,
+one-to-one). For multi-valued relationships see `prefetch_related`.
+
+Resources:
+- [select_related](https://docs.djangoproject.com/en/1.10/ref/models/querysets/#django.db.models.query.QuerySet.prefetch_related)
+- [prefetch_related](https://docs.djangoproject.com/en/1.10/ref/models/querysets/#select-related)
+- [whats-the-difference-between-select-related-and-prefetch-related-in-django-orm](https://stackoverflow.com/questions/31237042/whats-the-difference-between-select-related-and-prefetch-related-in-django-orm/45377282)
+
+### Log all database queries with timing information
+
+If you're trying to step through code and figure out why (and when) queries are being
+executed, it's useful to add database logging. It's as simple as whenever a
+query is made, the query will be printed in the process where atmosphere is
+running.
+
+This will slow down your application, but can be tremendously handy. Add the
+following to `atmosphere/settings/local.py`:
+```python
+LOGGING = {
+    'disable_existing_loggers': False,
+    'version': 1,
+    'handlers': {
+        'console': {
+            # logging handler that outputs log messages to terminal
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG', # message level to be written to console
+        },
+    },
+    'loggers': {
+        '': {
+            # this sets root level logger to log debug and higher level
+            # logs to console. All other loggers inherit settings from
+            # root level logger.
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False, # this tells logger to send logging message
+                                # to its parent (will send if set to True)
+        },
+        'django.db': {
+            'level': 'DEBUG'
+        },
+    },
+}
+```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ python scripts/<name of script>
 
 ## Contributing
 
+See [HACKING.md](./HACKING.md).
+
 ### Coding Style
 - Use 4 space indentation
 - Limit lines to 79 characters
@@ -83,7 +85,7 @@ See LICENSE.txt for license information
 
 + **Edwin Skidmore <edwin@iplantcollaborative.org>**
 
-## Authors 
+## Authors
 
 The following individuals who have help/helped make :cloud: great appear in alphabetic order, by surname.
 

--- a/api/v2/serializers/details/resource_request.py
+++ b/api/v2/serializers/details/resource_request.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 from core.models import ResourceRequest
-from api.v2.serializers.summaries import UserSummarySerializer
-from api.v2.serializers.fields import (
-    IdentityRelatedField, StatusTypeRelatedField
+from api.v2.serializers.summaries import (
+    UserSummarySerializer, StatusTypeSummarySerializer
 )
+from api.v2.serializers.fields import IdentityRelatedField
 from api.v2.serializers.fields.base import UUIDHyperlinkedIdentityField
 
 
@@ -14,7 +14,7 @@ class ResourceRequestSerializer(serializers.HyperlinkedModelSerializer):
     )
     created_by = UserSummarySerializer(read_only=True)
     identity = IdentityRelatedField(source='membership.identity')
-    status = StatusTypeRelatedField(allow_null=True, required=False)
+    status = StatusTypeSummarySerializer(read_only=True)
 
     class Meta:
         model = ResourceRequest

--- a/api/v2/serializers/fields/identity.py
+++ b/api/v2/serializers/fields/identity.py
@@ -7,9 +7,7 @@ class IdentityRelatedField(serializers.RelatedField):
     def get_queryset(self):
         return Identity.objects.all()
 
-    def to_representation(self, value):
-        queryset = self.get_queryset()
-        identity = queryset.get(pk=value.pk)
+    def to_representation(self, identity):
         serializer = IdentitySummarySerializer(identity, context=self.context)
         return serializer.data
 

--- a/api/v2/serializers/fields/status_type.py
+++ b/api/v2/serializers/fields/status_type.py
@@ -8,8 +8,7 @@ class StatusTypeRelatedField(serializers.RelatedField):
     def get_queryset(self):
         return StatusType.objects.all()
 
-    def to_representation(self, value):
-        status_type = StatusType.objects.get(pk=value.pk)
+    def to_representation(self, status_type):
         serializer = StatusTypeSummarySerializer(
             status_type,
             context=self.context)

--- a/api/v2/serializers/fields/user.py
+++ b/api/v2/serializers/fields/user.py
@@ -5,12 +5,6 @@ from api.v2.serializers.summaries import UserSummarySerializer
 
 class UserRelatedField(serializers.RelatedField):
 
-    def __init__(self, **kwargs):
-        kwargs['read_only'] = True
-        super(UserRelatedField, self).__init__(**kwargs)
-
-    def to_representation(self, value):
-        username = value.__str__()
-        user = AtmosphereUser.objects.get(username=username)
+    def to_representation(self, user):
         serializer = UserSummarySerializer(user, context=self.context)
         return serializer.data

--- a/api/v2/views/resource_request.py
+++ b/api/v2/views/resource_request.py
@@ -21,6 +21,25 @@ class ResourceRequestViewSet(BaseRequestViewSet):
     admin_serializer_class = ResourceRequestSerializer
     filter_fields = ('status__id', 'status__name', 'created_by__username')
 
+    def get_queryset(self):
+        """
+        Return users requests or all the requests if the user is an admin.
+        """
+        queryset = None
+        if self.request.user.is_staff:
+            queryset = self.model.objects.all()
+        else:
+            queryset = self.model.objects.filter(created_by=self.request.user)
+
+        # Note:
+        # Select_related is better but can only be used with 1-1, foreign key
+        # Prefetch_related is required for M2M
+        # See https://stackoverflow.com/a/31237071/1213041
+        return queryset \
+            .select_related("created_by", "status") \
+            .prefetch_related("membership__identity__credential_set") \
+            .order_by('-start_date')
+
     def close_action(self, instance):
         """
         Add an end date to a request and take no further action


### PR DESCRIPTION
## Description
**Problem:**
API call to resource requests is too slow
**Solution:**
Prefetch data in the nested serializers, create less objects

See [documentation](https://github.com/cyverse/atmosphere/pull/447/files#diff-88333ba11114e014e87198d04680144d).

The API endpoint for 400 models went from making 3000 db queries to about 10 and from roughly 20s total request time to 1s. Many of our apis will experience similar speedups from these fixes. 

Even though the queries were improved by a factor of 300, the time was only improved by a factor of 20, so database optimization isn't everything—serialization is also costly. 

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
