### PR TITLE
Problem: Instances with ephemeral storage mounted to /home cannot be shelved

### DIFF
--- a/service/instance.py
+++ b/service/instance.py
@@ -2028,6 +2028,12 @@ def run_instance_action(user, identity, instance_id, action_type, action_params)
     reclaim_ip = True if identity.provider.location != 'iPlant Cloud - Tucson' else False
     # ENDNOTE
 
+    # NOTE: This metadata statement is a HACK! It should be removed when all instances matching this metadata key have been removed.
+    instance_has_home_mount = esh_instance.extra['metadata'].get('atmosphere_ephemeral_home_mount', 'false').lower()
+    if instance_has_home_mount == 'true' and action_type == 'shelve':
+        logger.info("Instance %s will be suspended instead of shelved, because the ephemeral storage is in /home", esh_instance.id)
+        action_type = 'suspend'
+
     logger.info("User %s has initiated instance action %s to be executed on Instance %s" % (user, action_type, instance_id))
     if 'resize' == action_type:
         size_alias = action_params.get('size', '')

--- a/service/monitoring.py
+++ b/service/monitoring.py
@@ -153,6 +153,13 @@ def _execute_provider_action(identity, user, instance, action_name):
     reclaim_ip = True if identity.provider.location != 'iPlant Cloud - Tucson' else False
     # ENDNOTE
 
+    # NOTE: This metadata statement is a HACK! It should be removed when all instances matching this metadata key have been removed.
+    instance_has_home_mount = instance.extra['metadata'].get('atmosphere_ephemeral_home_mount', 'false').lower()
+    if instance_has_home_mount == 'true' and action_name == 'Shelve':
+        logger.info("Instance %s will be suspended instead of shelved, because the ephemeral storage is in /home" % instance.id)
+        action_name = 'Suspend'
+
+
     logger.info("User %s has gone over their allocation on Instance %s - Enforcement Choice: %s" % (user, instance, action_name))
     try:
         if not action_name:


### PR DESCRIPTION
## Solution
Create a metadata 'escape hatch' for instances with ephemeral drive mounted to /home. 
Treat these instances differently by ensuring any call to 'Shelve' will actually suspend to avoid losing data.

## Checklist before merging Pull Requests
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
