### PR TITLE
Support for django-prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ nohup.out
 .*
 #*#
 #*.*#
+atmosphere/settings/__init__.py
 atmosphere/settings/local.py
 atmosphere/settings/secrets.py
 atmosphere/settings/secret_key.py

--- a/atmosphere/settings/__init__.py.j2
+++ b/atmosphere/settings/__init__.py.j2
@@ -127,6 +127,9 @@ STATIC_URL = '/static/'
 ATMOSPHERE_NAMESPACE_UUID = UUID("40227dff-dedf-469c-a9f8-1953a7372ac1")
 
 MIDDLEWARE_CLASSES = (
+    {% if ENABLE_DJANGO_PROMETHEUS %}
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    {% endif %}
     'corsheaders.middleware.CorsMiddleware',
     # corsheaders.middleware.CorsMiddleware Must be ahead of
     # configuration CommonMiddleware for an edge case.
@@ -139,6 +142,10 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'atmosphere.slash_middleware.RemoveSlashMiddleware',
     'atmosphere.slash_middleware.RemoveCSRFMiddleware',
+    {% if ENABLE_DJANGO_PROMETHEUS %}
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
+    {% endif %}
+
 )
 
 ROOT_URLCONF = 'atmosphere.urls'

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -366,7 +366,7 @@ ANSIBLE_GROUP_VARS_DIR = os.path.join(ANSIBLE_ROOT, 'ansible/group_vars')
 ANSIBLE_PLAYBOOKS_DIR = os.path.join(ANSIBLE_ROOT, 'ansible/playbooks')
 ANSIBLE_ROLES_PATH = os.path.join(ANSIBLE_ROOT, 'ansible/roles')
 
-os.environ["ANSIBLE_CONFIG"] = ANSIBLE_CONFIG_FILE 
+os.environ["ANSIBLE_CONFIG"] = ANSIBLE_CONFIG_FILE
 
 # LOGSTASH
 {%- if LOGSTASH_HOST and LOGSTASH_PORT %}
@@ -581,3 +581,10 @@ CACHES = {
         'LOCATION': '/var/tmp/django_cache',
     }
 }
+
+# Support for django-prometheus
+{% if ENABLE_DJANGO_PROMETHEUS %}
+INSTALLED_APPS += (
+   'django_prometheus',
+)
+{% endif %}

--- a/atmosphere/urls.py
+++ b/atmosphere/urls.py
@@ -36,6 +36,10 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls))
 ]
 
+if 'django_prometheus' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^atmo-prometheus/', include('django_prometheus.urls')),
+    ]
 
 if settings.DEBUG and 'debug_toolbar.middleware.DebugToolbarMiddleware' in settings.MIDDLEWARE_CLASSES:
     try:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -45,6 +45,7 @@ django-filter==1.0.4
 django-jenkins==0.110.0
 django-memoize==2.1.0
 django-nose==1.4.4
+django-prometheus==1.0.9
 django-redis-cache==1.7.1
 django-sslserver==0.20
 django==1.11.4
@@ -120,6 +121,7 @@ pickleshare==0.7.4        # via ipython
 pillow==4.2.1
 positional==1.2.1
 prettytable==0.7.2
+prometheus-client==0.0.20
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.3
 ptyprocess==0.5.2         # via pexpect

--- a/requirements.in
+++ b/requirements.in
@@ -35,6 +35,9 @@ PyJWT
 
 python-logstash
 django-memoize
+
+django-prometheus
+
 #Theirs
 psycopg2
 python-ldap

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ appdirs==1.4.3            # via os-client-config
 asn1crypto==0.22.0        # via cryptography
 babel==2.3.4              # via flower, osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
 backports-abc==0.5        # via tornado
-backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud, tornado
+backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud
 bcrypt==3.1.3             # via paramiko
 billiard==3.5.0.3
 boto==2.39.0              # via chromogenic
@@ -35,6 +35,7 @@ django-cors-headers==2.1.0
 django-cyverse-auth==1.1.2
 django-filter==1.0.4
 django-memoize==2.1.0
+django-prometheus==1.0.9
 django-redis-cache==1.7.1
 django-sslserver==0.20
 django==1.11.4
@@ -89,6 +90,7 @@ pbr==3.1.1                # via cliff, debtcollector, keystoneauth1, openstacksd
 pillow==4.2.1
 positional==1.2.1         # via keystoneauth1, oslo.context, python-keystoneclient
 prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-irodsclient, python-novaclient
+prometheus-client==0.0.20  # via django-prometheus
 psycopg2==2.7.3
 pyasn1-modules==0.0.11    # via oauth2client
 pyasn1==0.3.2             # via oauth2client, paramiko, pyasn1-modules, rsa

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -25,6 +25,9 @@ UWSGI_USER = # www-data
 UWSGI_GROUP = # www-data
 UWSGI_LOG_PATH = # /var/log/uwsgi/atmosphere_uwsgi.log
 
+[init.py]
+ENABLE_DJANGO_PROMETHEUS = False # Boolean required
+
 [local.py]
 AUTH_USE_OVERRIDE =  True # Boolean required will override authentication set in __init__.py
 AUTH_MOCK_USER = # testuser

--- a/variables_templates.json
+++ b/variables_templates.json
@@ -26,7 +26,7 @@
           "extras/systemd/celeryd.default.dist.j2",
           "extras/systemd/celeryd.default"
         ],
-        "__init__.py": [
+        "init.py": [
           "atmosphere/settings/__init__.py.j2",
           "atmosphere/settings/__init__.py"
         ],

--- a/variables_templates.json
+++ b/variables_templates.json
@@ -26,6 +26,10 @@
           "extras/systemd/celeryd.default.dist.j2",
           "extras/systemd/celeryd.default"
         ],
+        "__init__.py": [
+          "atmosphere/settings/__init__.py.j2",
+          "atmosphere/settings/__init__.py"
+        ],
         "local.py": [
             "atmosphere/settings/local.py.j2",
             "atmosphere/settings/local.py"

--- a/variables_templates.json
+++ b/variables_templates.json
@@ -7,6 +7,9 @@
         "local.py": [
             "local.py"
         ],
+        "init.py": [
+            "init.py"
+        ],
         "nginx": [
             "nginx",
             "nginx-site",


### PR DESCRIPTION
## Description

Adds support for [django-prometheus](https://github.com/korfuri/django-prometheus) which can be conditionally enabled by the deployer.

Exports Atmosphere metrics via the `/atmo-prometheus/metrics` URL.
Co-depends on [PR #214 in clank](https://github.com/cyverse/clank/pull/214).
Haven't yet added the [model monitoring mixins](https://github.com/korfuri/django-prometheus#monitoring-your-models) but we could.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
  - [x] Tested in atmo-local to ensure Clank succesfully deploys and metrics are available at https://local.atmo.cloud/atmo-prometheus/metrics
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [x] New variables supported in Clank
- [ ] New variables committed to secrets repos
