### PR TITLE
Enforcement override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@
   install:
     # setuptools and pip-tools are necessary for ./travis/check_properly_generated_requirements.sh
     - pip install -U pip setuptools
-    - pip install pip-tools==1.9.0
+    - pip install pip-tools==1.11.0
 
   before_script:
     - psql -c "CREATE USER atmosphere_db_user WITH PASSWORD 'atmosphere_db_pass' CREATEDB;" -U postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [Carbonaceous-Comet(v29)](https://github.com/cyverse/atmosphere/milestone/16?closed=1) (as of 11/9/2017)
+## [Delightful-Duboshin (v30)](https://github.com/cyverse/atmosphere/milestone/17?closed=1) (as of 2017-12-18)
+
+New Features:
+-  Site operators can override enforcement behavior for specific allocation sources
+
+
+## [Carbonaceous-Comet (v29)](https://github.com/cyverse/atmosphere/milestone/16?closed=1) (as of 2017-11-09)
 New Features:
 - Site operators can now create machine validation plugins to control the flow of images in the atmosphere image catalog.
 - Users can now select a `guacamole_color` in their UserProfile, which will correspond to the theme used in guacamole web shell sessions.
@@ -12,7 +18,7 @@ Internal:
 - Update travis to include code linting
 - Enable auto reload for uwsgi as an option for configuration.
 - Celery init.d scripts are no longer included in Atmosphere. Use clank for installation/configuration of celery.
-## [Beneficent-Bolide(v28)](https://github.com/cyverse/atmosphere/milestone/15?closed=1) (as of 10/3/2017)
+## [Beneficent-Bolide(v28)](https://github.com/cyverse/atmosphere/milestone/15?closed=1) (as of 2017-10-03)
 New Features:
 - Users can now set 'access_list' on an application
   to specify an email/username pattern. Users that
@@ -39,7 +45,7 @@ Internal:
 - Introduced new manage.py command to start/stop a maintenance
 - Behave will be quieter in travis.ci
 
-## [Ancient-Asteroid(v27)](https://github.com/cyverse/atmosphere/milestone/14?closed=1) (as of 9/19/2017)
+## [Ancient-Asteroid(v27)](https://github.com/cyverse/atmosphere/milestone/14?closed=1) (as of 2017-09-19)
 Improvements:
 - Ansible will now deploy user-boot-scripts
 - API /v2/sizes includes 'root' attribute (Root disk size)
@@ -76,7 +82,7 @@ Deprecated:
   - /api/v2/allocations has been removed
   - identity.allocation, and quota.allocation have been removed
 
-## [Zesty-Zapdos](https://github.com/cyverse/atmosphere/milestone/13?closed=1) (as of 7/17/2017)
+## [Zesty-Zapdos](https://github.com/cyverse/atmosphere/milestone/13?closed=1) (as of 2017-07-17)
 
 Improvements:
  - Disable instance sizes if the hosting image has a disk size thats larger than what is allowed.
@@ -99,7 +105,7 @@ Internal:
  - Include script for replication of an application to a provider
 
 
-## [Yampy-Yellowlegs](https://github.com/cyverse/atmosphere/milestone/12?closed=1) (as of 6/12/2017)
+## [Yampy-Yellowlegs](https://github.com/cyverse/atmosphere/milestone/12?closed=1) (as of 2017-06-12)
 
 Improvements:
  - Improvements related to the new Allocation Source model introduced in Xenops
@@ -114,7 +120,7 @@ Internal:
  - Move web_desktop functionality to Atmosphere from Troposphere
  - New script created to help migrate an entire application to a new provider
 
-## [Xylotomous-Xenops](https://github.com/cyverse/atmosphere/milestone/11?closed=1) (as of 5/2/2017)
+## [Xylotomous-Xenops](https://github.com/cyverse/atmosphere/milestone/11?closed=1) (as of 2017-05-02)
  
 Improvements:
  - Updated Atmosphere to latest subspace Ansible 2.3 (https://github.com/cyverse/atmosphere/commit/253bf6d23ab1be0e15f35d97fa9a2b238b9bc639)
@@ -137,7 +143,7 @@ Internal:
  
  
 
-## [Whimsical-Wyvern](https://github.com/cyverse/atmosphere/milestone/10?closed=1) (as of 4/6/2017)
+## [Whimsical-Wyvern](https://github.com/cyverse/atmosphere/milestone/10?closed=1) (as of 2017-04-06)
 
 Features:
   - Include sentry.io error reporting for production environments
@@ -160,7 +166,7 @@ Internal:
   - Provide optional cloud_config options in 'deploy' section: 'volume_fs_type' and 'volume_mount_prefix'
   - Image validation is now a feature flag, configurable from settings.ENABLE_IMAGE_VALIDATION
 
-## [Voracious-Velociraptor](https://github.com/cyverse/atmosphere/milestone/9?closed=1) (as of 2/14/2017)
+## [Voracious-Velociraptor](https://github.com/cyverse/atmosphere/milestone/9?closed=1) (as of 2017-02-14)
 
 Features:
   - Image validation works as intended (and deletes instance on cleanup)
@@ -176,7 +182,7 @@ Internal:
   - Remove iPlant-isms from template pages
   - Fix logfile growing pains
 
-## Undulating-Umbrellabird (as of 1/4/17)
+## Undulating-Umbrellabird (as of 2017-01-04)
 
 Features:
   - move from iplantauth to django_cyverse_auth

--- a/cyverse_allocation/plugins/allocation_source.py
+++ b/cyverse_allocation/plugins/allocation_source.py
@@ -23,6 +23,38 @@ class FlexibleAllocationSourcePlugin(object):
 
         return _ensure_user_allocation_source(user)
 
+    def get_enforcement_override(self, user, allocation_source, provider=None):
+        """Returns whether (and how) to override the enforcement for a particular user, allocation source and provider
+        combination.
+
+        :param user: The user to check (not used by this plugin)
+        :type user: core.models.AtmosphereUser
+        :param allocation_source: The allocation source to check
+        :type allocation_source: core.models.AllocationSource
+        :param provider: The provider (not used by this plugin)
+        :type provider: core.models.Provider
+        :return: The enforcement override behaviour for the allocation source on the provider
+        :rtype: core.plugins.EnforcementOverrideChoice
+        """
+        return _get_enforcement_override(allocation_source)
+
+
+def _get_enforcement_override(allocation_source):
+    """Returns whether (and how) to override the enforcement for an allocation source.
+
+        :param allocation_source: The allocation source to check
+        :type allocation_source: core.models.AllocationSource
+        :return: The enforcement override behaviour for the allocation source on the provider
+        :rtype: core.plugins.EnforcementOverrideChoice
+        """
+    assert isinstance(allocation_source, AllocationSource)
+    import core.plugins
+    if allocation_source.name in getattr(settings, 'ALLOCATION_OVERRIDES_NEVER_ENFORCE', []):
+        return core.plugins.EnforcementOverrideChoice.NEVER_ENFORCE
+    if allocation_source.name in getattr(settings, 'ALLOCATION_OVERRIDES_ALWAYS_ENFORCE', []):
+        return core.plugins.EnforcementOverrideChoice.ALWAYS_ENFORCE
+    return core.plugins.EnforcementOverrideChoice.NO_OVERRIDE
+
 
 def _ensure_user_allocation_source(user):
     """Ensures that a user has valid allocation sources.

--- a/features/allocation.features/enforcing_override.feature
+++ b/features/allocation.features/enforcing_override.feature
@@ -1,0 +1,62 @@
+@skip-if-jetstream
+Feature: Override enforcing allocation usage on CyVerse
+
+  Background:
+    Given a dummy browser
+    And a current time of '2017-02-15T05:00:00Z' with tick = False
+    And "Admin" as the persona
+    When I set "username" to "admin"
+    And I set "password" to "very-clever-admin-password"
+    And we create a new admin user
+    And we create a provider "MockProvider"
+    And we create an identity for the current persona on provider "MockProvider"
+    And we make the current identity the admin on provider "MockProvider"
+
+  Scenario Outline: Override enforcement behavior for individual allocation sources
+    Given "anybody" as the persona
+    When I set "username" to "<username>"
+    And I set "password" to "some-very-long-string"
+    And we create a new user
+    Given a current time of '2017-02-16T06:00:00Z' with tick = False
+    When I log in
+    And we create an identity for the current persona on provider "MockProvider"
+    And we ensure that the user has an allocation source
+    And I set "allocation_source" to allocation source with name "<username>"
+    And I set "allocation_source_uuid" to attribute "uuid" of "allocation_source"
+    Then we should have the following user allocation sources
+      | atmosphere_username | allocation_source   |
+      | <username>          | <allocation_source> |
+    And we should have the following events
+      | entity_id           | name                                 | payload                                                                                                                                                    | timestamp                |
+      | <allocation_source> | allocation_source_created_or_renewed | {"renewal_strategy": "default", "uuid": "{allocation_source_uuid}", "allocation_source_name": "<allocation_source>", "compute_allowed": <compute_allowed>} | 2017-02-16 06:00:00+0000 |
+      | <username>          | user_allocation_source_created       | {"allocation_source_name": "<username>"}                                                                                                                   | 2017-02-16 06:00:00+0000 |
+
+    Given a current time of '<start_date>' with tick = False
+    When we create a provider machine for current persona
+    And we create an active instance
+    And I assign allocation source "<allocation_source>" to active instance
+
+    Given a current time of '<end_date>' with tick = False
+    When we update CyVerse snapshots
+    Then we should have the following allocation source snapshots
+      | name                | compute_used   | compute_allowed   |
+      | <allocation_source> | <compute_used> | <compute_allowed> |
+    And we should have the following user allocation source snapshots
+      | atmosphere_username | allocation_source   | compute_used   | burn_rate |
+      | <username>          | <allocation_source> | <compute_used> | 1.000     |
+    When the `monitor_allocation_sources` scheduled task is run with settings
+      | allocation_source   | override   |
+      | <allocation_source> | <override> |
+    Then `allocation_source_overage_enforcement_for_user` was called as follows
+      | username   | allocation_source   | called    |
+      | <username> | <allocation_source> | <enforce> |
+
+
+    Examples:
+      | username | allocation_source | override       | compute_allowed | start_date           | end_date             | compute_used | enforce |
+      | user801  | user801           | NO_OVERRIDE    | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | No      |
+      | user802  | user802           | NEVER_ENFORCE  | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | No      |
+      | user803  | user803           | ALWAYS_ENFORCE | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | Yes     |
+      | user804  | user804           | NO_OVERRIDE    | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | Yes     |
+      | user805  | user805           | NEVER_ENFORCE  | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | No      |
+      | user806  | user806           | ALWAYS_ENFORCE | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | Yes     |

--- a/features/jetstream.features/enforcing_override.feature
+++ b/features/jetstream.features/enforcing_override.feature
@@ -1,0 +1,101 @@
+@skip-if-cyverse
+Feature: Override enforcing allocation usage on Jetstream
+
+  Scenario Outline: Override enforcement behavior for individual allocation sources
+    Given a dummy browser
+    And a TAS API driver
+    And a current time of '2017-02-15T05:00:00Z'
+    And we clear the local cache
+    And the following Atmosphere users
+      | username |
+    And the following XSEDE to TACC username mappings
+      | xsede_username | tacc_username   |
+      | <username>     | tacc_<username> |
+    And the following TAS projects
+      | id    | chargeCode          |
+      | 29444 | <allocation_source> |
+    And the following TAS allocations
+      | id    | projectId | project             | computeAllocated  | computeUsed | start                | end                  | status | resource  |
+      | 38229 | 29444     | <allocation_source> | <compute_allowed> | 0           | 2016-01-01T06:00:00Z | 2017-06-30T05:00:00Z | Active | Jetstream |
+    And the following TACC usernames for TAS projects
+      | project             | tacc_usernames  |
+      | <allocation_source> | tacc_<username> |
+    When we get all projects
+    Then we should have the following local projects
+      | id    | chargeCode          |
+      | 29444 | <allocation_source> |
+    And we should have the following local allocations
+      | id    | projectId | project             | computeAllocated  | computeUsed | start                | end                  | status | resource  |
+      | 38229 | 29444     | <allocation_source> | <compute_allowed> | 0           | 2016-01-01T06:00:00Z | 2017-06-30T05:00:00Z | Active | Jetstream |
+    When we fill user allocation sources from TAS
+    Then we should have the following local username mappings
+      | key | value |
+    And we should have the following events
+      | entity_id | name | payload | timestamp |
+
+
+    Given "Admin" as the persona
+    When I set "username" to "admin"
+    And I set "password" to "very-clever-admin-password"
+    And we create a new admin user
+    And we create a provider "MockProvider"
+    And we create an identity for the current persona on provider "MockProvider"
+    And we make the current identity the admin on provider "MockProvider"
+
+    Given "<username>" as the persona
+    When I set "username" to "<username>"
+    And I set "password" to "some-very-long-string"
+
+    Given a current time of '2017-02-16T06:00:00Z' with tick = False
+    When I log in with valid XSEDE project required and default quota plugin enabled
+    And we create an account for the current persona on provider "MockProvider"
+    And I set "allocation_source" to allocation source with name "<allocation_source>"
+    And I set "allocation_source_uuid" to attribute "uuid" of "allocation_source"
+    Then we should have the following user allocation sources
+      | atmosphere_username | allocation_source   |
+      | <username>          | <allocation_source> |
+    And we should have the following events
+      | entity_id  | name                                      | payload                                                                                                                                                           | timestamp                |
+      |            | allocation_source_created_or_renewed      | {"allocation_source_name": "<allocation_source>", "start_date": "2016-01-01T06:00:00Z", "end_date": "2017-06-30T05:00:00Z", "compute_allowed": <compute_allowed>} | 2017-02-16 06:00:00+0000 |
+      |            | allocation_source_compute_allowed_changed | {"allocation_source_name": "<allocation_source>", "start_date": "2016-01-01T06:00:00Z", "end_date": "2017-06-30T05:00:00Z", "compute_allowed": <compute_allowed>} | 2017-02-16 06:00:00+0000 |
+      | <username> | user_allocation_source_created            | {"allocation_source_name": "<allocation_source>"}                                                                                                                 | 2017-02-16 06:00:00+0000 |
+
+    Given a current time of '<start_date>' with tick = False
+    When we create a provider machine for current persona
+    And we create an active instance
+    And I assign allocation source "<allocation_source>" to active instance
+
+    And I set "instance01" to another variable "active_instance"
+    Then we should have the following "instance_allocation_source_changed" events
+      | entity_id  | name                               | payload                                                                                         | timestamp                |
+      | <username> | instance_allocation_source_changed | {"instance_id": "{instance01.provider_alias}", "allocation_source_name": "<allocation_source>"} | 2017-02-16 07:00:00+0000 |
+
+    Given a current time of '<end_date>' with tick = False
+    And the following TAS projects
+      | id    | chargeCode          |
+      | 29444 | <allocation_source> |
+    And the following TAS allocations
+      | id    | projectId | project             | computeAllocated  | computeUsed    | start                | end                  | status | resource  |
+      | 38229 | 29444     | <allocation_source> | <compute_allowed> | <compute_used> | 2016-01-01T06:00:00Z | 2017-06-30T05:00:00Z | Active | Jetstream |
+    When we update snapshots
+    Then we should have the following allocation source snapshots
+      | name                | compute_used   | compute_allowed   |
+      | <allocation_source> | <compute_used> | <compute_allowed> |
+    And we should have the following user allocation source snapshots
+      | atmosphere_username | allocation_source   | compute_used   | burn_rate |
+      | <username>          | <allocation_source> | <compute_used> | 1.000     |
+    When the `monitor_allocation_sources` scheduled task is run with settings
+      | allocation_source   | override   |
+      | <allocation_source> | <override> |
+    Then `allocation_source_overage_enforcement_for_user` was called as follows
+      | username   | allocation_source   | called    |
+      | <username> | <allocation_source> | <enforce> |
+
+    Examples:
+      | username | allocation_source | override       | compute_allowed | start_date           | end_date             | compute_used | enforce |
+      | user901  | TG-BIO150091      | NO_OVERRIDE    | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | No      |
+      | user902  | TG-BIO150092      | NEVER_ENFORCE  | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | No      |
+      | user903  | TG-BIO150093      | ALWAYS_ENFORCE | 168             | 2017-02-16T07:00:00Z | 2017-02-17T07:00:00Z | 24           | Yes     |
+      | user904  | TG-BIO150094      | NO_OVERRIDE    | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | Yes     |
+      | user905  | TG-BIO150095      | NEVER_ENFORCE  | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | No      |
+      | user906  | TG-BIO150096      | ALWAYS_ENFORCE | 168             | 2017-02-16T07:00:00Z | 2017-02-24T07:00:00Z | 192          | Yes     |

--- a/features/steps/api_with_persona_steps.py
+++ b/features/steps/api_with_persona_steps.py
@@ -200,9 +200,9 @@ def we_create_allocation_source_through_api(context):
     for row in context.table:
         response = client.post('/api/v2/allocation_sources',
                                {
-                                   'renewal_strategy': row['renewal strategy'],
+                                   'renewal_strategy': row['renewal_strategy'],
                                    'name': row['name'],
-                                   'compute_allowed': row['compute allowed']
+                                   'compute_allowed': row['compute_allowed']
                                })
         if 'uuid' in response.data and response.data['uuid']:
             allocation_source_ids = context.persona.get('allocation_source_ids', {})

--- a/features/volume.features/create_and_edit_volume.feature
+++ b/features/volume.features/create_and_edit_volume.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Create volume and add to projects
 
   Background:

--- a/jetstream/plugins/allocation_source.py
+++ b/jetstream/plugins/allocation_source.py
@@ -1,3 +1,8 @@
+from django.conf import settings
+
+from core.models import AllocationSource
+
+
 class JetstreamAllocationSourcePlugin(object):
     def ensure_user_allocation_source(self, user, provider=None):
         """Ensures that a user has valid allocation sources.
@@ -12,5 +17,38 @@ class JetstreamAllocationSourcePlugin(object):
         :rtype: bool
         """
         return True  # TODO: Implement this
+
+    def get_enforcement_override(self, user, allocation_source, provider=None):
+        """Returns whether (and how) to override the enforcement for a particular user, allocation source and provider
+        combination.
+
+        :param user: The user to check (not used by this plugin)
+        :type user: core.models.AtmosphereUser
+        :param allocation_source: The allocation source to check
+        :type allocation_source: core.models.AllocationSource
+        :param provider: The provider (not used by this plugin)
+        :type provider: core.models.Provider
+        :return: The enforcement override behaviour for the allocation source on the provider
+        :rtype: core.plugins.EnforcementOverrideChoice
+        """
+        return _get_enforcement_override(allocation_source)
+
+
+def _get_enforcement_override(allocation_source):
+    """Returns whether (and how) to override the enforcement for an allocation source.
+
+        :param allocation_source: The allocation source to check
+        :type allocation_source: core.models.AllocationSource
+        :return: The enforcement override behaviour for the allocation source on the provider
+        :rtype: core.plugins.EnforcementOverrideChoice
+        """
+    assert isinstance(allocation_source, AllocationSource)
+    import core.plugins
+    if allocation_source.name in getattr(settings, 'ALLOCATION_OVERRIDES_NEVER_ENFORCE', []):
+        return core.plugins.EnforcementOverrideChoice.NEVER_ENFORCE
+    if allocation_source.name in getattr(settings, 'ALLOCATION_OVERRIDES_ALWAYS_ENFORCE', []):
+        return core.plugins.EnforcementOverrideChoice.ALWAYS_ENFORCE
+    return core.plugins.EnforcementOverrideChoice.NO_OVERRIDE
+
 
 __all__ = ['JetstreamAllocationSourcePlugin']

--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,7 @@ django-redis-cache
 itsdangerous
 redis
 eventlet
+enum34
 
 Jinja2
 django-celery-beat

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ djangorestframework-xml==1.3.0
 djangorestframework-yaml==1.0.3
 djangorestframework==3.6.3
 enum-compat==0.0.2        # via eventlet
-enum34==1.1.6             # via cryptography, enum-compat
+enum34==1.1.6
 eventlet==0.21.0
 fabric==1.10              # via rfive
 flower==0.9.2

--- a/travis/check_properly_generated_requirements.sh
+++ b/travis/check_properly_generated_requirements.sh
@@ -11,7 +11,7 @@
 # This script properly generates the requirements and performs a diff with the
 # current requirements.
 
-PIP_TOOLS_VERSION=1.9.0
+PIP_TOOLS_VERSION=1.11.0
 
 function main {
 
@@ -60,7 +60,7 @@ function generate_requirements {
 }
 
 function pip-tools-version {
-    pip-compile --version | grep -Po '\d\.\d\.\d';
+    pip-compile --version | grep -Po '\d+\.\d+\.\d+';
 }
 
 function warn_improper_pip_tools_version {


### PR DESCRIPTION
Problem: Need admin override for overage enforcement

Required behavior:
- Ignore enforcement/always allow: Allow allocations to "run" regardless
of SUs remaining in the allocation
- Always block: Prevent allocations or accounts (as appropriate) from
"running" regardless of SUs remaining in the allocation

Solution:
- Added a `get_enforcement_override` method on the allocation
source plugins
- The `monitor_allocation_sources` task checks the return value of this
method for every user + allocation source combination. If the value is:
  - `NEVER_ENFORCE`: Enforcement is always skipped
  - `ALWAYS_ENFORCE`: Enforcement is always triggered
  - `NO_OVERRIDE`: Enforcement depends on the `compute_used` (default)

For the initial version of this feature both the CyVerse & Jetstream
plugins will check the Django settings for two variables:

- `ALLOCATION_OVERRIDES_NEVER_ENFORCE`
- `ALLOCATION_OVERRIDES_ALWAYS_ENFORCE`

These should be lists with allocation source names.

Note: Global setting `ENFORCING` overrides any other behavior.
So if an allocation source has an override of `ALWAYS_ENFORCE`, but
`ENFORCING = False`, then no enforcement action will occur.

Proposed future enhancements:

- An admin panel where staff can configure this feature


## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- [x] If necessary, include a snippet in CHANGELOG.md
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
