### PR TITLE
v27 fix admin emails

### DIFF
--- a/core/email.py
+++ b/core/email.py
@@ -295,7 +295,7 @@ def send_approved_resource_email(user, request, reason):
     sender = email_address_str(from_name, from_email)
 
     return send_email_template(subject, template, recipients, sender,
-                               context=context, cc=[sender])
+                               context=context, cc=[sender], html=False)
 
 
 def send_denied_resource_email(user, request, reason):
@@ -319,7 +319,7 @@ def send_denied_resource_email(user, request, reason):
     sender = email_address_str(from_name, from_email)
 
     return send_email_template(subject, template, recipients, sender,
-                               context=context, cc=[sender])
+                               context=context, cc=[sender], html=False)
 
 
 def send_instance_email(username, instance_id, instance_name,

--- a/core/email.py
+++ b/core/email.py
@@ -42,7 +42,7 @@ def send_email_template(subject, template, recipients, sender,
         "fail_silently": silent,
         "html": html
     }
-    return send_email.si(*args, **kwargs)
+    return send_email.delay(*args, **kwargs)
 
 
 def email_address_str(name, email):

--- a/core/email.py
+++ b/core/email.py
@@ -578,11 +578,8 @@ def resource_request_email(request, username, quota, reason, options={}):
     admin_url = reverse('admin:core_identitymembership_change',
                         args=(membership.id,))
 
-    # TODO: To enable joseph's admin_url this will need to be uncommented
-    # See https://pods.iplantcollaborative.org/jira/browse/ATMO-1155
-    #
-    # if 'admin_url' in options:
-    #     admin_url = options['admin_url']
+    if 'admin_url' in options:
+        admin_url = options['admin_url']
 
     subject = "Atmosphere Resource Request - %s" % username
     context = {


### PR DESCRIPTION
## Description
**Problems:**
1. emails have no newlines
2. rt links to the wrong url to address the request

**Solutions:**
1. don't send emails as html, when they are actually plaintext
2. link to the proper url supplied by atmosphere

#### solution 1
<img width="938" alt="screen shot 2017-08-22 at 1 01 02 pm" src="https://user-images.githubusercontent.com/3847314/29584943-31f87100-873a-11e7-9c25-3e5abef7773d.png">

#### solution 2
<img width="1060" alt="screen shot 2017-08-22 at 1 03 32 pm" src="https://user-images.githubusercontent.com/3847314/29585005-69ae75ae-873a-11e7-8e0a-d115b9bd37af.png">

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
