### PR TITLE
Problem: ansible fails when script text includes special characters.

### DIFF
--- a/core/models/boot_script.py
+++ b/core/models/boot_script.py
@@ -61,11 +61,29 @@ class BootScript(models.Model):
         """
         return slugify(self.title).replace('-', '_')
 
-    def get_text(self):
+    def get_text(self, clean=True):
+        raw_text = ""
         if self.script_type.name == 'Raw Text':
-            return self.script_text.strip()  # Remove whitespace
+            raw_text = self.script_text.strip()  # Remove whitespace
         elif self.script_type.name == 'URL':
-            return self._text_from_url()
+            raw_text = self._text_from_url()
+        if clean:
+            return BootScript._clean_script_text(raw_text)
+        return raw_text
+
+    @classmethod
+    def _clean_script_text(self, raw_text):
+        """
+        Remove special characters from boot-scripts to avoid ansible failures.
+        """
+        if not raw_text:
+            return ""
+        elif type(raw_text) == unicode:
+            return raw_text.encode('ascii', 'ignore')
+        elif type(raw_text) == str:
+            return raw_text.decode('unicode_escape').encode('ascii', 'ignore')
+        else:
+            raise TypeError("Expected type of 'raw_text' to be unicode/str. Found: %s" % type(raw_text))
 
     def _text_from_url(self):
         """

--- a/core/tests/boot_script.py
+++ b/core/tests/boot_script.py
@@ -1,0 +1,19 @@
+import unittest
+
+from django.utils.timezone import now
+
+from core.models import BootScript
+
+
+class BootScriptTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # initialization goes here
+        pass
+
+    def test_special_characters_removed(self):
+        str_special = "This\xc2\xb6string\xc2\xb6has\xc2\xb6special\xc2\xb6characters"
+        unicode_special = u"This\xc2\xb6string\xc2\xb6has\xc2\xb6special\xc2\xb6characters"
+        expected_result = "Thisstringhasspecialcharacters"
+        self.assertEquals(BootScript._clean_script_text(str_special), expected_result)
+        self.assertEquals(BootScript._clean_script_text(unicode_special), expected_result)


### PR DESCRIPTION
## Solution

Remove special characters before sending script_text to ansible.
Provide a test case to prove that the solution works.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Reviewed and approved by at least one other contributor.
