### PR TITLE
Problem: machine monitoring creates errors in image catalog

### DIFF
--- a/core/models/application.py
+++ b/core/models/application.py
@@ -51,12 +51,12 @@ class Application(models.Model):
         """
         from core.models import AtmosphereUser
 
-        if not self.access_list.count():
-            return AtmosphereUser.objects.none()
-
-        all_users = AtmosphereUser.objects.all()
+        all_users = AtmosphereUser.objects.none()
         for pattern_match in self.access_list.all():
-            all_users &= pattern_match.validate_users()
+            if pattern_match.allow_access:
+                all_users |= pattern_match.validate_users()
+            else:
+                all_users &= pattern_match.validate_users()
         return all_users
 
     @property

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -360,7 +360,7 @@ class ApplicationMembership(models.Model):
 
 def _get_owner_identity(provider, created_by=None):
     """
-    This private method is intenteded to ensure that a valid identity exists
+    This private method is intended to ensure that a valid identity exists
     for the 'owner' of an Application.
     If the identity cannot be found, the AccountProvider will be the author.
     """

--- a/core/models/application_version.py
+++ b/core/models/application_version.py
@@ -290,7 +290,7 @@ def merge_duplicated_app_versions(
 
 def create_app_version(
         app,
-        version_str,
+        name,
         created_by=None,
         created_by_identity=None,
         change_log=None, allow_imaging=None, provider_machine_id=None):
@@ -300,15 +300,14 @@ def create_app_version(
         created_by_identity = app.created_by_identity
 
     if provider_machine_id:
-        app_version = test_machine_in_version(app, version_str, provider_machine_id)
-    if app_version:
+        app_version = test_machine_in_version(app, name, provider_machine_id)
         app_version.created_by = created_by
         app_version.created_by_identity = created_by_identity
         app_version.save()
     else:
         app_version = create_unique_version(
             app,
-            version_str,
+            name,
             created_by,
             created_by_identity)
     last_version = app.latest_version

--- a/core/tests/application.py
+++ b/core/tests/application.py
@@ -1,0 +1,122 @@
+import unittest
+
+from django.utils.timezone import now
+
+from core.tests.helpers import CoreApplicationHelper
+from core.models import (AtmosphereUser, MatchType, PatternMatch)
+
+
+class CoreApplicationTestCase(unittest.TestCase):
+
+    def assertAccessList(self, expected_result):
+        usernames = self.calculate_valid_usernames()
+        return self.assertTrue(usernames == expected_result, "%s != ExpectedResult(%s)" % (usernames, expected_result))
+
+    def calculate_valid_usernames(self):
+        allowed_users = self.app.get_users_from_access_list()
+        usernames = sorted(allowed_users.values_list('username', flat=True))
+        return usernames
+
+
+class TestApplicationAccessList(CoreApplicationTestCase):
+
+    def setUp(self):
+        self.app_helper = CoreApplicationHelper(
+            "Pattern Match app test", now())
+        self.app = self.app_helper.application
+        self._prepare_patterns()
+        self._prepare_users()
+
+    def _prepare_users(self):
+        AtmosphereUser.objects.get_or_create(
+            username='cdosborn', email="cdosborn@test.email.com")
+        AtmosphereUser.objects.get_or_create(
+            username='lenards', email="lenards@test.email.com")
+        AtmosphereUser.objects.get_or_create(
+            username='steve', email="steve-gregory@test.email.com")
+        AtmosphereUser.objects.get_or_create(
+            username='gmail_user', email="test_user@gmail.com")
+        AtmosphereUser.objects.get_or_create(
+            username='cyversedemo1', email="cyversedemo1@test.email.com")
+        AtmosphereUser.objects.get_or_create(
+            username='cyversedemo2', email="cyversedemo2@test.email.com")
+        AtmosphereUser.objects.get_or_create(
+            username='cyversedemo3', email="cyversedemo3@test.email.com")
+        return
+
+    def _prepare_patterns(self):
+        atmosphere_user = self.app_helper.user
+        email_type = MatchType.objects.get_or_create(name='Email')[0]
+        user_type = MatchType.objects.get_or_create(name='Username')[0]
+        self.allow_lenards = PatternMatch.objects.get_or_create(
+            pattern="lenards",
+            type=user_type,
+            created_by=atmosphere_user,
+            allow_access=True)[0]
+        self.allow_cdosborn = PatternMatch.objects.get_or_create(
+            pattern="cdosborn",
+            type=user_type,
+            created_by=atmosphere_user,
+            allow_access=True)[0]
+        self.allow_cyverse_demos = PatternMatch.objects.get_or_create(
+            pattern="cyversedemo*",
+            type=user_type,
+            created_by=atmosphere_user,
+            allow_access=True)[0]
+        self.allow_test_email = PatternMatch.objects.get_or_create(
+            pattern="*@test.email.com",
+            type=email_type,
+            created_by=atmosphere_user,
+            allow_access=True)[0]
+        self.deny_specific_test_email = PatternMatch.objects.get_or_create(
+            pattern="steve-gregory@test.email.com",
+            type=email_type,
+            created_by=atmosphere_user,
+            allow_access=False)[0]
+        return
+
+    def test_simple_access(self):
+        """
+        Assert that the instance has only ONE history
+        """
+        self.app.access_list.add(self.allow_cdosborn)
+        expected_result = [u'cdosborn']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()
+
+        self.app.access_list.add(self.allow_lenards)
+        expected_result = [u'lenards']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()
+
+        self.app.access_list.add(self.allow_cyverse_demos)
+        expected_result = [
+            u'cyversedemo1', u'cyversedemo2', u'cyversedemo3']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()
+
+        self.app.access_list.add(self.allow_test_email)
+        expected_result = [
+            u'cdosborn', u'cyversedemo1', u'cyversedemo2',
+            u'cyversedemo3', u'lenards', u'steve']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()
+
+    def test_allow_deny_logic(self):
+        self.app.access_list.add(self.allow_test_email)
+        self.app.access_list.add(self.deny_specific_test_email)
+        expected_result = [
+            u'cdosborn', u'cyversedemo1', u'cyversedemo2',
+            u'cyversedemo3', u'lenards']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()
+
+    def test_multiple_allow_logic(self):
+        self.app.access_list.add(self.allow_cyverse_demos)
+        self.app.access_list.add(self.allow_cdosborn)
+        self.app.access_list.add(self.allow_lenards)
+        expected_result = [
+            u'cdosborn', u'cyversedemo1', u'cyversedemo2',
+            u'cyversedemo3', u'lenards']
+        self.assertAccessList(expected_result)
+        self.app.access_list.clear()

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -5,9 +5,9 @@ UserManager:
 import time
 import string
 from urlparse import urlparse
-
+import glanceclient
 from django.db.models import ObjectDoesNotExist
-from rtwo.exceptions import NovaOverLimit, KeystoneUnauthorized
+from rtwo.exceptions import NovaOverLimit, KeystoneUnauthorized, GlanceForbidden
 
 #FIXME: Add this exception to rtwo before merge.
 try:
@@ -496,19 +496,8 @@ class AccountDriver(BaseAccountDriver):
         return keypair
 
     def shared_images_for(self, image_id, status="approved"):
-        if getattr(settings, "REPLICATION_PROVIDER_LOCATION"):
-            from core.models import Provider
-            from service.driver import get_account_driver
-            provider = Provider.objects.get(location=settings.REPLICATION_PROVIDER_LOCATION)
-            acct_driver = get_account_driver(provider)
-            if not acct_driver:
-                raise Exception("Cannot create account_driver for %s" % provider)
-        else:
-            acct_driver = self
-        # acct_driver = self
-        all_projects = {p.id: p for p in acct_driver.list_projects()}
-        shared_with = self.image_manager.shared_images_for(
-            image_id=image_id)
+        all_projects = {p.id: p for p in self.list_projects()}
+        shared_with = self.image_manager.glance.image_members.list(image_id)
         projects = []
         try:
             for member in shared_with:
@@ -520,10 +509,13 @@ class AccountDriver(BaseAccountDriver):
                 if not project:
                     continue
                 projects.append(project)
+        except glanceclient.exc.HTTPNotFound as exc:
+            # If image is not found, no projects should be added
+            pass
         except GlanceForbidden as exc:
-            if 'Only shared images have members' in exc.details:
-                return projects
-            raise
+            # Skip over exception if image visibility is public/private.
+            if 'Only shared images have members' not in exc.details:
+                raise
         return projects
 
     @timeout_after(10)

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -134,6 +134,7 @@ class AccountDriver(BaseAccountDriver):
         from service.driver import get_esh_driver
 
         self.core_provider = provider
+        self.project_name = provider.get_admin_identity().project_name()
 
         provider_creds = provider.get_credentials()
         self.cloud_config = provider.cloud_config
@@ -149,12 +150,11 @@ class AccountDriver(BaseAccountDriver):
         all_creds.update(provider_creds)
         return all_creds
 
-    def __init__(self, provider=None, *args, **kwargs):
+    def __init__(self, provider, *args, **kwargs):
         super(AccountDriver, self).__init__()
-        if provider:
-            all_creds = self._init_by_provider(provider, *args, **kwargs)
-        else:
-            all_creds = kwargs
+
+        all_creds = self._init_by_provider(provider, *args, **kwargs)
+
         if 'cloud_config' in all_creds:
             self.cloud_config = all_creds['cloud_config']
         if not self.cloud_config:

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -495,7 +495,7 @@ class AccountDriver(BaseAccountDriver):
                 public_key=public_key)
         return keypair
 
-    def shared_images_for(self, image_id, status="approved"):
+    def get_image_members(self, image_id, status="approved"):
         all_projects = {p.id: p for p in self.list_projects()}
         shared_with = self.image_manager.glance.image_members.list(image_id)
         projects = []

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -315,6 +315,9 @@ def _get_all_access_list(account_driver, db_machine, cloud_machine):
     # Extend to include based on projects already granted access to the image
     cloud_shared_set = set(p.name for p in existing_members)
 
+    # Deprecation warning: Now that we use a script to do replication,
+    # we should not need to account for shares on another provider.
+    # Remove this code any time during/after the v29 release
     has_machine_request = MachineRequest.objects.filter(
         new_machine__instance_source__identifier=cloud_machine.id,
         status__name='completed').last()
@@ -328,9 +331,6 @@ def _get_all_access_list(account_driver, db_machine, cloud_machine):
 
         request_provider = has_machine_request.new_machine_provider
         request_identifier = has_machine_request.new_machine.instance_source.identifier
-        # Deprecation warning: Now that we use a script to do replication,
-        # we should not need to account for shares on another provider.
-        # Remove this code any time during/after the v29 release
         if request_provider != db_machine.provider:
             main_account_driver = get_account_driver(request_provider)
             # Extend to include based on information in the machine request

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -16,6 +16,7 @@ from core.models.volume import Volume, convert_esh_volume
 from core.models.instance import Instance, convert_esh_instance
 from core.models.provider import Provider
 from core.models.machine import convert_glance_image, get_or_create_provider_machine, ProviderMachine, ProviderMachineMembership
+from core.models.machine_request import MachineRequest
 from core.models.application import Application, ApplicationMembership
 from core.models.allocation_source import AllocationSource
 from core.models.application_version import ApplicationVersion
@@ -235,8 +236,9 @@ def machine_is_valid(cloud_machine, accounts):
         - Domain-specific image catalog(?)
     """
     provider = accounts.core_provider
