### PR TITLE
Problem: Want to reset renewal date for allocation sources

### DIFF
--- a/scripts/force_renew_allocation_sources.py
+++ b/scripts/force_renew_allocation_sources.py
@@ -1,0 +1,19 @@
+import argparse
+
+import django
+
+django.setup()
+
+from cyverse_allocation.tasks import renew_allocation_sources
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true', help='Print output rather than perform operation')
+    parser.set_defaults(dry_run=False)
+    args = parser.parse_args()
+    renew_allocation_sources(renewal_strategy='default', ignore_current_compute_allowed=True, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Solution: Tweak existing functions to allow overriding `compute_allowed`
and add a script which calls `renew_allocation_sources` for all
allocation sources with `default` strategy.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
