### PR TITLE
Problem: OpenstackLoginBackend fails after new account creation logic

### DIFF
--- a/api/tests/v2/test_allocation_sources.py
+++ b/api/tests/v2/test_allocation_sources.py
@@ -1,4 +1,6 @@
+import decimal
 import itertools
+import uuid
 from unittest import skip
 from django.core import urlresolvers
 from rest_framework.test import APIClient, APIRequestFactory
@@ -8,6 +10,7 @@ from api.tests.factories import (
     UserFactory, AnonymousUserFactory, IdentityFactory, ProviderFactory, AllocationSourceFactory,
     UserAllocationSourceFactory
 )
+from cyverse_allocation.tasks import update_snapshot_cyverse
 from .base import APISanityTestCase
 from api.v2.views import AllocationSourceViewSet as ViewSet
 
@@ -54,6 +57,45 @@ class AllocationSourceTests(APITestCase, APISanityTestCase):
             'compute_allowed': 9000
         }
         self.assertDictContainsSubset(expected_values, allocation_source.__dict__)
+
+    def test_can_create_infinite_allocation_source(self):
+        """Can I create an allocation source with infinite compute_allowed"""
+        client = APIClient()
+        client.force_authenticate(user=self.user_without_sources)
+        payload = {
+            'uuid': str(uuid.uuid4()),
+            'allocation_source_name': 'TG-INF990002',
+            'compute_allowed': -1,
+            'renewal_strategy': 'default'}
+
+        from core.models import EventTable, AllocationSource, AllocationSourceSnapshot
+        creation_event = EventTable(
+            name='allocation_source_created_or_renewed',
+            entity_id=payload['allocation_source_name'],
+            payload=payload)
+
+        creation_event.save()
+
+        allocation_source = AllocationSource.objects.get(name='TG-INF990002')
+        expected_values = {
+            'name': 'TG-INF990002',
+            'compute_allowed': -1
+        }
+        self.assertDictContainsSubset(expected_values, allocation_source.__dict__)
+        assert isinstance(allocation_source, AllocationSource)
+        self.assertEqual(allocation_source.compute_allowed, -1)
+        update_snapshot_cyverse()
+        self.assertEqual(allocation_source.time_remaining(), decimal.Decimal('Infinity'))
+        self.assertEqual(allocation_source.is_over_allocation(), False)
+        allocation_snapshot = allocation_source.snapshot
+        assert isinstance(allocation_snapshot, AllocationSourceSnapshot)
+        self.assertEqual(allocation_snapshot.compute_allowed, -1)
+        self.assertEqual(allocation_snapshot.compute_used, 0)
+        allocation_snapshot.compute_used = 9999999
+        allocation_snapshot.save()
+        self.assertEqual(allocation_source.time_remaining(), decimal.Decimal('Infinity'))
+        self.assertEqual(allocation_source.is_over_allocation(), False)
+
 
     def test_anonymous_user_cant_see_allocation_sources(self):
         request_factory = APIRequestFactory()

--- a/api/v2/serializers/post/token_update.py
+++ b/api/v2/serializers/post/token_update.py
@@ -84,8 +84,8 @@ class TokenUpdateSerializer(serializers.ModelSerializer):
         quota = None
         # FIXME: In a different PR re-work quota to sync based on the values in OpenStack.
         # otherwise the value assigned (default) will differ from the users _actual_ quota in openstack and artificially limit the account.
-        identity = Identity._create_identity(
-            user, group, provider, quota, credentials)
+        identity = Identity.build_account(
+            user.username, group.name, username, provider.location, quota, **credentials)
         self.validate_token_with_driver(provider_uuid, username, project_name, token)
         return identity
 

--- a/api/v2/serializers/post/token_update.py
+++ b/api/v2/serializers/post/token_update.py
@@ -35,12 +35,13 @@ class TokenUpdateSerializer(serializers.ModelSerializer):
         identity = self._find_identity_match(validated_data['provider'], username, validated_data['project_name'])
         user = AtmosphereUser.objects.filter(username=atmosphere_username).first()
         if not user:
