### PR TITLE
Fix old requirment that resource request is associated with identity

### DIFF
--- a/api/tests/v2/test_resource_requests.py
+++ b/api/tests/v2/test_resource_requests.py
@@ -103,7 +103,11 @@ class UserResourceRequestTests(APITestCase):
         url = reverse('api:v2:resourcerequest-list')
         view = ResourceRequestViewSet.as_view({'post': 'create'})
         factory = APIRequestFactory()
-        request = factory.post(url, {'request': "100000 AU", 'description': 'Make world better place'})
+        request = factory.post(url, {
+            'request': "100000 AU",
+            'description': 'Make world better place',
+            'admin_url': 'https://local.atmo.cloud/application/admin/resource_requests/'
+        })
         force_authenticate(request, user=user)
         response = view(request)
 

--- a/core/email.py
+++ b/core/email.py
@@ -571,21 +571,16 @@ def resource_request_email(request, username, quota, reason, options={}):
 
     Returns a response.
     """
-    user = User.objects.get(username=username)
-    membership = IdentityMembership.objects.get(
-        identity=user.select_identity(),
-        member__in=user.memberships.values_list('group__id',flat=True))
-    admin_url = reverse('admin:core_identitymembership_change',
-                        args=(membership.id,))
 
+    url = None
     if 'admin_url' in options:
-        admin_url = options['admin_url']
+        url = request.build_absolute_uri(options['admin_url'])
 
     subject = "Atmosphere Resource Request - %s" % username
     context = {
         "quota": quota,
         "reason": reason,
-        "url": request.build_absolute_uri(admin_url)
+        "url": url
     }
     context.update(request_data(request))
     body = render_to_string("resource_request.html", context=context)

--- a/core/templates/core/email/resource_request.html
+++ b/core/templates/core/email/resource_request.html
@@ -1,12 +1,12 @@
 Username : {{ username }} ({{ name }})
 
-Resource Requested : 
+Resource Requested :
     {{ quota }}
 
-Reason for Increase : 
+Reason for Increase :
     {{ reason }}
-
-URL for Resource Increase : 
+{% if url %}
+URL for Resource Increase :
     {{ url }}
-
+{% endif %}
 {% include "fingerprint.html" %}


### PR DESCRIPTION
Problem: email sent to RT during test failed
Solution: fix email logic to no longer require the submitting user to have identities

This fixes a failing test when the resource request email is sent. The admin
url is supplied and passed by troposphere. It's optional, the default url is
constructed from the user's selected identity. Because the test user has no identities, the test failed.

There is no longer any reason to try and construct this admin_url in the
template email from an identity, so it has been removed.

The tests have been updated to reflect that troposphere provides an admin_url. The email template supports an optional admin_url if it's not supplied.

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
