### PR TITLE
WIP - Simplify atmosphere-ansible variables

### DIFF
--- a/service/deploy.py
+++ b/service/deploy.py
@@ -68,9 +68,9 @@ def ansible_deployment(
         shared_users.append(username)
     extra_vars.update({
         "SHARED_USERS": shared_users,
-    })
-    extra_vars.update({
         "ATMOUSERNAME": username,
+        "ATMOSPHERE_KEYPAIR_FILE": settings.ATMOSPHERE_KEYPAIR_FILE,
+        "ATMOSPHERE_PRIVATE_KEYFILE": settings.ATMOSPHERE_PRIVATE_KEYFILE
     })
     pbs = execute_playbooks(
         playbooks_dir, host_file, extra_vars, limit_hosts,


### PR DESCRIPTION
## Description

Problem: Same variable is defined in two places, easy to misconfigure
Solution: Merge the two, by atmosphere providing its variable

atmosphere-ansible is now less dependent on a correctly configured secrets
repo. Atmosphere is calling subspace with variables, which removes the need
for SSHKEYS to exist in atmosphere-ansible. It also means that clank no longer
has to template out an ssh config file.

See accompanying pr https://github.com/cyverse/atmosphere-ansible/pull/116

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
