### PR TITLE
Test imports in production environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@
 
   language: python
   python:
-    - 2.7
+    - 2.7.6
 
   env:
     - DISTRIBUTION=cyverse
@@ -36,21 +36,28 @@
     # setuptools and pip-tools are necessary for ./travis/check_properly_generated_requirements.sh
     - pip install -U pip setuptools
     - pip install pip-tools==1.9.0
-    - pip install coveralls
-    - pip install -r dev_requirements.txt
 
   before_script:
     - psql -c "CREATE USER atmosphere_db_user WITH PASSWORD 'atmosphere_db_pass' CREATEDB;" -U postgres
     - psql -c "CREATE DATABASE atmosphere_db WITH OWNER atmosphere_db_user;" -U postgres
-    - cp ./variables.ini.dist ./variables.ini
-    - patch variables.ini variables_for_testing_${DISTRIBUTION}.ini.patch
-    - ./configure
 
   script:
     - ./travis/check_properly_generated_requirements.sh
+
+    # Test production environment
+    - pip-sync requirements.txt
+    - cp ./variables.ini.dist ./variables.ini
+    - ./configure
+    - python manage.py check
+    - python manage.py makemigrations --dry-run --check
+
+    # Test development envionment
+    - patch variables.ini variables_for_testing_${DISTRIBUTION}.ini.patch
+    - ./configure
+    - pip-sync dev_requirements.txt
+    - pip install coveralls
     - coverage run manage.py test --keepdb --noinput --settings=atmosphere.settings
     - coverage run --append manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION} --settings=atmosphere.settings
-    - python manage.py makemigrations --dry-run --check
 
   after_success:
     coveralls


### PR DESCRIPTION
## Description

Our travis build should test the production setup. Prior it was only testing the development packages, because it needed those to run tests. Now we run manage.py check with the production environment, this should help us catch import errors and other mistakes given our production packages.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
