### PR TITLE
WIP Problem: Special allocation quota not set on first login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Bugfixes:
     - Legacy clouds need to call 'list images' twice and append info to the v2 api.
     - Skip machines if their status is 'queued' or 'saving'
 - Various small bug fixes like undefined variables and attributes
+- Workaround cron script for special allocation quota not being set on first login
 
 
 ## [Carbonaceous-Comet (v29)](https://github.com/cyverse/atmosphere/milestone/16?closed=1) (as of 2017-11-09)

--- a/scripts/enforce_special_allocation_quota.py
+++ b/scripts/enforce_special_allocation_quota.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+import argparse
+
+import django
+
+django.setup()
+
+from core.models import Identity
+
+from service.quota import set_provider_quota
+
+
+def main():
+    """
+    Return a list of ALL users on a provider, their CURRENT allocation totals,
+    and # of instances used.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true', help='Print output rather than perform operation')
+    parser.set_defaults(dry_run=False)
+    args = parser.parse_args()
+    return run_command(args, special_allocation_source='TG-ASC160018')
+
+
+def run_command(args, special_allocation_source):
+    query = '''SELECT identity.*
+FROM
+  (SELECT
+     atmosphere_user.id,
+     atmosphere_user.username,
+     array_agg(allocation_source.name) allocation_sources
+   FROM public.atmosphere_user
+     LEFT JOIN public.user_allocation_source ON atmosphere_user.id = user_allocation_source.user_id
+     LEFT JOIN public.allocation_source ON user_allocation_source.allocation_source_id = allocation_source.id
+   GROUP BY atmosphere_user.id
+   HAVING array_agg(allocation_source.name) = '{TG-ASC160018}'
+   ORDER BY username) AS users
+  LEFT OUTER JOIN public.identity ON identity.created_by_id = users.id
+  LEFT OUTER JOIN public.quota ON identity.quota_id = quota.id
+WHERE
+  identity.quota_id <> 33
+  AND identity.quota_id IS NOT NULL;'''
+
+    identities = Identity.objects.raw(raw_query=query)
+    for identity in identities:
+        print(identity)
+        print(identity.quota)
+        if not args.dry_run:
+            identity.quota_id = 33
+            identity.save()
+            set_provider_quota(identity.uuid)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enforce_special_allocation_quota.sh
+++ b/scripts/enforce_special_allocation_quota.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+HOME="/opt/dev/atmosphere"
+VIRTUAL="/opt/env/atmo"
+export DJANGO_SETTINGS_MODULE="atmosphere.settings"
+export PYTHONPATH="$HOME:$PYTHONPATH"
+cd $HOME
+. $VIRTUAL/bin/activate
+python $HOME/scripts/enforce_special_allocation_quota.py


### PR DESCRIPTION
Due to two separate plugins which don't play well together. My tests
for the special allocation plugin does not try the combination with this
other plugin. `DefaultQuotaPluginManager` is never triggered when
`AccountCreationPluginManager` is enabled.

Solution: Temporary workaround - a script run in cron to reset the quota

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- [x] If necessary, include a snippet in CHANGELOG.md
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~

  