### PR TITLE
Problem: Allocations should renew on first day of calendar month

### DIFF
--- a/cyverse_allocation/tasks.py
+++ b/cyverse_allocation/tasks.py
@@ -49,8 +49,9 @@ def update_snapshot_cyverse(start_date=None, end_date=None):
                                                                     'global_burn_rate': total_burn_rate})
 
         run_all(rule_list=cyverse_rules,
-                defined_variables=CyverseTestRenewalVariables(allocation_source, end_date, start_date),
-                defined_actions=CyverseTestRenewalActions(allocation_source, end_date), )
+                defined_variables=CyverseTestRenewalVariables(allocation_source, current_time=end_date,
+                                                              last_renewal_event_date=start_date),
+                defined_actions=CyverseTestRenewalActions(allocation_source, current_time=end_date))
     # At the end of the task, fire-off an allocation threshold check
     logger.debug("update_snapshot_cyverse task finished at %s." % datetime.now())
     allocation_threshold_check.apply_async()


### PR DESCRIPTION
Solution: Refactor rules parser and add a `on_calendar_day` strategy

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