+    cloud_machine_name = cloud_machine.name if cloud_machine.name else ""
     # If the name of the machine indicates that it is a Ramdisk, Kernel, or Chromogenic Snapshot, skip it.
-    if any(cloud_machine.name.startswith(prefix) for prefix in ['eri-','eki-', 'ChromoSnapShot']):
+    if any(cloud_machine_name.startswith(prefix) for prefix in ['eri-','eki-', 'ChromoSnapShot']):
         celery_logger.info("Skipping cloud machine %s" % cloud_machine)
         return False
     # If the metadata 'skip_atmosphere' is found, do not add the machine.
@@ -287,48 +289,58 @@ def distribute_image_membership(account_driver, cloud_machine, provider):
             update_cloud_membership_for_machine(pm, group)
         except TimeoutError:
             celery_logger.warn("Failed to add cloud membership for %s - Operation timed out" % group)
+    return groups
 
 
 def _get_all_access_list(account_driver, db_machine, cloud_machine):
+    """
+    Input: AccountDriver, ProviderMachine, glance_image
+    Output: A list of _all project names_ that should be included on `cloud_machine`
+
+    This list will include:
+    - Users who match the provider_machine's application.access_list
+    - Users who are already approved to use the `cloud_machine`
+    - The owner of the application/Creator of the MachineRequest
+    - If using settings.REPLICATION_PROVIDER:
+      - include all those approved on the replication provider's copy of the image
+    """
+    #TODO: In a future update to 'imaging' we might image 'as the user' rather than 'as the admin user', in this case we should just use 'owner' metadata
+
     image_owner = cloud_machine.get('application_owner','')
