### PR TITLE
Problem: Emulate is broken

### DIFF
--- a/api/v1/views/token.py
+++ b/api/v1/views/token.py
@@ -47,7 +47,8 @@ class TokenEmulate(AuthAPIView):
                             % username, status=status.HTTP_404_NOT_FOUND)
 
         # User is authenticated, username exists. Make a token for them.
-        token = get_or_create_token(user, issuer="DRF-EmulatedUser")
+        user_to_emulate = AtmosphereUser.objects.get_by_natural_key(username)
+        token = get_or_create_token(user_to_emulate, issuer="DRF-EmulatedUser")
         expireTime = token.issuedTime + secrets.TOKEN_EXPIRY_TIME
         auth_json = {
             # Extra data passed only on emulation..


### PR DESCRIPTION
While fixing the emulate endpoint in PR #464, I broke it in a different
way. I didn't fully understand how the emulate process worked. I assumed
the `username` and the `user` were interchangeable based on the other
examples of `get_or_create_token`. But in this case the `username`
corresponded to a different user (the user to emulate), and not to the
logged-in user. As a consequence the user ended up emulating themselves.

Solution: Look up the user to emulate and pass that into the
`get_or_create_token` function.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
