### PR TITLE
Stripping line breaks from application_description when talking to Glance API V1 Client

### DIFF
--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -319,7 +319,7 @@ def main(application_id,
                                                   application_version=app_version.name,
                                                   # Glance v1 client throws exception on line breaks
                                                   application_description=app.description
-                                                      .replace('\r', '').replace('\n', ''),
+                                                      .replace('\r', '').replace('\n', ' -- '),
                                                   application_owner=app_creator_uname,
                                                   application_tags=json.dumps(app_tags),
                                                   application_uuid=str(app.uuid))

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -317,7 +317,9 @@ def main(application_id,
                                                   tags=app_tags,
                                                   application_name=app.name,
                                                   application_version=app_version.name,
-                                                  application_description=app.description,
+                                                  # Glance v1 client throws exception on line breaks
+                                                  application_description=app.description
+                                                      .replace('\r', '').replace('\n', ''),
                                                   application_owner=app_creator_uname,
                                                   application_tags=json.dumps(app_tags),
                                                   application_uuid=str(app.uuid))


### PR DESCRIPTION
## Description

Glance v1 client throws exception on line breaks in any of the metadata fields. We're likely to have line breaks in `application_description` for many images. This PR replaces line breaks with ` -- `.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
