### PR TITLE
Problem: atmosphere-ansible ssh setup tasks can be hard to debug

### DIFF
--- a/service/deploy.py
+++ b/service/deploy.py
@@ -82,16 +82,20 @@ def ansible_deployment(
     return pbs
 
 
-def ready_to_deploy(instance_ip, username, instance_id):
+def ready_to_deploy(instance_ip, username, instance_id, **runner_opts):
     """
     Use service.ansible to deploy to an instance.
     """
     playbooks_dir = settings.ANSIBLE_PLAYBOOKS_DIR
     playbooks_dir = os.path.join(playbooks_dir, 'utils')
+    extra_vars = {
+        "SSH_IDENTITY_FILE": settings.ATMOSPHERE_PRIVATE_KEYFILE,
+    }
 
     return ansible_deployment(
         instance_ip, username, instance_id, playbooks_dir,
-        limit_playbooks=['check_networking.yml'])
+        limit_playbooks=['check_networking.yml'],
+        extra_vars=extra_vars, **runner_opts)
 
 
 def deploy_mount_volume(instance_ip, username, instance_id,
@@ -240,6 +244,7 @@ def instance_deploy(instance_ip,
     Use service.ansible to deploy to an instance.
     """
     extra_vars = {
+        "SSH_IDENTITY_FILE": settings.ATMOSPHERE_PRIVATE_KEYFILE,
         "VNCLICENSE": secrets.ATMOSPHERE_VNC_LICENSE,
     }
     playbooks_dir = settings.ANSIBLE_PLAYBOOKS_DIR


### PR DESCRIPTION
## Solution
- Allow atmosphere to pass `SSH_IDENTITY_FILE` to atmosphere-ansible as extra_vars, for both `ready_to_deploy` and `instance_deploy` playbooks.

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.
- [x] [Reviewed and approved atmosphere-ansible companion PR.](https://github.com/cyverse/atmosphere-ansible/pull/124)
