### PR TITLE
Differentiate between inactive/end-dated

### DIFF
--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -549,7 +549,7 @@ class Instance(AuthAPIView):
         #       all the things that are 'inactive'
         try:
             provider = Provider.objects.get(uuid=provider_uuid)
-            if not provider.is_active():
+            if not provider.is_current():
                 raise ProviderNotActive(provider)
         except Provider.DoesNotExist:
             return invalid_creds(provider_uuid, identity_uuid)

--- a/api/v2/serializers/details/image_version.py
+++ b/api/v2/serializers/details/image_version.py
@@ -63,11 +63,11 @@ class ImageVersionSerializer(serializers.HyperlinkedModelSerializer):
         """
         user = self.context['request'].user
 
-        filtered = obj.machines
+        filtered = obj.machines.filter(Q(instance_source__provider__active=True))
         if isinstance(user, AnonymousUser):
-            filtered = obj.machines.filter(Q(instance_source__provider__public=True))
+            filtered = filtered.filter(Q(instance_source__provider__public=True))
         elif not user.is_staff:
-            filtered = obj.machines.filter(Q(instance_source__provider_id__in=user.provider_ids()))
+            filtered = filtered.filter(Q(instance_source__provider_id__in=user.provider_ids()))
         serializer = ProviderMachineSummarySerializer(
            filtered,
            context=self.context,

--- a/api/v2/views/project_volume.py
+++ b/api/v2/views/project_volume.py
@@ -2,7 +2,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from core.models import Volume
-
+from core.query import only_current_source
 from api.v2.serializers.details import ProjectVolumeSerializer
 from api.v2.views.base import AuthModelViewSet
 
@@ -23,13 +23,6 @@ class ProjectVolumeViewSet(AuthModelViewSet):
         """
         user = self.request.user
         now = timezone.now()
-        # TODO: Refactor -- core.query
         return Volume.objects.filter(
-            Q(instance_source__end_date__gt=now)
-            | Q(instance_source__end_date__isnull=True),
-            Q(instance_source__provider__end_date__gt=now)
-            | Q(instance_source__provider__end_date__isnull=True),
-            instance_source__provider__active=True,
-            instance_source__start_date__lt=now,
-            instance_source__provider__start_date__lt=now,
+            only_current_source(),
             project__owner__user=user)

--- a/api/v2/views/provider_machine.py
+++ b/api/v2/views/provider_machine.py
@@ -126,5 +126,6 @@ class ProviderMachineViewSet(MultipleFieldLookup, OwnerUpdateViewSet):
             '-instance_source__start_date')
 
         if not isinstance(request_user, AnonymousUser):
-            queryset = queryset.filter(in_provider_list(request_user.current_providers))
+            launchable_providers = request_user.current_providers.filter(active=True)
+            queryset = queryset.filter(in_provider_list(launchable_providers))
         return queryset

--- a/core/models/group.py
+++ b/core/models/group.py
@@ -22,7 +22,7 @@ from core.models.quota import Quota
 from core.models.user import AtmosphereUser
 
 from core.query import (
-        only_current, only_active_memberships, only_active_provider, only_current_provider
+        only_current, only_active_memberships, only_current_provider
     )
 
 
@@ -93,7 +93,7 @@ class Group(DjangoGroup):
 
     @property
     def current_identities(self):
-        return Identity.shared_with_group(self).filter(only_current_provider(), only_active_provider())
+        return Identity.shared_with_group(self).filter(only_current_provider())
 
     @property
     def current_providers(self):

--- a/core/models/provider.py
+++ b/core/models/provider.py
@@ -203,7 +203,23 @@ class Provider(models.Model):
     def get_type_name(self):
         return self.type.name
 
+    def is_current(self):
+        """
+        Is current when:
+        - No end date present
+        - End date is earlier than 'now'
+        """
+        if not self.end_date:
+            return True
+        now = timezone.now()
+        return self.end_date < now
+
     def is_active(self):
+        """
+        Is active when:
+        - No end date present OR end date is earlier than now
+        - active' == True
+        """
         if not self.active:
             return False
         if self.end_date:

--- a/core/models/provider.py
+++ b/core/models/provider.py
@@ -207,18 +207,20 @@ class Provider(models.Model):
         """
         Is current when:
         - No end date present
-        - End date is earlier than 'now'
+        - End date is later than 'now'
         """
-        if not self.end_date:
-            return True
         now = timezone.now()
