### PR TITLE
Fix trivial key mismatch

### DIFF
--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -463,10 +463,10 @@ class AccountDriver(BaseAccountDriver):
         #FIXME: This isn't working for CyVerse Cloud.
         for kp in keypairs:
             if kp.name == keyname:
-                if kp.public_key != public_key:
+                if kp.public_key.strip() != public_key.strip():
                     raise Exception(
                         "Mismatched public key found for keypair named: %s"
-                        ". Expected: %s Original: %s"
+                        ". Expected:\n%s\nFound:\n%s"
                         % (keyname, public_key, kp.public_key))
                 return (kp, False)
         return (self.create_keypair(


### PR DESCRIPTION
## Description
Before atmosphere runs subspace, it checks that ssh deploy key is the key that
was injected into the instance. The check was failing because of a trailing
new line. Same key is used to inject as is to perform the check, just reading
from python didn't strip the newline.## Checklist before merging Pull Requests

- [x] Reviewed and approved by at least one other contributor.
