### PR TITLE
Problem: ScriptType missing on new databases

### DIFF
--- a/core/fixtures/boot_script.json
+++ b/core/fixtures/boot_script.json
@@ -1,0 +1,17 @@
+[
+{
+  "pk": 1,
+  "model": "core.scripttype",
+  "fields": {
+    "name": "URL"
+  }
+},
+{
+  "pk": 2,
+  "model": "core.scripttype",
+  "fields": {
+    "name": "Raw Text"
+  }
+}
+]
+


### PR DESCRIPTION
## Solution: Add ScriptType in boot_script.json fixtures

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [x] [New variables supported in Clank](https://github.com/cyverse/clank/pull/229)