### PR TITLE
Fix quota cannot exceed limit

### DIFF
--- a/service/quota.py
+++ b/service/quota.py
@@ -227,6 +227,7 @@ def _set_compute_quota(user_quota, identity):
         'floating_ips': user_quota.floating_ip_count,
         'fixed_ips': user_quota.port_count,
         'instances': user_quota.instance_count,
+        'force': True
     }
     creds = identity.get_all_credentials()
     use_tenant_id = False

--- a/service/quota.py
+++ b/service/quota.py
@@ -251,13 +251,13 @@ def _set_compute_quota(user_quota, identity):
         except Exception:
             logger.exception("Could not set a user-quota, trying to set tenant-quota")
             raise
-        # FIXME: For jetstream, return result here.
-    # For CyVerse old clouds, run the top method. don't use try/except.
-    try:
-        result = admin_driver._connection.ex_update_quota_for_user(
-            tenant_id, ks_user.id, compute_values, use_tenant_id=use_tenant_id)
-    except Exception:
-        logger.exception("Could not set a user-quota, trying to set tenant-quota")
-        raise
-    logger.info("Updated quota for %s to %s" % (username, result))
+    else:
+        # For CyVerse old clouds, run the top method. don't use try/except.
+        try:
+            result = admin_driver._connection.ex_update_quota_for_user(
+                tenant_id, ks_user.id, compute_values, use_tenant_id=use_tenant_id)
+        except Exception:
+            logger.exception("Could not set a user-quota, trying to set tenant-quota")
+            raise
+        logger.info("Updated quota for %s to %s" % (username, result))
     return result


### PR DESCRIPTION
## Description

Problem: 
Updating quota would often fail with the following message:
```
Quota limit must be greater than or equal to ...
```
Solution:
Send `force: True` in the body of the request

Here are the official docs
https://github.com/openstack/nova/blob/master/api-ref/source/os-quota-sets.inc#update-quotas


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