-        return self.end_date < now
+        return (not self.end_date) or (self.end_date >= now)
 
     def is_active(self):
         """
         Is active when:
         - No end date present OR end date is earlier than now
         - active' == True
+
+        NOTE: Due to how the API handles end-dated providers
+        It is possible that `self.active` is True
+         and `self.is_active()` is False.
         """
         if not self.active:
             return False

--- a/core/query.py
+++ b/core/query.py
@@ -58,7 +58,6 @@ def only_current_provider(now_time=None):
         now_time = timezone.now()
     return (Q(provider__end_date__isnull=True) |
             Q(provider__end_date__gt=now_time)) &\
-        Q(provider__active=True) &\
         Q(provider__start_date__lt=now_time)
 
 
@@ -71,8 +70,7 @@ def only_current_instances(now_time=None, restrict_start=False):
         An instance.source is active if the provider is active and un-end-dated.
         """
         return (Q(source__provider__end_date__isnull=True) |
-                Q(source__provider__end_date__gt=now_time)) &\
-            Q(source__provider__active=True)
+                Q(source__provider__end_date__gt=now_time))
 
     if not now_time:
         now_time = timezone.now()
@@ -175,10 +173,9 @@ def only_current_source(now_time=None):
     """
     Filters the current instance_sources.
     """
-    def _active_provider():
+    def current_provider():
         return (Q(instance_source__provider__end_date__isnull=True) |
-                Q(instance_source__provider__end_date__gt=now_time)) &\
-            Q(instance_source__provider__active=True)
+                Q(instance_source__provider__end_date__gt=now_time))
 
     def _in_range():
         return (Q(instance_source__end_date__isnull=True) |
@@ -187,7 +184,7 @@ def only_current_source(now_time=None):
 
     if not now_time:
         now_time = timezone.now()
-    return _in_range() & _active_provider()
+    return _in_range() & current_provider()
 
 
 def only_public_providers(now_time=None):

--- a/service/driver.py
+++ b/service/driver.py
@@ -219,7 +219,7 @@ def get_esh_provider(core_provider, username=None):
 def get_esh_driver(core_identity, username=None, identity_kwargs={}, **kwargs):
     try:
         core_provider = core_identity.provider
-        if not core_provider.is_active():
+        if not core_provider.is_current():
             raise ProviderNotActive(core_identity.provider)
         esh_map = get_esh_map(core_provider)
         if not username:

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -52,9 +52,11 @@ class InstanceLaunchConflict(ServiceException):
 
 
 class InstanceDoesNotExist(ServiceException):
+    message = "Instance does not exist"
 
     def __init__(self, instance_id):
-        self.message = instance_id
+        if instance_id:
+            self.message = instance_id
         self.status_code = 404
         super(InstanceDoesNotExist, self).__init__()
 

--- a/service/instance.py
+++ b/service/instance.py
@@ -40,6 +40,7 @@ from core.models.size import convert_esh_size
 from core.models.machine import ProviderMachine
 from core.models.volume import convert_esh_volume
 from core.models.provider import AccountProvider, Provider, ProviderInstanceAction
+from core.exceptions import ProviderNotActive
 
 from atmosphere import settings
 from atmosphere.settings import secrets
@@ -859,6 +860,8 @@ def launch_instance(user, identity_uuid,
          "Request Received"))
     identity = CoreIdentity.objects.get(uuid=identity_uuid)
     provider = identity.provider
+    if not provider.is_active():
+        raise ProviderNotActive(provider)
 
     esh_driver = get_cached_driver(identity=identity)
 

--- a/service/task.py
+++ b/service/task.py
@@ -58,7 +58,7 @@ def add_floating_ip_task(driver, instance, *args, **kwargs):
 
 def destroy_instance_task(user, instance, identity_uuid, *args, **kwargs):
     if not instance:
-        raise InstanceDoesNotExist(instance_id=instance.alias)
+        raise InstanceDoesNotExist()
     return destroy_instance.delay(
         instance.alias, user, identity_uuid, *args, **kwargs)
 


### PR DESCRIPTION
## Differentiate between inactive/end-dated providers

### End-Dated providers:
End-dated providers are not visible within the GUI/API (Archived)
To include end-dated providers in API responses use '?archived=True'
End-dated providers will throw ProviderNotActive exception.

### Inactive providers:
Inactive providers are visible with the GUI/API
Inactive providers _are not available for instance launch_ within the GUI/API
Inactive providers can still have drivers created.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
