### PR TITLE
Ensure visibility handled consistently for images

### DIFF
--- a/core/models/application.py
+++ b/core/models/application.py
@@ -234,7 +234,7 @@ class Application(models.Model):
         so the value must be flipped internally.
         """
         is_public = not is_private
-        self.update_images(visibility='public' if is_public else 'private')
+        self.update_images(visibility='public' if is_public else 'shared')
         self.private = is_private
         self.save()
 

--- a/service/machine.py
+++ b/service/machine.py
@@ -216,7 +216,7 @@ def upload_privacy_data(machine_request, new_machine):
 
     if is_public:
         print "Marking image %s private" % img.id
-        accounts.image_manager.update_image(img, visibility='private')
+        accounts.image_manager.update_image(img, visibility='shared')
 
     accounts.clear_cache()
     admin_driver = accounts.admin_driver  # cache has been cleared

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -901,7 +901,7 @@ def _share_image(account_driver, cloud_machine, identity, members, dry_run=False
     cloud_machine_is_public = cloud_machine.is_public if hasattr(cloud_machine,'is_public') else cloud_machine.get('visibility','') == 'public'
     if cloud_machine_is_public == True:
         celery_logger.info("Making Machine %s private" % cloud_machine.id)
-        account_driver.image_manager.glance.images.update(cloud_machine.id, visibility='private')
+        account_driver.image_manager.glance.images.update(cloud_machine.id, visibility='shared')
 
     celery_logger.info("Sharing image %s<%s>: %s with %s" % (cloud_machine.id, cloud_machine.name, identity.provider.location, tenant_name.value))
     if not dry_run:


### PR DESCRIPTION
## Description

This work ensures that we mark private images as "shared" (=> you + admin).

With changes made to handle group ownership, images that were "private" are considered "shared"; the explanation is that they're shared with a user (you) and the admin - always. So a private or shared with specific user image are both treated as "shared" within the glance catalog (I
think).

This is noted and captured here as a fix for issue related to imaging encountered during a verification of "private" images, and this updated semantic is required.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~If necessary, include a snippet in CHANGELOG.md~
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
