### PR TITLE
Metadata syncing refactor

### DIFF
--- a/scripts/application_sync_providers.py
+++ b/scripts/application_sync_providers.py
@@ -161,7 +161,7 @@ def _app_complete_on_provider(application, provider):
     """
     for av in application.active_versions():
         av_on_prov = False
-        for prov_machine in av.active_machines():
+        for prov_machine in av.machines.all():
             if prov_machine.instance_source.provider == provider:
                 av_on_prov = True
         if not av_on_prov:

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -107,10 +107,10 @@ def _parse_args():
                              "attempt. (Local cache is always deleted after successful upload). "
                              "May consume a lot of disk space.")
     parser.add_argument("--src-glance-client-version",
-                        type=int,
+                        type=float,
                         help="Glance client version to use for source provider")
     parser.add_argument("--dst-glance-client-version",
-                        type=int,
+                        type=float,
                         help="Glance client version to use for destination provider")
     parser.add_argument("--irods-conn",
                         type=str, metavar="irods://user:password@host:port/zone",
@@ -335,6 +335,25 @@ def main(application_id,
                                                       kernel_id=sprov_glance_image.kernel_id,
                                                       ramdisk_id=sprov_glance_image.ramdisk_id)
                                                   )
+        elif dst_glance_client_version >= 2.5:
+            dprov_glance_client.images.update(dprov_glance_image.id,
+                                              name=app.name,
+                                              container_format="ami" if ami else sprov_glance_image.container_format,
+                                              disk_format="ami" if ami else sprov_glance_image.disk_format,
+                                              visibility="shared" if app.private else "public",
+                                              owner=dprov_app_owner_uuid,
+                                              tags=app_tags,
+                                              application_name=app.name,
+                                              application_version=app_version.name,
+                                              application_description=app.description,
+                                              application_owner=app_creator_uname,
+                                              application_tags=json.dumps(app_tags),
+                                              application_uuid=str(app.uuid),
+                                              )
+            if ami:
+                dprov_glance_client.images.update(dprov_glance_image.id,
+                                                  kernel_id=sprov_glance_image.kernel_id,
+                                                  ramdisk_id=sprov_glance_image.ramdisk_id)
         else:
             dprov_glance_client.images.update(dprov_glance_image.id,
                                               name=app.name,

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -245,7 +245,7 @@ def main(application_id,
         sprov_img_uuid = sprov_instance_source.identifier
         
         sprov_acct_driver = service.driver.get_account_driver(sprov, raise_exception=True)
-        if src_glance_client_version:
+        if src_glance_client_version == 1:
             sprov_keystone_client = service.driver.get_account_driver(sprov, raise_exception=True)
             sprov_glance_client = _connect_to_glance(sprov_keystone_client, version=src_glance_client_version)
         else:

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -327,7 +327,6 @@ def main(application_id,
                                                   application_owner=app_creator_uname,
                                                   application_tags=json.dumps(app_tags),
                                                   application_uuid=str(app.uuid))
-                                                  # Todo min_disk? min_ram? Do we care?
                                               )
             if ami:
                 dprov_glance_client.images.update(dprov_glance_image.id,
@@ -368,7 +367,6 @@ def main(application_id,
                                               application_owner=app_creator_uname,
                                               application_tags=json.dumps(app_tags),
                                               application_uuid=str(app.uuid),
-                                              # Todo min_disk? min_ram? Do we care?
                                               )
             if ami:
                 dprov_glance_client.images.update(dprov_glance_image.id,

--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -581,7 +581,6 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
                         password=irods_conn.get('password'))
     src_data_obj_path = os.path.join(irods_src_coll, img_uuid)
     dst_data_obj_path = os.path.join(irods_dst_coll, img_uuid)
-    print(src_data_obj_path, dst_data_obj_path)
     sess.data_objects.copy(src_data_obj_path, dst_data_obj_path)
     logging.info("Copied image data to destination collection in iRODS")
     dst_img_location = "irods://{0}:{1}@{2}:{3}{4}".format(
@@ -592,7 +591,7 @@ def migrate_image_data_irods(dst_glance_client, irods_conn, irods_src_coll, irod
         dst_data_obj_path
     )
     # Assumption that iRODS copy will always be correct+complete, not inspecting checksums afterward?
-    if int(dst_glance_client_version) == 1:
+    if dst_glance_client_version == 1:
         dst_glance_client.images.update(img_uuid, location=dst_img_location)
     else:
         dst_glance_client.images.add_location(img_uuid, dst_img_location, dict())


### PR DESCRIPTION
## Description

- Fixed: `application_to_provider` previously did not migrate custom image metadata, such as `atmo_image_include` which J7m is using as part of their machine validation strategy; this caused `InstanceSource`s in replica providers to be end-dated by `prune_machines`.
- Fixed: `application_sync_providers` previously only looked at active (non-end-dated) `InstanceSource`s + `ProviderMachine`s on a replica provider to determine if an `Application` was "complete" on that provider; this caused unnecessary work for the script when the `Application` was complete on a replica provider but at least one of its `InstanceSource`s was end-dated.
- Refactored the part of `application_to_provider` which sets metadata, for less code duplication

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~ Tested on J7m
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
