### PR TITLE
Problem: Legacy libcloud deployments mixed in with ansible

### DIFF
--- a/atmosphere/celery_router.py
+++ b/atmosphere/celery_router.py
@@ -25,15 +25,18 @@ DEPLOY_TASKS = [
     "_deploy_instance_for_user",
     "check_web_desktop_task",
     "_deploy_init_to", "service.tasks.driver._deploy_init_to",
-    "deploy_ready_test", "service.tasks.driver.deploy_ready_test", 
-    "check_process_task", "service.tasks.driver.check_process_task", 
+    "deploy_ready_test", "service.tasks.driver.deploy_ready_test",
+    "check_process_task", "service.tasks.driver.check_process_task",
+    "check_volume_task", "service.tasks.volume.check_volume_task",
+    "mount_volume_task", "service.tasks.volume.mount_volume_task",
+    "unmount_volume_task", "service.tasks.volume.unmount_volume_task"
 ]
 EMAIL_TASKS = [
     "send_email", "core.tasks.email.send_email",
 ]
 IMAGING_TASKS = [
     # Atmosphere specific
-    "freeze_instance_task", "service.tasks.machine.freeze_instance_task",
+    "prep_instance_for_snapshot", "service.tasks.machine.prep_instance_for_snapshot",
     "process_request", "service.tasks.machine.process_request",
     "imaging_complete", "validate_new_image",
     # Chromogenic
@@ -41,7 +44,6 @@ IMAGING_TASKS = [
     "machine_imaging_task", "chromogenic.tasks.machine_imaging_task",
     "chromogenic.tasks.migrate_instance_task",
     "chromogenic.tasks.machine_imaging_task",
-    "service.tasks.machine.freeze_instance_task",
     "service.tasks.machine.process_request",
 
 ]

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -168,7 +168,7 @@ smmap2==2.0.3             # via gitdb2
 splinter==0.7.6           # via behaving
 sqlparse==0.2.3           # via django-debug-toolbar
 stevedore==1.25.0
-subspace==0.4.1
+subspace==0.5
 threepio==0.2.0
 tornado==4.5.1
 traitlets==4.3.2          # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ simplejson==3.11.1        # via osc-lib, python-cinderclient, python-neutronclie
 singledispatch==3.4.0.3   # via tornado
 six==1.10.0               # via bcrypt, cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, pynacl, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, python-swiftclient, singledispatch, stevedore, warlock
 stevedore==1.25.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
-subspace==0.4.1
+subspace==0.5
 threepio==0.2.0
 tornado==4.5.1            # via flower
 unicodecsv==0.14.1        # via cliff, djangorestframework-csv

--- a/service/instance.py
+++ b/service/instance.py
@@ -379,17 +379,12 @@ def resize_and_redeploy(esh_driver, esh_instance, core_identity_uuid):
     """
     from service.tasks.driver import deploy_init_to
     from service.tasks.driver import wait_for_instance, complete_resize
-    from service.deploy import deploy_test
-    touch_script = deploy_test()
     core_identity = CoreIdentity.objects.get(uuid=core_identity_uuid)
 
     task_one = wait_for_instance.s(
         esh_instance.id, esh_driver.__class__, esh_driver.provider,
         esh_driver.identity, "verify_resize")
     raise Exception("Programmer -- Fix this method based on the TODO")
-    # task_two = deploy_script.si(
-    #     esh_driver.__class__, esh_driver.provider,
-    #     esh_driver.identity, esh_instance.id, touch_script)
     task_three = complete_resize.si(
         esh_driver.__class__, esh_driver.provider,
         esh_driver.identity, esh_instance.id,
@@ -1952,16 +1947,16 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
                 'a volume. (Current: %s)'
                 'Retry request when instance is active.'
                 % (instance_id, instance_status))
-        result = task.attach_volume_task(
+        result = task.attach_volume(
                 identity, esh_driver, esh_instance.alias,
                 volume_id, device_location, mount_location)
     elif 'mount_volume' == action_type:
-        result = task.mount_volume_task(
+        result = task.mount_volume(
                 identity, esh_driver, esh_instance.alias,
                 volume_id, device_location, mount_location)
     elif 'unmount_volume' == action_type:
         (result, error_msg) =\
-            task.unmount_volume_task(esh_driver,
+            task.unmount_volume(esh_driver,
                                      esh_instance.alias,
                                      volume_id, device_location,
                                      mount_location)
@@ -1974,7 +1969,7 @@ def run_instance_volume_action(user, identity, esh_driver, esh_instance, action_
                 'Retry request when instance is active.'
                 % (instance_id, instance_status))
         (result, error_msg) =\
-            task.detach_volume_task(esh_driver,
+            task.detach_volume(esh_driver,
                                     esh_instance.alias,
                                     volume_id)
         if not result and error_msg:

--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -4,7 +4,7 @@ Tasks for volume operations.
 import re
 import time
 
-from datetime import datetime
+from django.utils import timezone
 
 from celery import current_app as app
 from celery.result import allow_join_result
@@ -13,17 +13,16 @@ from celery import chain
 
 from threepio import celery_logger
 from rtwo.driver import EucaDriver, OSDriver
-from rtwo.exceptions import LibcloudDeploymentError
 
 from atmosphere.settings.local import ATMOSPHERE_PRIVATE_KEYFILE
 
 from service.driver import get_driver
 from service.deploy import (
-    mount_volume,
-    check_mount, umount_volume, lsof_location,
-    deploy_check_volume, deploy_mount_volume,
+    deploy_check_volume, deploy_mount_volume, deploy_unmount_volume,
     build_host_name, execution_has_failures, execution_has_unreachable)
 from service.exceptions import DeviceBusyException
+
+# Ansible deployment tasks
 
 
 @task(name="check_volume_task",
@@ -33,7 +32,7 @@ from service.exceptions import DeviceBusyException
 def check_volume_task(driverCls, provider, identity,
                       instance_id, volume_id, device_type='ext4', *args, **kwargs):
     try:
-        celery_logger.debug("check_volume task started at %s." % datetime.now())
+        celery_logger.debug("check_volume task started at %s." % timezone.now())
         driver = get_driver(driverCls, provider, identity)
         instance = driver.get_instance(instance_id)
         volume = driver.get_volume(volume_id)
@@ -58,40 +57,57 @@ def check_volume_task(driverCls, provider, identity,
                 "Error encountered while checking volume for filesystem: %s"
                 % playbooks.stats.summarize(host=hostname))
         return result
-    except LibcloudDeploymentError as exc:
-        celery_logger.exception(exc)
     except Exception as exc:
         celery_logger.warn(exc)
         check_volume_task.retry(exc=exc)
 
 
-def _parse_mount_location(mount_output, device_location):
-    """
-    GENERAL ASSUMPTION:
-    Mount output is ALWAYS the same, and it looks like this:
-    <DEV_LOCATION> on <MOUNT_LOCATION> type (Disk Specs ...)
-    By splitting ' on '     AND      ' type '
-    we can always retrieve <MOUNT_LOCATION>
-    """
-    for line in mount_output.split("\n"):
-        if device_location not in line:
-            continue
-        before_text_idx = line.find(" on ") + 4
-        after_text_idx = line.find(" type ")
-        if before_text_idx == -1 or after_text_idx == -1:
-            return ""
-        return line[before_text_idx:after_text_idx]
-
-
-@task(name="mount_task",
+@task(name="unmount_volume_task",
       max_retries=0,
       default_retry_delay=20,
       ignore_result=False)
-def mount_task(driverCls, provider, identity, instance_id, volume_id,
+def unmount_volume_task(driverCls, provider, identity, instance_id, volume_id,
+               *args, **kwargs):
+    try:
+        celery_logger.debug("unmount task started at %s." % timezone.now())
+        driver = get_driver(driverCls, provider, identity)
+        username = identity.get_username()
+        instance = driver.get_instance(instance_id)
+        volume = driver.get_volume(volume_id)
+        device_location = None
+
+        try:
+            attach_data = volume.extra['attachments'][0]
+            device_location = attach_data['device']
+        except (KeyError, IndexError):
+            celery_logger.warn("Volume %s missing attachments in Extra"
+                               % (volume,))
+        if not device_location:
+            raise Exception("No device_location found or inferred by volume %s" % volume)
+        playbooks = deploy_unmount_volume(
+            instance.ip, username, instance.id, device_location)
+        hostname = build_host_name(instance.id, instance.ip)
+        result = False if execution_has_failures(playbooks, hostname)\
+            or execution_has_unreachable(playbooks, hostname) else True
+        if not result:
+            raise Exception(
+                "Error encountered while unmounting volume: %s"
+                % playbooks.stats.summarize(host=hostname))
+        return device_location
+    except Exception as exc:
+        celery_logger.warn(exc)
+        unmount_volume_task.retry(exc=exc)
+
+
+@task(name="mount_volume_task",
+      max_retries=0,
+      default_retry_delay=20,
+      ignore_result=False)
+def mount_volume_task(driverCls, provider, identity, instance_id, volume_id,
                device_location, mount_location, device_type,
                mount_prefix=None, *args, **kwargs):
     try:
-        celery_logger.debug("mount task started at %s." % datetime.now())
+        celery_logger.debug("mount task started at %s." % timezone.now())
         celery_logger.debug("mount_location: %s" % (mount_location, ))
         driver = get_driver(driverCls, provider, identity)
         username = identity.get_username()
@@ -128,75 +144,10 @@ def mount_task(driverCls, provider, identity, instance_id, volume_id,
         return mount_location
     except Exception as exc:
         celery_logger.warn(exc)
-        mount_task.retry(exc=exc)
+        mount_volume_task.retry(exc=exc)
 
 
-@task(name="umount_task",
-      max_retries=3,
-      default_retry_delay=32,
-      ignore_result=False)
-def umount_task(driverCls, provider, identity, instance_id,
-                volume_id, *args, **kwargs):
-    try:
-        celery_logger.debug("umount_task started at %s." % datetime.now())
-        driver = get_driver(driverCls, provider, identity)
-        instance = driver.get_instance(instance_id)
-        volume = driver.get_volume(volume_id)
-        attach_data = volume.extra['attachments'][0]
-        device = attach_data['device']
-
-        # Check mount to find the mount_location for device
-        private_key = "/opt/dev/atmosphere/extras/ssh/id_rsa"
-        kwargs.update({'ssh_key': private_key})
-        kwargs.update({'timeout': 120})
-
-        mount_location = None
-        cm_script = check_mount()
-        kwargs.update({'deploy': cm_script})
-        driver.deploy_to(instance, **kwargs)
-        regex = re.compile("(?P<device>[\w/]+) on (?P<location>.*) type")
-        for line in cm_script.stdout.split('\n'):
-            res = regex.search(line)
-            if not res:
-                continue
-            search_dict = res.groupdict()
-            dev_found = search_dict['device']
-            if device == dev_found:
-                mount_location = search_dict['location']
-                break
-
-        # Volume not mounted, move along..
-        if not mount_location:
-            return
-
-        um_script = umount_volume(device)
-        kwargs.update({'deploy': um_script})
-        driver.deploy_to(instance, **kwargs)
-
-        if 'is busy' in um_script.stdout:
-            # Show all processes that are making device busy..
-            lsof_script = lsof_location(mount_location)
-            kwargs.update({'deploy': lsof_script})
-            driver.deploy_to(instance, **kwargs)
-
-            regex = re.compile("(?P<name>[\w]+)\s*(?P<pid>[\d]+)")
-            offending_processes = []
-            for line in lsof_script.stdout.split('\n'):
-                res = regex.search(line)
-                if not res:
-                    continue
-                search_dict = res.groupdict()
-                offending_processes.append(
-                    (search_dict['name'], search_dict['pid']))
-
-            raise DeviceBusyException(mount_location, offending_processes)
-        # Return here if no errors occurred..
-        celery_logger.debug("umount_task finished at %s." % datetime.now())
-    except DeviceBusyException:
-        raise
-    except Exception as exc:
-        celery_logger.warn(exc)
-        umount_task.retry(exc=exc)
+# Libcloud Instance Action (Attachment) tasks
 
 
 @task(name="attach_task",
@@ -206,7 +157,7 @@ def umount_task(driverCls, provider, identity, instance_id,
 def attach_task(driverCls, provider, identity, instance_id, volume_id,
                 device_choice=None, *args, **kwargs):
     try:
-        celery_logger.debug("attach_task started at %s." % datetime.now())
+        celery_logger.debug("attach_task started at %s." % timezone.now())
         driver = get_driver(driverCls, provider, identity)
         from service.volume import attach_volume  # TODO: Test pulling this up -- out of band
         attach_volume(driver, instance_id, volume_id, device_choice=device_choice)
@@ -250,7 +201,7 @@ def attach_task(driverCls, provider, identity, instance_id, volume_id,
                         "Volume:%s Extra:%s" % (volume.id, volume.extra))
             device = None
 
-        celery_logger.debug("attach_task finished at %s." % datetime.now())
+        celery_logger.debug("attach_task finished at %s." % timezone.now())
         return device
     except Exception as exc:
         celery_logger.exception(exc)
@@ -264,7 +215,7 @@ def attach_task(driverCls, provider, identity, instance_id, volume_id,
 def detach_task(driverCls, provider, identity,
                 instance_id, volume_id, *args, **kwargs):
     try:
-        celery_logger.debug("detach_task started at %s." % datetime.now())
+        celery_logger.debug("detach_task started at %s." % timezone.now())
         driver = get_driver(driverCls, provider, identity)
         instance = driver.get_instance(instance_id)
         volume = driver.get_volume(volume_id)
@@ -297,7 +248,7 @@ def detach_task(driverCls, provider, identity,
             raise Exception("Failed to detach Volume %s to instance %s"
                             % (volume, instance))
 
-        celery_logger.debug("detach_task finished at %s." % datetime.now())
+        celery_logger.debug("detach_task finished at %s." % timezone.now())
     except DeviceBusyException:
         # We should NOT retry if the device is busy
         raise
@@ -307,6 +258,8 @@ def detach_task(driverCls, provider, identity,
             return
         celery_logger.exception(exc)
         detach_task.retry(exc=exc)
+
+# Volume metadata tasks
 
 
 @task(name="update_mount_location", max_retries=2, default_retry_delay=15)
@@ -319,7 +272,7 @@ def update_mount_location(new_mount_location,
     try:
         celery_logger.debug(
             "update_mount_location task started at %s." %
-            datetime.now())
+            timezone.now())
         driver = get_driver(driverCls, provider, identity)
         volume = driver.get_volume(volume_alias)
         if not volume:
@@ -332,7 +285,7 @@ def update_mount_location(new_mount_location,
             metadata={'mount_location': new_mount_location})
         celery_logger.debug(
             "update_mount_location task finished at %s." %
-            datetime.now())
+            timezone.now())
     except Exception as exc:
         celery_logger.exception(exc)
         update_mount_location.retry(exc=exc)
@@ -348,7 +301,7 @@ def update_volume_metadata(driverCls, provider,
     try:
         celery_logger.debug(
             "update_volume_metadata task started at %s." %
-            datetime.now())
+            timezone.now())
         driver = get_driver(driverCls, provider, identity)
         volume = driver.get_volume(volume_alias)
         if not volume:
@@ -356,12 +309,12 @@ def update_volume_metadata(driverCls, provider,
         return volume_service._update_volume_metadata(
             driver, volume,
             metadata=metadata)
-        celery_logger.debug("volume_metadata task finished at %s." % datetime.now())
+        celery_logger.debug("volume_metadata task finished at %s." % timezone.now())
     except Exception as exc:
         celery_logger.exception(exc)
         update_volume_metadata.retry(exc=exc)
 
-# Deploy and Destroy tasks
+# Exception handling tasks
 
 
 @task(name="mount_failed")
@@ -373,7 +326,7 @@ def mount_failed(
         unmount=False, **celery_task_args):
     from service import volume as volume_service
     try:
-        celery_logger.debug("mount_failed task started at %s." % datetime.now())
+        celery_logger.debug("mount_failed task started at %s." % timezone.now())
         celery_logger.info("task context=%s" % context)
         err_str = "%s\nMount Error Traceback:%s" % (exception_msg, traceback)
         celery_logger.error(err_str)
@@ -386,7 +339,25 @@ def mount_failed(
         return volume_service._update_volume_metadata(
             driver, volume,
             metadata={'tmp_status': tmp_status})
-        celery_logger.debug("mount_failed task finished at %s." % datetime.now())
+        celery_logger.debug("mount_failed task finished at %s." % timezone.now())
     except Exception as exc:
         celery_logger.warn(exc)
         mount_failed.retry(exc=exc)
+
+
+def _parse_mount_location(mount_output, device_location):
+    """
+    GENERAL ASSUMPTION:
+    Mount output is ALWAYS the same, and it looks like this:
+    <DEV_LOCATION> on <MOUNT_LOCATION> type (Disk Specs ...)
+    By splitting ' on '     AND      ' type '
+    we can always retrieve <MOUNT_LOCATION>
+    """
+    for line in mount_output.split("\n"):
+        if device_location not in line:
+            continue
+        before_text_idx = line.find(" on ") + 4
+        after_text_idx = line.find(" type ")
+        if before_text_idx == -1 or after_text_idx == -1:
+            return ""
+        return line[before_text_idx:after_text_idx]

--- a/service/tasks/volume.py
+++ b/service/tasks/volume.py
@@ -84,8 +84,12 @@ def unmount_volume_task(driverCls, provider, identity, instance_id, volume_id,
                                % (volume,))
         if not device_location:
             raise Exception("No device_location found or inferred by volume %s" % volume)
-        playbooks = deploy_unmount_volume(
-            instance.ip, username, instance.id, device_location)
+        try:
+            playbooks = deploy_unmount_volume(
+                instance.ip, username, instance.id, device_location)
+        except DeviceBusyException:
+            # Future-Fixme: Update VolumeStatusHistory.extra, set status to 'unmount_failed'
+            raise
         hostname = build_host_name(instance.id, instance.ip)
         result = False if execution_has_failures(playbooks, hostname)\
             or execution_has_unreachable(playbooks, hostname) else True


### PR DESCRIPTION
Solution: Remove libcloud deployments & replace missing scripts with ansible roles/playbooks.

## Highlight reel
- Imaging tasks to sync/freeze in playbooks/imaging
- Volume mount/unmount tasks in playbooks/instance_actions
- Update `service` to remove all references to ScriptDeploy and
  LibcloudDeployments

## Newly added!
- Use new functionality in subspace>=0.5.0 to inspect the 'register' variable
   inside of ansible. Provide hints for how `lsof` and `unmount` failures can be
   recorded for a future PR that deals with "improvements to volume status history" (link coming soon)

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [x] [New playbooks/tasks included in atmosphere-ansible](https://github.com/cyverse/atmosphere-ansible/pull/103)
