### PR TITLE
application_to_provider bugfix for Glance API v2.5 image visibility

### DIFF
--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -107,10 +107,10 @@ def _parse_args():
                              "attempt. (Local cache is always deleted after successful upload). "
                              "May consume a lot of disk space.")
     parser.add_argument("--src-glance-client-version",
-                        type=int,
+                        type=float,
                         help="Glance client version to use for source provider")
     parser.add_argument("--dst-glance-client-version",
-                        type=int,
+                        type=float,
                         help="Glance client version to use for destination provider")
     parser.add_argument("--irods-conn",
                         type=str, metavar="irods://user:password@host:port/zone",
@@ -335,6 +335,25 @@ def main(application_id,
                                                       kernel_id=sprov_glance_image.kernel_id,
                                                       ramdisk_id=sprov_glance_image.ramdisk_id)
                                                   )
+        elif dst_glance_client_version >= 2.5:
+            dprov_glance_client.images.update(dprov_glance_image.id,
+                                              name=app.name,
+                                              container_format="ami" if ami else sprov_glance_image.container_format,
+                                              disk_format="ami" if ami else sprov_glance_image.disk_format,
+                                              visibility="shared" if app.private else "public",
+                                              owner=dprov_app_owner_uuid,
+                                              tags=app_tags,
+                                              application_name=app.name,
+                                              application_version=app_version.name,
+                                              application_description=app.description,
+                                              application_owner=app_creator_uname,
+                                              application_tags=json.dumps(app_tags),
+                                              application_uuid=str(app.uuid),
+                                              )
+            if ami:
+                dprov_glance_client.images.update(dprov_glance_image.id,
+                                                  kernel_id=sprov_glance_image.kernel_id,
+                                                  ramdisk_id=sprov_glance_image.ramdisk_id)
         else:
             dprov_glance_client.images.update(dprov_glance_image.id,
                                               name=app.name,

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -245,7 +245,7 @@ def main(application_id,
         sprov_img_uuid = sprov_instance_source.identifier
         
         sprov_acct_driver = service.driver.get_account_driver(sprov, raise_exception=True)
-        if src_glance_client_version:
+        if src_glance_client_version == 1:
             sprov_keystone_client = service.driver.get_account_driver(sprov, raise_exception=True)
             sprov_glance_client = _connect_to_glance(sprov_keystone_client, version=src_glance_client_version)
         else:

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -327,7 +327,6 @@ def main(application_id,
                                                   application_owner=app_creator_uname,
                                                   application_tags=json.dumps(app_tags),
                                                   application_uuid=str(app.uuid))
-                                                  # Todo min_disk? min_ram? Do we care?
                                               )
             if ami:
                 dprov_glance_client.images.update(dprov_glance_image.id,
@@ -368,7 +367,6 @@ def main(application_id,
                                               application_owner=app_creator_uname,
                                               application_tags=json.dumps(app_tags),
                                               application_uuid=str(app.uuid),
-                                              # Todo min_disk? min_ram? Do we care?
                                               )
             if ami:
                 dprov_glance_client.images.update(dprov_glance_image.id,

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -581,7 +581,6 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
                         password=irods_conn.get('password'))
     src_data_obj_path = os.path.join(irods_src_coll, img_uuid)
     dst_data_obj_path = os.path.join(irods_dst_coll, img_uuid)
-    print(src_data_obj_path, dst_data_obj_path)
     sess.data_objects.copy(src_data_obj_path, dst_data_obj_path)
     logging.info("Copied image data to destination collection in iRODS")
     dst_img_location = "irods://{0}:{1}@{2}:{3}{4}".format(
@@ -592,7 +591,7 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
         dst_data_obj_path
     )
     # Assumption that iRODS copy will always be correct+complete, not inspecting checksums afterward?
-    if int(dst_glance_client_version) == 1:
+    if dst_glance_client_version == 1:
         dst_glance_client.images.update(img_uuid, location=dst_img_location)
     else:
         dst_glance_client.images.add_location(img_uuid, dst_img_location, dict())


### PR DESCRIPTION
## Description

Glance has made API changes in version 2.5 which [add community-level image sharing](https://specs.openstack.org/openstack/glance-specs/specs/newton/approved/glance/community_visibility.html). The new image visibility sematics use `private` to mean "not shared with anyone, only accessible to owner", and `shared` to mean "private but can have additional members". We were previously using "private" when, for Glance API v2.5+, we should now use "shared". This PR fixes `application_to_provider.py` to reflect this.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
