### PR TITLE
Problem: success percent might cause division by zero error

### DIFF
--- a/core/metrics/application.py
+++ b/core/metrics/application.py
@@ -87,7 +87,9 @@ def calculate_summarized_application_metrics(app):
     app_instances = Instance.objects.filter(source__providermachine__application_version__application__id=app.id)
     total_launched = app_instances.count()
     total_successful = app_instances.filter(instancestatushistory__status__name='active').distinct().count()
-    success_pct = total_successful/float(total_launched) * 100
+    success_pct = 0.0
+    if total_launched != 0:
+        success_pct = total_successful/float(total_launched) * 100
 
     application_metrics = {
         'forks': num_forks,


### PR DESCRIPTION
## Description

When an image has not be launched, we hit `total_launched = 0` and then
the percentage calculation will throw:
```
...
>>> ZeroDivisionError: float division by zero
```

This sets the percent to `0.0` and only does the division if we have launches.

Note: when trying to test or reproduce this, you might need to do a clear of the redis cache for these calculations to be performed:
```
$ redis-cli flushall
```
One image that did *not* have launced in my local test envirionment was
- https://local.atmo.cloud/application/images/1468

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
