### PR TITLE
Problem: unused variable became "used" again

### DIFF
--- a/api/v2/views/resource_request.py
+++ b/api/v2/views/resource_request.py
@@ -127,7 +127,7 @@ class ResourceRequestViewSet(MultipleFieldLookup, AuthModelViewSet):
         Create a resource request
         """
         status, _ = StatusType.objects.get_or_create(name='pending')
-        serializer.save(
+        instance = serializer.save(
             created_by=self.request.user,
             status=status
         )


### PR DESCRIPTION
## Description

This resolves a Travis CI build failure. It brings back a variable, `instance`, removed in #554.

Thank you Travis CI! 🎉 
