### PR TITLE
Problem: cannot filter v2 Volumes & Instances by provider_id

### DIFF
--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -1,3 +1,5 @@
+import django_filters
+
 from api.v2.serializers.details import InstanceSerializer, InstanceActionSerializer
 from api.v2.serializers.post import InstanceSerializer as POST_InstanceSerializer
 from api.v2.views.base import AuthModelViewSet
@@ -11,7 +13,7 @@ from core.models.instance import find_instance
 from core.models.instance_action import InstanceAction
 from core.query import only_current_instances
 
-from rest_framework import status
+from rest_framework import filters, status
 from rest_framework import renderers
 from rest_framework.decorators import detail_route, renderer_classes
 from rest_framework.response import Response
@@ -36,6 +38,14 @@ from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure
 
 
+class InstanceFilter(filters.FilterSet):
+    provider_id = django_filters.NumberFilter(name="created_by_identity__provider__id")
+
+    class Meta:
+        model = Instance
+        fields = ['provider_id']
+
+
 class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
 
     """
@@ -44,6 +54,7 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
 
     queryset = Instance.objects.all()
     serializer_class = InstanceSerializer
+    filter_class = InstanceFilter
     filter_fields = ('created_by__id', 'project')
     lookup_fields = ("id", "provider_alias")
     http_method_names = ['get', 'put', 'patch', 'post',

--- a/api/v2/views/volume.py
+++ b/api/v2/views/volume.py
@@ -29,10 +29,12 @@ VOLUME_EXCEPTIONS = (OverQuotaError, ConnectionFailure, LibcloudBadResponseError
 class VolumeFilter(django_filters.FilterSet):
     min_size = django_filters.NumberFilter(name="size__gte")
     max_size = django_filters.NumberFilter(name="size__lte")
+    provider_id = django_filters.NumberFilter(
+        name="instance_source__created_by_identity__provider__id")
 
     class Meta:
         model = Volume
-        fields = ['min_size', 'max_size', 'project']
+        fields = ['min_size', 'max_size', 'provider_id', 'project']
 
 
 class VolumeViewSet(MultipleFieldLookup, AuthModelViewSet):

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -34,6 +34,7 @@ from core.models.managers import ActiveInstancesManager
 from atmosphere import settings
 from service.mock import MockInstance
 
+
 class Instance(models.Model):
     """
     When a user launches a machine, an Instance is created.


### PR DESCRIPTION
## Description

This added the ability to filter by `provider_id` for responses from:
- api/v2/volumes
- api/v2/instances

This is a "feature-enabling", enhancement request for the development of the user interface. 

See [ATMO-2132](https://pods.iplantcollaborative.org/jira/browse/ATMO-2132).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] ~Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~