-    shared_group_names = [image_owner]
+    # NOTE: This assumes that the 'owner' (atmosphere user) == 'project_name' (Openstack)
+    # Always include the original application owner
+    shared_project_names = [image_owner]
+
     shared_projects = account_driver.shared_images_for(cloud_machine.id, None)
-    has_machine_request = db_machine.application_version.machinerequest_set.filter(status__name='completed').first()
+    # Extend to include based on projects already granted access to the image
+    shared_project_names.extend([p.name for p in shared_projects if p.name not in shared_project_names])
+
+    has_machine_request = MachineRequest.objects.filter(
+        new_machine__instance_source__identifier=cloud_machine.id,
+        status__name='completed').last()
     if has_machine_request:
         access_list = has_machine_request.get_access_list()
-        # THIS IS A HACK: If there are LOTS of projects shared with the main driver, it is probably
-        # an accident. _ESPECIALLY_ if the list in the access list is smaller. so lets just ignore them.
-        # - SGregory
-        if len(shared_projects) > len(access_list):
-            shared_projects = []
-        provider = has_machine_request.new_machine_provider
-        identifier = has_machine_request.new_machine.identifier
-        shared_group_names.extend([name for name in access_list if name not in shared_group_names])
-        main_account_driver = get_account_driver(provider)
-        #Extend to include based on information in the machine request
-        shared_projects_from_main =  main_account_driver.shared_images_for(identifier, None)
-        # THIS IS A HACK: If there are LOTS of projects shared with the main driver, it is probably
-        # an accident. _ESPECIALLY_ if the list in the access list is smaller. so lets just ignore them.
-        # - SGregory
-        if len(shared_projects_from_main) > len(access_list):
-            shared_projects_from_main = []
-        shared_projects_from_main = [p for p in shared_projects_from_main if p not in shared_projects]
-        shared_projects.extend(shared_projects_from_main)
+        # NOTE: This assumes that every name in
+        #      accesslist (AtmosphereUser) == project_name(Openstack)
+        shared_project_names.extend(
+                [name for name in access_list
+                 if name not in shared_project_names])
+        request_provider = has_machine_request.new_machine_provider
+        request_identifier = has_machine_request.new_machine.instance_source.identifier
+        if request_provider != db_machine.provider:
+            main_account_driver = get_account_driver(request_provider)
+            # Extend to include based on information in the machine request
+            request_shared_projects = main_account_driver.shared_images_for(request_identifier, None)
+            request_shared_projects = [p.name for p in request_shared_projects if p.name not in shared_project_names]
+            shared_project_names.extend(request_shared_projects)
 
