### PR TITLE
Fixes to monitor_machines and validation

### DIFF
--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -126,6 +126,21 @@ class AccountDriver(BaseAccountDriver):
             })
         return export_data
 
+    def add_owner_to_machine(self, cloud_machines, cloud_machines_dict):
+        for warlock_image in cloud_machines:
+            glance_img_match = [
+                glance_img for glance_img
+                in cloud_machines_dict
+                if glance_img['id'] == warlock_image.id
+            ]
+            if not glance_img_match:
+                logger.warn(
+                    "Image list mismatch: %s exists in glance-v2 "
+                    "and not in glance-v1.." % warlock_image.id
+                )
+                continue
+            warlock_image.owner = glance_img_match[0].get('owner', '')
+
     def clear_cache(self):
         self.admin_driver.provider.machineCls.invalidate_provider_cache(
                 self.admin_driver.provider)

--- a/service/tasks/monitoring.py
+++ b/service/tasks/monitoring.py
@@ -194,7 +194,9 @@ def monitor_machines_for(provider_id, limit_machines=[], print_logs=False, dry_r
 
     if account_driver.user_manager.version == 2:
         #Old providers need to use v1 glance to get owner information.
-        cloud_machines = account_driver.image_manager.list_v1_images()
+        cloud_machines_dict = account_driver.image_manager.list_v1_images()
+        cloud_machines = account_driver.list_all_images()
+        account_driver.add_owner_to_machine(cloud_machines, cloud_machines_dict)
     else:
         cloud_machines = account_driver.list_all_images()
 


### PR DESCRIPTION
## Highlights
- Legacy clouds need to call 'list images' twice and append  info to the v2 api.
- Skip machines if their status is 'queued' or 'saving'

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.