### PR TITLE
Problem: SizeSerializer does not "root" disk storage attribute

### DIFF
--- a/api/v2/serializers/summaries/size.py
+++ b/api/v2/serializers/summaries/size.py
@@ -17,6 +17,7 @@ class SizeSummarySerializer(serializers.HyperlinkedModelSerializer):
             'name',
             'cpu',
             'disk',
+            'root',
             'mem',
             'active',
             'start_date',


### PR DESCRIPTION
## Description

The solution offered here is included `'root'` in the summary serializer for Size.

Size has the distinction between a "root" and ephemeral storage disks associated with a _flavor_. This meant that `"disk"` for Sizes in Atmosphere were being set to `0` and this would mean they're excluded from being displayed in the user interface, Troposphere. 

Unfortunately, the Instance Details will not show anything for storage as the "size" data associated with an Instance has this omission. 

<details>

## Before the pull request

For `GET /api/v2/instances/4101ce77-352b-44fe-a8eb-701479c42700`, you see the `"root"` attribute is *not* included in `"size"`:

```
{
    "id": 34581,
    "uuid": "4101ce77-352b-44fe-a8eb-701479c42700",
    "url": "https://atmo.cyverse.org/api/v2/instances/4101ce77-352b-44fe-a8eb-701479c42700",
    "name": "Ubuntu 14_04 with Docker 1_7_x",
    "status": "suspended",
    "activity": "",
    "size": {
        "id": 140,
        "uuid": "3b9c567c-e1fe-4ef7-857a-020bd687be6a",
        "url": "https://atmo.cyverse.org/api/v2/sizes/3b9c567c-e1fe-4ef7-857a-020bd687be6a",
        "alias": "42ac57b3-49ca-40da-b523-e63a3b7b0452",
        "name": "tiny1",
        "cpu": 1,
        "disk": 0,
        "mem": 4096,
        "active": true,
        "start_date": "2017-02-24T02:00:26.100234Z",
        "end_date": null
    },
    "ip_address": "0.0.0.0",
    "shell": false,
    "vnc": false,
    "web_desktop": false,
    // ... omitted
 }
```

## After the pull request 

For `GET /api/v2/instances/4101ce77-352b-44fe-a8eb-701479c42700`, you see the `"root"` attribute is now included in `"size"`:

```
{
    "id": 32815,
    "uuid": "4101ce77-352b-44fe-a8eb-701479c42700",
    "url": "https://local.atmo.cloud/api/v2/instances/4101ce77-352b-44fe-a8eb-701479c42700",
    "name": "Ubuntu 14_04 with Docker 1_7_x",
    "status": "active",
    "activity": "",
    "size": {
        "id": 140,
        "uuid": "3b9c567c-e1fe-4ef7-857a-020bd687be6a",
        "url": "https://local.atmo.cloud/api/v2/sizes/3b9c567c-e1fe-4ef7-857a-020bd687be6a",
        "alias": "42ac57b3-49ca-40da-b523-e63a3b7b0452",
        "name": "tiny1",
        "cpu": 1,
        "disk": 0,
        "root": 30,
        "mem": 4096,
        "active": true,
        "start_date": "2017-02-24T02:00:26.100234Z",
        "end_date": null
    },
    "ip_address": "128.196.142.38",
    "shell": false,
    "vnc": false,
    "web_desktop": false,
    // ... omitted
 }
```

</details>

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~If necessary, include a snippet in CHANGELOG.md~
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
