### PR TITLE
Problem: `AttributeError` on `applicationversion` admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -192,18 +192,18 @@ class ApplicationVersionMembershipAdmin(admin.ModelAdmin):
     ]
 
     def _start_date(self, obj):
-        return obj.application_version.start_date
+        return obj.image_version.application.start_date
 
     def _app_private(self, obj):
-        return obj.application_version.application.private
+        return obj.image_version.application.private
 
     _app_private.boolean = True
 
     def _app_name(self, obj):
-        return obj.application_version
+        return obj.image_version.application.name
 
     def render_change_form(self, request, context, *args, **kwargs):
-        context['adminform'].form.fields['application_version'].queryset = \
+        context['adminform'].form.fields['image_version'].queryset = \
             models.ApplicationVersion.objects.order_by('application__name')
         context['adminform'].form.fields[
             'group'].queryset = models.Group.objects.order_by('name')


### PR DESCRIPTION
`AttributeError: 'ApplicationVersionMembership' object has no attribute 'application_version'`

Solution: Use `image_version` instead of `application_version`

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
