### PR TITLE
Fix for PR #424 - Guacamole key auth and default Guac shell color

### DIFF
--- a/api/v2/views/web_token.py
+++ b/api/v2/views/web_token.py
@@ -115,7 +115,7 @@ class WebTokenView(RetrieveAPIView):
                           + '&guac.enable-sftp=true')
 
         if protocol == "ssh":
-            request_string += "guac.color-scheme=white-black"
+            request_string += "&guac.color-scheme=white-black"
 
         # Send request to Guacamole backend and record the result
         response = requests.post(guac_server + '/api/tokens', data=request_string)


### PR DESCRIPTION
Fix for merged PR #424 

The line with `request_string += "guac.color-scheme=white-black"` is missing a "&"
This didn't cause any failures, but prevented Guacamole from parsing the additional parameters. This PR simply adds a "&" in front of that string.