### PR TITLE
Problem: `behave` is very verbose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ static/*
 extras/euca/*
 extras/goodies/*
 extras/init.d/celeryd.default
+extras/systemd/celeryd.default
 extras/install-scripts/*
 extras/sql/*
 extras/ssh/*
@@ -56,3 +57,4 @@ scratch
 .coverage
 coverage.xml
 htmlcov/
+rerun_failing.features

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@
   script:
     - ./travis/check_properly_generated_requirements.sh
     - coverage run manage.py test --keepdb --noinput --settings=atmosphere.settings
-    - coverage run --append manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION} --settings=atmosphere.settings
+    - coverage run --append manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION} --settings=atmosphere.settings --format rerun --outfile rerun_failing.features
+    - if [ -f "rerun_failing.features" ]; then python manage.py behave --logging-level DEBUG --capture-stderr --capture --verbosity 3 --keepdb @rerun_failing.features; fi
     - python manage.py makemigrations --dry-run --check
 
   after_success:

--- a/run_tests_like_travis.sh
+++ b/run_tests_like_travis.sh
@@ -33,8 +33,11 @@ ${SUDO_POSTGRES} createdb --owner=atmosphere_db_user atmosphere_db
 cp ./variables.ini.dist ./variables.ini
 patch variables.ini variables_for_testing_${DISTRIBUTION}.ini.patch
 ./configure
-#./travis/check_properly_generated_requirements.sh
+./travis/check_properly_generated_requirements.sh
 
 python manage.py test --keepdb
-python manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION}
+rm -f rerun_failing.features
+python manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION} --format rerun --outfile rerun_failing.features
+if [ -f "rerun_failing.features" ]; then python manage.py behave --logging-level DEBUG --capture-stderr --capture --verbosity 3 --keepdb @rerun_failing.features; fi
+
 python manage.py makemigrations --dry-run --check


### PR DESCRIPTION
We really just want to see the failing scenarios.

Solution:
- Use the `rerun` output format
- Output to a file instead of `stdout`
- Add line to run failed scenarios in the new file (if any)

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