-    # Extend to include based on projects already granted access to the image
-    shared_group_names.extend([p.name for p in shared_projects if p.name not in shared_group_names])
+    shared_project_names.extend([p.name for p in shared_projects if p.name not in shared_project_names])
 
-
-    #Extend to include new names found by application pattern_match
+    # Extend to include new names found by application pattern_match
     parent_app = db_machine.application_version.application
     matching_users = list(parent_app.get_users_from_access_list().values_list('username', flat=True))
-    if len(matching_users) > 128:
-        # THIS IS A HACK: If there are LOTS of projects shared with the parent application, thats likely
-        # an accident. _ESPECIALLY_ if the list in the access list is smaller. so lets just ignore them.
-        # - SGregory
-        matching_users = []
-    shared_group_names.extend([user for user in matching_users if user not in shared_group_names])
-    return shared_group_names
+    shared_project_names.extend([user for user in matching_users if user not in shared_project_names])
+    return shared_project_names
 
 
 def update_image_membership(account_driver, cloud_machine, db_machine):
@@ -339,23 +351,31 @@ def update_image_membership(account_driver, cloud_machine, db_machine):
     image_visibility = cloud_machine.get('visibility','private')
     if image_visibility.lower() == 'public':
         return
-    #TODO: In a future update to 'imaging' we might image 'as the user' rather than 'as the admin user', in this case we should just use 'owner' metadata
-    shared_group_names = _get_all_access_list(account_driver, db_machine, cloud_machine)
-    #Future-FIXME: This logic expects groupname == username. If this assumption changes, change this line to
-    #       lookup all groups that a user is part of, and potentially filtered by
-    #       all identities a group has Membership access to
-    groups = Group.objects.filter(name__in=shared_group_names)
+    shared_project_names = _get_all_access_list(account_driver, db_machine, cloud_machine)
+
+    #Future-FIXME: This logic expects project_name == Group.name
+    #       When this changes, logic should update to include checks for:
+    #       - Lookup Identities with this project_name
+    #       - Share with group that has IdentityMembership
+    #       - Alternatively, consider changing ProviderMachineMembership
+    #       to point to Identity for a 1-to-1 mapping.
+    groups = Group.objects.filter(name__in=shared_project_names)
 
     # THIS IS A HACK - some images have been 'compromised' in this event, reset the access list _back_ to the last-known-good configuration, based on a machine request.
