### PR TITLE
Don't compute unnecessary and very expensive query

### DIFF
--- a/core/models/identity.py
+++ b/core/models/identity.py
@@ -459,9 +459,6 @@ class Identity(models.Model):
         id_member = self.identity_memberships.all()[0]
         # See core/models/membership.py#IdentityMembership
         quota_dict = id_member.get_quota_dict()
-        allocation_dict = self.get_allocation_dict()
-        if allocation_dict:
-            quota_dict.update({"allocation": allocation_dict})
         return quota_dict
 
     def json(self):

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -321,7 +321,9 @@ def main(application_id,
                                                   tags=app_tags,
                                                   application_name=app.name,
                                                   application_version=app_version.name,
-                                                  application_description=app.description,
+                                                  # Glance v1 client throws exception on line breaks
+                                                  application_description=app.description
+                                                      .replace('\r', '').replace('\n', ' -- '),
                                                   application_owner=app_creator_uname,
                                                   application_tags=json.dumps(app_tags),
                                                   application_uuid=str(app.uuid))


### PR DESCRIPTION
## Description

Each call to `api/v1/profile` was computing a users allocation across all their instances (old style allocation), and was ignoring the result 😆 . There is a lot of dead code to nuke.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
