### PR TITLE
Problem: Emulate endpoint broken

### DIFF
--- a/api/v1/views/token.py
+++ b/api/v1/views/token.py
@@ -32,7 +32,6 @@ class TokenEmulate(AuthAPIView):
         Create a new token in the database on behalf of 'username'
         Returns success 201 Created - Body is JSON and contains
         """
-        params = request.data
         user = request.user
         if not username:
             return Response("Username was not provided",
@@ -48,7 +47,7 @@ class TokenEmulate(AuthAPIView):
                             % username, status=status.HTTP_404_NOT_FOUND)
 
         # User is authenticated, username exists. Make a token for them.
-        token = get_or_create_token(username, issuer="DRF-EmulatedUser")
+        token = get_or_create_token(user, issuer="DRF-EmulatedUser")
         expireTime = token.issuedTime + secrets.TOKEN_EXPIRY_TIME
         auth_json = {
             # Extra data passed only on emulation..

--- a/api/v2/views/emulate.py
+++ b/api/v2/views/emulate.py
@@ -28,11 +28,11 @@ class TokenEmulateViewSet(ViewSet):
         username = kwargs.get('username')
         expireDate = timezone.now() + secrets.TOKEN_EXPIRY_TIME
         new_token = get_or_create_token(
-                username,
-                token_key='EMULATED-'+str(uuid4()),
-                remote_ip=self.request.META['REMOTE_ADDR'],
-                token_expire=expireDate,
-                issuer="DRF-EmulatedToken-%s" % user.username)
+            user,
+            token_key='EMULATED-' + str(uuid4()),
+            remote_ip=self.request.META['REMOTE_ADDR'],
+            token_expire=expireDate,
+            issuer="DRF-EmulatedToken-%s" % user.username)
         serialized_data = TokenSerializer(new_token, context={'request':self.request}).data
         return Response(serialized_data, status=status.HTTP_201_CREATED)
 
@@ -72,7 +72,7 @@ def emulate_session(request, username=None):
         logger.info("Emulate success, creating tokens for %s" % username)
         expireDate = timezone.now() + secrets.TOKEN_EXPIRY_TIME
         token = get_or_create_token(
-            username,
+            user,
             token_key='EMULATED-'+str(uuid4()),
             token_expire=expireDate,
             remote_ip=request.META['REMOTE_ADDR'],

--- a/features/steps/allocation_story_steps.py
+++ b/features/steps/allocation_story_steps.py
@@ -103,14 +103,15 @@ def step_impl(context):
 def step_impl(context):
     for row in context.table:
         provider_alias = context.instance[row['instance_id']]
-        context.client.get('/api/v2/emulate_session/%s' % (row['username']))
-        source_id = context.allocation_sources[row['allocation_source_id']]
+        emulate_response = context.client.get('/api/v2/emulate_session/%s' % (row['username']))
+        context.test.assertEqual(emulate_response.status_code, 201)
         name = context.allocation_sources_name[row['allocation_source_id']]
         response = context.client.post('/api/v2/instance_allocation_source',
                                        {"instance_id": provider_alias,
                                         "allocation_source_name": name})
-        assert response.status_code == 201
-    context.client.get('/api/v2/emulate_session/lenards')
+        context.test.assertEqual(response.status_code, 201)
+    unemulate_response = context.client.get('/api/v2/emulate_session/lenards')
+    context.test.assertEqual(unemulate_response.status_code, 201)
 
 
 @when('User instance runs for some days')


### PR DESCRIPTION
The recent refactor of `get_or_create_token` in `django_cyverse_auth`
changed from using a username to using `AtmosphereUser` objects.

This was not updated in the `emulate` view.

Solution: Change remaining occurrences of `username` to `user` when
calling `get_or_create_token`

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
~- [ ] If necessary, include a snippet in CHANGELOG.md~
~- [ ] New variables supported in Clank~
~- [ ] New variables committed to secrets repos~