-    if len(shared_group_names) > 128:
+    has_machine_request = MachineRequest.objects.filter(
+        new_machine__instance_source__identifier=cloud_machine.id,
+        status__name='completed').last()
+    parent_app = db_machine.application_version.application
+    if len(shared_project_names) > 128:
         celery_logger.warn("Application %s has too many shared users. Consider running 'prune_machines' to cleanup", parent_app)
         if not has_machine_request:
             return
         access_list = has_machine_request.get_access_list()
-        shared_group_names = access_list
+        shared_project_names = access_list
+    #ENDHACK
     for group in groups:
         update_db_membership_for_group(db_machine, group)
-    return shared_group_names
+    return groups
 
 
 
@@ -377,7 +397,8 @@ def get_public_and_private_apps(provider):
     # if you do not believe this is the case, you should call 'prune_machines_for'
     for cloud_machine in cloud_machines:
         #Filter out: ChromoSnapShot, eri-, eki-, ... (Or dont..)
-        if any(cloud_machine.name.startswith(prefix) for prefix in ['eri-','eki-', 'ChromoSnapShot']):
+        cloud_machine_name = cloud_machine.name if cloud_machine.name else ""
+        if any(cloud_machine_name.startswith(prefix) for prefix in ['eri-','eki-', 'ChromoSnapShot']):
             #celery_logger.debug("Skipping cloud machine %s" % cloud_machine)
             continue
         app_name, version_name = ProviderMachine._split_cloud_name(cloud_machine.name)