-                raise serializers.ValidationError(
-                    "User %s does not exist and should be created before token update." % atmosphere_username)
+           raise serializers.ValidationError(
+               "User %s does not exist and should be created before token update." % atmosphere_username)
         group = Group.objects.filter(name=atmosphere_username).first()
         if not group:
-                raise serializers.ValidationError(
-                    "Group %s does not exist and should be created before token update." % atmosphere_username)
+            group = Group.objects.create(name=atmosphere_username)
+            # raise serializers.ValidationError(
+            #     "Group %s does not exist and should be created before token update." % atmosphere_username)
 
         provider_uuid = validated_data['provider']
         if not identity:

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -144,6 +144,11 @@ AUTO_CREATE_NEW_ACCOUNTS = True
 {%- else %}
 AUTO_CREATE_NEW_ACCOUNTS = False
 {%- endif %}
+{%- if AUTO_CREATE_NEW_PROJECTS %}
+AUTO_CREATE_NEW_PROJECTS = True
+{%- else %}
+AUTO_CREATE_NEW_PROJECTS = False
+{%- endif %}
 {%- if CELERYBEAT_SCHEDULE %}
 #CELERYBEAT_SCHEDULE OVERRIDES:
   {%- for task_key, schedule in CELERYBEAT_SCHEDULE.items() %}

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -203,6 +203,11 @@ ALLOCATIONS_CELERYBEAT_SCHEDULE = {
 CELERYBEAT_SCHEDULE.update(ALLOCATIONS_CELERYBEAT_SCHEDULE)
 ALLOCATION_SOURCE_PLUGINS = ['cyverse_allocation.plugins.allocation_source.FlexibleAllocationSourcePlugin',]
 {% endif %}
+{%- if ALLOCATION_SOURCE_COMPUTE_ALLOWED %}
+ALLOCATION_SOURCE_COMPUTE_ALLOWED = {{ ALLOCATION_SOURCE_COMPUTE_ALLOWED }}
+{%- else %}
+ALLOCATION_SOURCE_COMPUTE_ALLOWED = 1000
+{%- endif %}
 # Logging
 LOGGING_LEVEL = {{ LOGGING_LEVEL | default("logging.INFO") }}
 # Logging level for dependencies.

--- a/core/models/allocation_source.py
+++ b/core/models/allocation_source.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -36,6 +38,7 @@ class AllocationSource(models.Model):
         user: If passed in *and* allocation source is 'special', calculate remaining time based on user snapshots.
 
         Will return a negative number if 'over allocation', when `compute_used` is larger than `compute_allowed`.
+        Will return Infinity if `compute_allowed` is `-1` (or any negative number)
         :return: decimal.Decimal
         :rtype: decimal.Decimal
         """
@@ -57,6 +60,8 @@ class AllocationSource(models.Model):
         else:
             compute_allowed = self.compute_allowed
             last_snapshot = self.snapshot
+        if compute_allowed < 0:
+            return decimal.Decimal('Infinity')
         compute_used = last_snapshot.compute_used if last_snapshot else 0
         remaining_compute = compute_allowed - compute_used
         return remaining_compute

--- a/cyverse_allocation/plugins/allocation_source.py
+++ b/cyverse_allocation/plugins/allocation_source.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from threepio import logger
 
@@ -63,10 +64,11 @@ def _ensure_user_allocation_source(user):
 
 
 def _create_allocation_source(name):
+    default_compute_allowed = getattr(settings, 'ALLOCATION_SOURCE_COMPUTE_ALLOWED', 168)
     payload = {
         'uuid': str(uuid.uuid4()),
         'allocation_source_name': name,
-        'compute_allowed': 168,  # TODO: Make this configurable
+        'compute_allowed': default_compute_allowed,  # TODO: Make this a plugin configurable
         'renewal_strategy': 'default'
     }
     event = EventTable(

--- a/cyverse_allocation/tasks.py
+++ b/cyverse_allocation/tasks.py
@@ -63,7 +63,7 @@ def allocation_threshold_check():
         logger.debug("CHECK_THRESHOLD is FALSE -- allocation_threshold_check task finished at %s." % datetime.now())
         return
 
-    for allocation_source in AllocationSource.objects.all():
+    for allocation_source in AllocationSource.objects.filter(compute_allowed__gte=0).all():
         snapshot = allocation_source.snapshot
         percentage_used = (snapshot.compute_used / snapshot.compute_allowed) * 100
         # check if percentage more than threshold

--- a/features/instance.features/edit_instance.feature
+++ b/features/instance.features/edit_instance.feature
@@ -37,8 +37,8 @@ Feature: Launching & editing of an instance
       | user407             | user407           |
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0            |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0            | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.000        | 0.000     |
@@ -105,8 +105,8 @@ Feature: Launching & editing of an instance
     Given a current time of '2017-02-16T07:02:00Z' with tick = False
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0.020        |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0.020        | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.020        | 1.000     |
@@ -117,8 +117,8 @@ Feature: Launching & editing of an instance
     Given a current time of '2017-02-16T08:00:00Z' with tick = False
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user407 | 0.980        |
+      | name    | compute_used | compute_allowed |
+      | user407 | 0.980        | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user407             | user407           | 0.980        | 1.000     |

--- a/features/jetstream.features/enforcing.feature
+++ b/features/jetstream.features/enforcing.feature
@@ -106,8 +106,8 @@ Feature: Enforcing allocation usage on Jetstream
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.000        | 0.000     |
@@ -141,8 +141,8 @@ Feature: Enforcing allocation usage on Jetstream
     Given a current time of '2017-02-16T07:02:00Z' with tick = False
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.020        | 1.000     |
@@ -154,8 +154,8 @@ Feature: Enforcing allocation usage on Jetstream
     Given a current time of '2017-02-16T08:00:00Z' with tick = False
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user208             | TG-BIO150062      | 0.980        | 1.000     |

--- a/features/jetstream.features/monitor_jetstream_allocation_sources.feature
+++ b/features/jetstream.features/monitor_jetstream_allocation_sources.feature
@@ -111,9 +111,9 @@ Feature: Monitor Jetstream Allocation Sources
     And we fill user allocation sources from TAS
     And we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-ENG150061 | 781768.010   |
-      | TG-TRA160006 | 87914.060    |
+      | name         | compute_used | compute_allowed |
+      | TG-ENG150061 | 781768.010   | 1000000         |
+      | TG-TRA160006 | 87914.060    | 600000          |
 
 
   Scenario: Correct events, with no duplicates when checking twice

--- a/features/jetstream.features/special_allocation.feature
+++ b/features/jetstream.features/special_allocation.feature
@@ -86,8 +86,8 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-ASC160018 | 3000001.100  |
+      | name         | compute_used | compute_allowed |
+      | TG-ASC160018 | 3000001.100  | 5000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user110             | TG-ASC160018      | 0.000        | 0.000     |
@@ -150,8 +150,8 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-BIO150062 | 781768.01    |
+      | name         | compute_used | compute_allowed |
+      | TG-BIO150062 | 781768.01    | 1000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user108             | TG-BIO150062      | 0.000        | 0.000     |
@@ -195,9 +195,9 @@ Feature: Special Allocations
 
     When we update snapshots
     Then we should have the following allocation source snapshots
-      | name         | compute_used |
-      | TG-TRA160003 | 87914.06     |
-      | TG-ASC160018 | 3000001.100  |
+      | name         | compute_used | compute_allowed |
+      | TG-TRA160003 | 87914.06     | 600000          |
+      | TG-ASC160018 | 3000001.100  | 5000000         |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user111             | TG-TRA160003      | 0.000        | 0.000     |

--- a/features/steps/tas_api_steps.py
+++ b/features/steps/tas_api_steps.py
@@ -164,18 +164,18 @@ def update_snapshots(context):
 def should_have_allocation_sources(context):
     expected_allocation_sources = dict((row.cells[0], Decimal(row.cells[1]),) for row in context.table)
     from core.models import AllocationSource
-    allocation_sources = {item['name']: item['compute_allowed'] for item in
-                          AllocationSource.objects.all().order_by('name').values('name', 'compute_allowed')}
+    allocation_sources = {item.name: item.compute_allowed for item in
+                          AllocationSource.objects.all().order_by('name')}
     context.test.assertDictEqual(expected_allocation_sources, allocation_sources)
 
 
 @then(u'we should have the following allocation source snapshots')
 def should_have_allocation_source_snapshots(context):
-    expected_allocation_source_snapshots = dict((row.cells[0], Decimal(row.cells[1]),) for row in context.table)
+    expected_allocation_source_snapshots = dict(
+        (row.cells[0], [Decimal(row.cells[1]), Decimal(row.cells[2])],) for row in context.table)
     from core.models import AllocationSourceSnapshot
-    allocation_source_snapshots = {item['allocation_source__name']: item['compute_used'] for item in
-                                   AllocationSourceSnapshot.objects.all().values('allocation_source__name',
-                                                                                 'compute_used')}
+    allocation_source_snapshots = {item.allocation_source.name: [item.compute_used, item.compute_allowed] for item in
+                                   AllocationSourceSnapshot.objects.select_related('allocation_source').all()}
     context.test.assertDictEqual(expected_allocation_source_snapshots, allocation_source_snapshots)
 
 

--- a/features/volume.features/create_and_edit_volume.feature
+++ b/features/volume.features/create_and_edit_volume.feature
@@ -38,8 +38,8 @@ Feature: Create volume and add to projects
       | user607             | user607           |
     When we update CyVerse snapshots
     Then we should have the following allocation source snapshots
-      | name    | compute_used |
-      | user607 | 0            |
+      | name    | compute_used | compute_allowed |
+      | user607 | 0            | 168             |
     And we should have the following user allocation source snapshots
       | atmosphere_username | allocation_source | compute_used | burn_rate |
       | user607             | user607           | 0.000        | 0.000     |

--- a/service/instance.py
+++ b/service/instance.py
@@ -1605,8 +1605,8 @@ def user_network_init(core_identity):
         username = core_identity.created_by.username
     esh_driver = get_cached_driver(identity=core_identity)
     dns_nameservers = core_identity.provider.get_config('network', 'dns_nameservers', [])
-    subnet_pool_id = core_identity.provider.get_config('network', 'subnet_pool_id', None)
-    topology_name = core_identity.provider.get_config('network', 'topology', None)
+    subnet_pool_id = core_identity.provider.get_config('network', 'subnet_pool_id', raise_exc=False)
+    topology_name = core_identity.provider.get_config('network', 'topology', raise_exc=False)
     if not topology_name:
         logger.error(
             "Network topology not selected -- "

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -80,6 +80,7 @@ TESTING =  False # Boolean required
 #local.py - site configuration
 AUTO_CREATE_NEW_ACCOUNTS =  False # Boolean required
 AUTO_CREATE_NEW_PROJECTS =  False # Boolean required
+ALLOCATION_SOURCE_COMPUTE_ALLOWED =  168 # Boolean required
 USE_JETSTREAM_PLUGIN =  False # Boolean required
 TIME_ZONE = # America/Phoenix
 SITE_NAME = # CyVerse

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -79,6 +79,7 @@ SELF_SIGNED_CERT =  False # Boolean required
 TESTING =  False # Boolean required
 #local.py - site configuration
 AUTO_CREATE_NEW_ACCOUNTS =  False # Boolean required
+AUTO_CREATE_NEW_PROJECTS =  False # Boolean required
 USE_JETSTREAM_PLUGIN =  False # Boolean required
 TIME_ZONE = # America/Phoenix
 SITE_NAME = # CyVerse


### PR DESCRIPTION
## Solution:
- Update the AccountCreationPlugin topology to better explain which plugin to use, and why.
- Continue with a simple approach that uses `/token_update` to do all of the heavy lifting
- Create a new 'AccountCreationPlugin' (DirectLogin) and include the ability to auto-create a new projects for the user  as part of the plugins settings.
- New settings available: `ALLOCATION_SOURCE_COMPUTE_ALLOWED`, `AUTO_CREATE_NEW_PROJECTS`

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [x] [New variables supported in Clank](https://github.com/cyverse/clank/pull/211)
- [x] New variables committed to secrets repos
- [ ] [Reviewed and approved the Troposphere Companion PR for Unlimited AU support.](https://github.com/cyverse/troposphere/pull/708)