### PR TITLE
Problem: Migration potentially broken

### DIFF
--- a/core/migrations/0092_set_unknown_size_instance_status_history.py
+++ b/core/migrations/0092_set_unknown_size_instance_status_history.py
@@ -7,16 +7,16 @@ from django.db import migrations
 
 def set_unknown_size_entries(apps, schema_editor):
     InstanceStatusHistory = apps.get_model("core", "InstanceStatusHistory")
-    Size = apps.get_model("core", "Size")
 
     for instance_history_entry in InstanceStatusHistory.objects.filter(size__isnull=True):
         provider = instance_history_entry.instance.created_by_identity.provider
-        unknown_size = get_unknown_for_provider(provider)
+        unknown_size = get_unknown_for_provider(apps, provider)
         instance_history_entry.size = unknown_size
         instance_history_entry.save()
 
 
-def get_unknown_for_provider(provider):
+def get_unknown_for_provider(apps, provider):
+    Size = apps.get_model("core", "Size")
     unknown_size = Size.objects.filter(provider=provider, name__iexact='unknown').first()
     if not unknown_size:
         unknown_size = Size.objects.create(


### PR DESCRIPTION
`Size` is not in scope where it is referenced.

Solution: Move its instantiation into the `get_unknown_for_provider`
function where it is used.

@steve-gregory Could you please check this?

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