@@ -974,7 +995,8 @@ def _share_image(account_driver, cloud_machine, identity, members, dry_run=False
     cloud_machine_is_public = cloud_machine.is_public if hasattr(cloud_machine,'is_public') else cloud_machine.get('visibility','') == 'public'
     if cloud_machine_is_public == True:
         celery_logger.info("Making Machine %s private" % cloud_machine.id)
-        account_driver.image_manager.glance.images.update(cloud_machine.id, visibility='shared')
+        if not dry_run:
+            account_driver.image_manager.glance.images.update(cloud_machine.id, visibility='shared')
 
     celery_logger.info("Sharing image %s<%s>: %s with %s" % (cloud_machine.id, cloud_machine.name, identity.provider.location, tenant_name.value))
     if not dry_run:
@@ -985,7 +1007,7 @@ def _share_image(account_driver, cloud_machine, identity, members, dry_run=False
                 pass
         except GlanceForbidden as exc:
             if 'Public images do not have members' in exc.message:
-                celery_logger.warn("CONFLICT -- This image should have been marked 'private'! %s" % cloud_machine)
+                celery_logger.warn("CONFLICT -- This image should have been marked 'shared'! %s" % cloud_machine)
                 pass
     return
 

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -164,7 +164,7 @@ def monitor_machines():
 
 
 @task(name="monitor_machines_for")
-def monitor_machines_for(provider_id, limit_machines=[], print_logs=False, dry_run=False):
+def monitor_machines_for(provider_id, limit_machines=[], print_logs=False, dry_run=False, validate=True):
     """
     Run the set of tasks related to monitoring machines for a provider.
     Optionally, provide a list of usernames to monitor
@@ -191,7 +191,7 @@ def monitor_machines_for(provider_id, limit_machines=[], print_logs=False, dry_r
     # ASSERT: All non-end-dated machines in the DB can be found in the cloud
     # if you do not believe this is the case, you should call 'prune_machines_for'
     for cloud_machine in cloud_machines:
-        if not machine_is_valid(cloud_machine, account_driver):
+        if not machine_is_valid(cloud_machine, account_driver, validate):
             continue
         owner_project = _get_owner(account_driver, cloud_machine)
         #STEP 1: Get the application, version, and provider_machine registered in Atmosphere
@@ -228,7 +228,7 @@ def _get_owner(accounts, cloud_machine):
     return owner_project
 
 
-def machine_is_valid(cloud_machine, accounts):
+def machine_is_valid(cloud_machine, accounts, validate=True):
     """
     As the criteria for "what makes a glance image an atmosphere ProviderMachine" changes, we can use this function to hook out to external plugins, etc.
     Filters out:
@@ -236,6 +236,8 @@ def machine_is_valid(cloud_machine, accounts):
         - Images that are not authored by Atmosphere
         - Domain-specific image catalog(?)
     """
+    if not validate:
+        return True
 
     # Skip the machine if the owner was not the chromogenic image creator
     # (tenant name must match admin tenant name)


### PR DESCRIPTION
Problem(s):
- (1) Application with empty access-list returned _all users_ which made private images "Shared with >128 Users" error show up
- (2) New applications are being created with 'v. VersionName' in the
- (3) New applications are being created for each version update.

Solution(s):
- (1) return AtmosphereUser.objects.none() when access_list is empty.
- (2) Imaging will include version name, and monitoring should strip
      version name before processing.
      (This was noted in comment but never implemented)
- (3) Rely on application_uuid metadata and "fall back" on the
      glance image name to be the secondary 'key' of truth.
      If API users are creating images with the _same name_ and _same
      application UUID_ then we will need to find a new way
      to address this problem.

Cleanup related to the solution:
- Do away with confusing logic about REPLICATION_DRIVER.
  the code replaces the acting account driver with
  _an account driver pointed at a different provider_
  which makes it hard to use in practice.
- Remove (most) HACK statements
- Re-factor logic for retrieving the 'entire access list'
- small changes to speed up monitoring
  by making less calls to '.get(image_id)'
  and catch spurious error when image is not found.
- Update documentation and filter statements name.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [ ] Check with support team(s) to determine if this should be hot-fixed or wait until v29.