### PR TITLE
Revert to previous return None, which is serializable

### DIFF
--- a/service/instance.py
+++ b/service/instance.py
@@ -443,7 +443,7 @@ def redeploy_instance(
     deploy_chain = get_idempotent_deploy_chain(
         esh_driver.__class__, esh_driver.provider, esh_driver.identity,
         esh_instance, core_identity, core_identity.created_by.username)
-    return deploy_chain.apply_async()
+    deploy_chain.apply_async()
 
 
 def restore_ip_chain(esh_driver, esh_instance, redeploy=False,


### PR DESCRIPTION
Problem:
api was trying to render an AsyncResult into a template, which is not serializable

Solution:
revert to prior functionality which returned None, which is serializable

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
