### PR TITLE
Problem: Race condition can create two fixed IPs, causing networking errors

### DIFF
--- a/service/instance.py
+++ b/service/instance.py
@@ -437,11 +437,25 @@ def redeploy_instance(
 
     if type(esh_driver) == AtmosphereMockDriver:
         return
+    # HACK: Forces a metadata update to avoid "Instance activity workflow" errors in the GUI
+    # by setting 'tmp_status' to 'initializing' users will not be stuck in a "final state"
+    # if API polling starts _prior_ to instance action being successful.
+    # When 'Instance activity workflow' has been addressed, remove these lines.
+    metadata = {'tmp_status': 'initializing'}
+    _update_instance_metadata(
+        esh_driver,
+        esh_instance,
+        metadata
+    )
+    esh_instance = esh_driver.get_instance(esh_instance.id)
+    # END-HACK
+
     # Start deployment chain based on the instance above
     deploy_chain = get_idempotent_deploy_chain(
         esh_driver.__class__, esh_driver.provider, esh_driver.identity,
         esh_instance, core_identity, core_identity.created_by.username)
     deploy_chain.apply_async()
+    return
 
 
 def restore_ip_chain(esh_driver, esh_instance, redeploy=False,
@@ -1765,7 +1779,7 @@ def update_instance_metadata(core_instance, data={}, replace=False):
     esh_instance = esh_driver.get_instance(instance_id)
     return _update_instance_metadata(esh_driver, esh_instance, data, replace)
 
-def _update_instance_metadata(esh_driver, esh_instance, data={}, replace=True):
+def _update_instance_metadata(esh_driver, esh_instance, data={}, replace=False):
     """
     NOTE: This will NOT WORK for TAGS until openstack
     allows JSONArrays as values for metadata!

--- a/service/task.py
+++ b/service/task.py
@@ -8,7 +8,7 @@ from threepio import logger
 
 from service.exceptions import DeviceBusyException, VolumeMountConflict, InstanceDoesNotExist
 
-from service.tasks.driver import deploy_init_to, add_floating_ip
+from service.tasks.driver import deploy_init_to
 from service.tasks.driver import destroy_instance
 from service.tasks.volume import attach_task, mount_volume_task, check_volume_task
 from service.tasks.volume import detach_task, unmount_volume_task,\
@@ -46,14 +46,6 @@ def deploy_init_task(driver, instance, identity,
                                 redeploy,
                                 deploy),
                                immutable=True)
-
-
-def add_floating_ip_task(driver, instance, *args, **kwargs):
-    add_floating_ip.delay(driver.__class__,
-                          driver.provider,
-                          driver.identity,
-                          instance.alias,
-                          *args, **kwargs)
 
 
 def destroy_instance_task(user, instance, identity_uuid, *args, **kwargs):

--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -77,7 +77,7 @@ def complete_resize(driverCls, provider, identity, instance_alias,
         driver = get_driver(driverCls, provider, identity)
         instance = driver.get_instance(instance_alias)
         if not instance:
-            celery_logger.debug("Instance has been teminated: %s." % instance_id)
+            celery_logger.debug("Instance has been teminated: %s." % instance_alias)
             return False, None
         result = instance_service.confirm_resize(
             driver, instance, core_provider_uuid, core_identity_uuid, user)
@@ -661,17 +661,17 @@ def get_chain_from_active_no_ip(
     network_meta_task = update_metadata.si(
         driverCls, provider, identity, instance.id,
         {'tmp_status': 'networking'})
-    floating_task = add_floating_ip.si(
+    networking_task = add_floating_ip.si(
         driverCls, provider, identity, str(core_identity.uuid), instance.id, delete_status=False)
-    floating_task.link_error(
+    networking_task.link_error(
         deploy_failed.s(driverCls, provider, identity, instance.id))
 
     if instance.extra.get('metadata', {}).get('tmp_status', '') == 'networking':
-        start_chain = floating_task
+        start_chain = networking_task
     else:
         start_chain = network_meta_task
-        start_chain.link(floating_task)
-    end_chain = floating_task
+        start_chain.link(networking_task)
+    end_chain = networking_task
     deploy_start = get_chain_from_active_with_ip(
         driverCls, provider, identity, instance, core_identity,
         username=username, password=password,
@@ -693,7 +693,7 @@ def get_chain_from_active_with_ip(
     start_chain = None
     # Guarantee 'networking' passes deploy_ready_test first!
     deploy_ready_task = deploy_ready_test.si(
-        driverCls, provider, identity, instance.id)
+        driverCls, provider, identity, instance.id, str(core_identity.uuid))
     # ALWAYS start by testing that deployment is possible. then deploy.
     start_chain = deploy_ready_task
 
@@ -845,11 +845,10 @@ def _deploy_ready_failed_email_test(
 
 @task(name="deploy_ready_test",
       default_retry_delay=64,
-      # 16 second hard-set time limit. (NOTE:TOO LONG? -SG)
       soft_time_limit=120,
-      max_retries=300  # Attempt up to two hours
+      max_retries=115  # Attempt up to two hours
       )
-def deploy_ready_test(driverCls, provider, identity, instance_id,
+def deploy_ready_test(driverCls, provider, identity, instance_id, core_identity_uuid,
                       **celery_task_args):
     """
     deploy_ready_test -
@@ -879,6 +878,12 @@ def deploy_ready_test(driverCls, provider, identity, instance_id,
             celery_logger.debug("Instance IP address missing from : %s." % instance_id)
             raise Exception("Instance IP Missing? %s" % instance_id)
 
+        # HACK: A race-condition exists where an instance may enter this task with _two_ private IPs
+        # If this happens, it is _possible_ that the Fixed IP port is invalid.
+        # The method below will attempt to correct that behavior _prior_ to seeing if the instance
+        # networking is indeed ready.
+        if len(instance._node.private_ips) >= 2:
+            _update_floating_ip_to_active_fixed_ip(driver, instance, core_identity_uuid)
     except (BaseException, Exception) as exc:
         celery_logger.exception(exc)
         _deploy_ready_failed_email_test(
@@ -1130,33 +1135,38 @@ def add_floating_ip(driverCls, provider, identity, core_identity_uuid,
             driver._clean_floating_ip()
         # ENDNOTE
 
-        # assign if instance doesn't already have an IP addr
         instance = driver.get_instance(instance_alias)
         if not instance:
             celery_logger.debug("Instance has been teminated: %s." % instance_alias)
             return None
         network_driver = instance_service._to_network_driver(core_identity)
+
         floating_ips = network_driver.list_floating_ips()
+        floating_ip_addr = None
         selected_floating_ip = None
         if floating_ips:
-            for fip in floating_ips:
-                if fip.get("instance_id",'') == instance_alias:
-                    selected_floating_ip = fip["floating_ip_address"]
+            instance_floating_ips = [fip for fip in floating_ips if fip.get("instance_id",'') == instance_alias]
+            selected_floating_ip = instance_floating_ips[0] if instance_floating_ips else None
+
         if selected_floating_ip:
-            floating_ip = selected_floating_ip
+            floating_ip_addr = selected_floating_ip["floating_ip_address"]
             celery_logger.debug(
-                "Reusing existing floating_ip_address - %s" %
-                floating_ip)
+                "Skip floating IP add:"
+                " address %s already exists for Instance %s",
+                floating_ip_addr, instance_alias)
+            floating_ip = selected_floating_ip
         else:
-            floating_ip = network_driver.associate_floating_ip(instance_alias)["floating_ip_address"]
-            celery_logger.debug("Created new floating_ip_address - %s" % floating_ip)
+            floating_ip = network_driver.associate_floating_ip(instance_alias)
+            floating_ip_addr = floating_ip["floating_ip_address"]
+            celery_logger.debug("Created new floating_ip_address - %s" % floating_ip_addr)
+
         _update_status_log(instance, "Networking Complete")
         # TODO: Implement this as its own task, with the result from
         #'floating_ip' passed in. Add it to the deploy_chain before deploy_to
-        hostname = build_host_name(instance.id, floating_ip)
+        hostname = build_host_name(instance.id, floating_ip_addr)
         metadata_update = {
             'public-hostname': hostname,
-            'public-ip': floating_ip
+            'public-ip': floating_ip_addr
         }
         # NOTE: This is part of the temp change, should be removed when moving
         # to vxlan
@@ -1167,7 +1177,7 @@ def add_floating_ip(driverCls, provider, identity, core_identity_uuid,
             network = [net for net in network if net['subnets'] != []][0]
         if instance_ports:
             for idx, fixed_ip_port in enumerate(instance_ports):
-                fixed_ips = fixed_ip_port.get('fixed_ips', [])
+                # fixed_ips = fixed_ip_port.get('fixed_ips', [])
                 mac_addr = fixed_ip_port.get('mac_address')
                 metadata_update['mac-address%s' % idx] = mac_addr
                 metadata_update['port-id%s' % idx] = fixed_ip_port['id']
@@ -1402,6 +1412,58 @@ def update_links(instances):
             continue
     celery_logger.debug("Instances updated: %d" % len(updated))
     return updated
+
+
+def _update_floating_ip_to_active_fixed_ip(driver, instance, core_identity_uuid):
+    """
+    - Given an instance matching the input described:
+      - determine which fixed IP is 'active' and valid for connection
+      - If floating IP is not set to that fixed IP, update the floating IP accordingly
+
+    Input: An instance with 2+ private/fixed IPs and 1+ floating IP attached
+    Output: Floating IP associated with an ACTIVE 'fixed IP' port, attached to instance.
+    Notes:
+      - In a future where >1 fixed IP and >1 floating IP is "normal"
+        this method will need to be changed/removed.
+    """
+    # Determine which port is the active port
+    from service import instance as instance_service
+    core_identity = Identity.objects.get(uuid=core_identity_uuid)
+    network_driver = instance_service._to_network_driver(core_identity)
+    port_id = _select_port_id(network_driver, driver, instance)
+    instance_id = instance.id
+    # NOTE: Strategy is to manage only the first floating IP address. Other IP addresses would be managed by user.
+    floating_ip_addr = selected_floating_ip = None
+    floating_ips = network_driver.list_floating_ips()
+    instance_floating_ips = [fip for fip in floating_ips if fip.get("instance_id", '') == instance_id]
+    selected_floating_ip = instance_floating_ips[0] if instance_floating_ips else None
+    if selected_floating_ip and port_id:
+        floating_ip_addr = selected_floating_ip["floating_ip_address"]
+        previous_port_id = selected_floating_ip["port_id"]
+        if previous_port_id != port_id:
+            celery_logger.info(
+                "Re-setting existing floating_ip_address %s port: %s -> %s",
+                floating_ip_addr, previous_port_id, port_id)
+            selected_floating_ip = network_driver.neutron.update_floatingip(selected_floating_ip['id'], {'floatingip': {'port_id': port_id}})
+    return selected_floating_ip
+
+
+def _select_port_id(network_driver, driver, instance):
+    """
+    - Input: Instance with two fixed IPs (will fail networking)
+      Output: Instance with one, valid fixed IP
+    """
+    instance_alias = instance.id
+    fixed_ip_ports = [p for p in network_driver.list_ports() if p['device_id'] == instance_alias]
+    active_fixed_ip_ports = [p for p in fixed_ip_ports if 'ACTIVE' in p['status']]
+    # Select the first active fixed ip port.
+    # nt.
+    if not active_fixed_ip_ports:
+        logger.warn(
+            "Instance %s has >1 Fixed IPs AND neither is ACTIVE."
+            " Ports found: %s", instance_alias, fixed_ip_ports)
+    port_id = active_fixed_ip_ports[0]['id']
+    return port_id
 
 
 def _cleanup_traceback(err_str):


### PR DESCRIPTION
## Solution
- Given multiple ports, select a port which is ACTIVE and attached
  - Fix provided in the 'ready_to_deploy' task, so that it can be caught
    and fixed with a simple redeploy.


## Additional/semi-related changes
- Rename task: 'add_floating_ip'->'initialize_instance_networking'
  Rationale:
  - This task is doing a _whole lot_ more than just adding a floating IP
  - Goal of the task: instance is ready to network by the end of the task.

- Set metadata to 'initializing' for a redeploy/reboot
  Rationale:
  -  avoid 'bouncing back' to error states

## Checklist before merging Pull Requests
- [x] Tested and verified on "broken" instances and new instances
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md