### PR TITLE
Revert "Remove the action that sends requests to RT tracker"

### DIFF
--- a/api/v2/views/base.py
+++ b/api/v2/views/base.py
@@ -166,7 +166,11 @@ class BaseRequestViewSet(MultipleFieldLookup, AuthModelViewSet):
                 status=status,
                 created_by=self.request.user
             )
-            self.submit_action(instance)
+            if serializer.initial_data.get("admin_url"):
+                admin_url = serializer.initial_data.get("admin_url") + str(instance.id)
+                self.submit_action(instance, options={"admin_url": admin_url})
+            else: 
+                self.submit_action(instance)
         except (core_exceptions.ProviderLimitExceeded,  # NOTE: DEPRECATED -- REMOVE SOON, USE BELOW.
                 core_exceptions.RequestLimitExceeded):
             message = "Only one active request is allowed per provider."

--- a/api/v2/views/resource_request.py
+++ b/api/v2/views/resource_request.py
@@ -130,6 +130,14 @@ class ResourceRequestViewSet(MultipleFieldLookup, AuthModelViewSet):
             created_by=self.request.user,
             status=status
         )
+        options = {}
+        if serializer.initial_data.get("admin_url"):
+            options={"admin_url": serializer.initial_data.get("admin_url") + str(instance.id)}
+        email.resource_request_email(self.request,
+                                     self.request.user.username,
+                                     instance.request,
+                                     instance.description,
+                                     options)
 
     def perform_destroy(self, serializer):
         """


### PR DESCRIPTION
Problem: attempt at removing RT from resource request approval was too ambitious
Solution: send resource requests to RT

We are going to continue sending resource requests to RT until the admin
resource request view is a closer replacement. Right now there's no way to
view closed requests and no way to reach out to the user for clarification.

This reverts commit f7702f309f69ae51ed8b757357c6fa86449783df.

Dependent pr https://github.com/cyverse/troposphere/pull/736
## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [x] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
