### PR TITLE
(WIP) Problem: Django tests fail when run consecutively

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -575,9 +575,17 @@ WEB_DESKTOP = {
     }
 }
 
+{% if TESTING %}
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+{%- else %}
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
         'LOCATION': '/var/tmp/django_cache',
     }
 }
+{%- endif %}


### PR DESCRIPTION
In particular failures happen in the VCR checks for whether the
cassettes have all been played. This is because the TAS API results are
cached on disk.

Solution: Disable caching when testing by using the `DummyCache` backend

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
