### PR TITLE
Problem: Manual uWSGI reload in dev environment - Nope

### DIFF
--- a/extras/uwsgi/atmo.uwsgi.ini.j2
+++ b/extras/uwsgi/atmo.uwsgi.ini.j2
@@ -14,6 +14,7 @@ gid = {{ UWSGI_GROUP }}
 buffer-size = 8192
 {% if LOCAL_DEV -%}
 chmod-socket = 776
+python-autoreload = 1
 {% endif -%}
 vacuum = true
 max-requests = 10


### PR DESCRIPTION
Solution: Use `LOCAL_DEV: True` variable to enable uWSGI
`python-autoreload` feature.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
