### PR TITLE
Optimize SQL queries to avoid slow /v2/images calls.

### DIFF
--- a/core/models/application.py
+++ b/core/models/application.py
@@ -169,11 +169,11 @@ class Application(models.Model):
             # This query is not the most clear. Here's an explanation:
             # Include all images created by the user or active images in the
             # users providers that are either shared with the user or public
-            queryset = Application.objects.filter(
+            queryset = Application.objects.select_related('created_by').prefetch_related('versions__machines__instance_source__provider', 'versions__machines__members', 'versions__membership').filter(
                     query.created_by_user(user) |
                     (query.only_current_apps() &
                      query.in_users_providers(user) &
-                     (query.images_shared_with_user(user) | is_public)))
+                     (query.images_shared_with_user_by_ids(user) | is_public)))
         return queryset.distinct()
 
     def _current_versions(self):


### PR DESCRIPTION
- when using 'id in' queries, use a list() over a QuerySet.
- *Most important* Rather than join membership tables, do a lookup on individual tables, and look for results in query.
- Use prefetch_related/select_related on API get_queryset call