### PR TITLE
Problem: Spurious 'IOError' in Sentry

### DIFF
--- a/extras/uwsgi/atmo.uwsgi.ini.j2
+++ b/extras/uwsgi/atmo.uwsgi.ini.j2
@@ -18,3 +18,6 @@ chmod-socket = 776
 vacuum = true
 max-requests = 10
 daemonize = {{ UWSGI_LOG_PATH }}
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true


### PR DESCRIPTION
Thousands of them. Very noisy.

See https://github.com/getsentry/raven-python/issues/732

Solution: Add some exclusions to `atmo.uwsgi.ini` template as
recommended by GitHub issue above.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Keep an eye on atmobeta and see if this stops appearing in Sentry
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
