### PR TITLE
Problem: Use enforcement override for instance actions

### DIFF
--- a/api/tests/v2/test_instance_actions.py
+++ b/api/tests/v2/test_instance_actions.py
@@ -10,9 +10,9 @@ from rest_framework.test import APITestCase, APIRequestFactory, force_authentica
 from api.tests.factories import (
     UserFactory, AnonymousUserFactory, InstanceFactory, InstanceHistoryFactory, InstanceStatusFactory,
     ApplicationVersionFactory, ProviderMachineFactory, IdentityFactory, ProviderFactory,
-    SizeFactory)
+    SizeFactory, AllocationSourceFactory)
 from api.v2.views import InstanceViewSet
-from core.models import AtmosphereUser
+from core.models import InstanceAllocationSourceSnapshot
 from service.driver import get_esh_driver
 
 
@@ -67,6 +67,10 @@ class InstanceActionTests(APITestCase):
                 instance=self.active_instance_second,
                 start_date=start_date_second + delta_time*3)
         self.mock_driver.add_core_instance(self.active_instance_second)
+        self.allocation_source_1 = AllocationSourceFactory.create(name='TEST_INSTANCE_ALLOCATION_SOURCE_01',
+                                                                  compute_allowed=1000)
+        InstanceAllocationSourceSnapshot.objects.update_or_create(instance=self.active_instance,
+                                                                  allocation_source=self.allocation_source_1)
 
     # For resize, I will add a size in InstanceStatusHistory. for stop, we don't have to have
     def test_stop_instance_action(self):

--- a/features/allocation.features/enforcing_override.feature
+++ b/features/allocation.features/enforcing_override.feature
@@ -50,6 +50,9 @@ Feature: Override enforcing allocation usage on CyVerse
     Then `allocation_source_overage_enforcement_for_user` was called as follows
       | username   | allocation_source   | called    |
       | <username> | <allocation_source> | <enforce> |
+    And `check_allocation` with username '<username>' and '<allocation_source>' will throw an exception: <enforce>
+      | allocation_source   | override   |
+      | <allocation_source> | <override> |
 
 
     Examples:

--- a/features/jetstream.features/enforcing_override.feature
+++ b/features/jetstream.features/enforcing_override.feature
@@ -90,6 +90,10 @@ Feature: Override enforcing allocation usage on Jetstream
     Then `allocation_source_overage_enforcement_for_user` was called as follows
       | username   | allocation_source   | called    |
       | <username> | <allocation_source> | <enforce> |
+    And `check_allocation` with username '<username>' and '<allocation_source>' will throw an exception: <enforce>
+      | allocation_source   | override   |
+      | <allocation_source> | <override> |
+
 
     Examples:
       | username | allocation_source | override       | compute_allowed | start_date           | end_date             | compute_used | enforce |

--- a/features/steps/allocation_steps.py
+++ b/features/steps/allocation_steps.py
@@ -94,6 +94,35 @@ def allocation_source_overage_enforcement_for_user_called(context):
     context.test.assertEqual(method_calls, expected_calls)
 
 
+@step(
+    u"`check_allocation` with username '{username}' and '{allocation_source_name}' will throw an exception: {yes_or_no}")
+def step_impl(context, username, allocation_source_name, yes_or_no):
+    override_settings = [dict(zip(row.headings, row.cells)) for row in context.table]
+    never_enforce = [setting['allocation_source'] for setting in override_settings if
+                     setting['override'] == 'NEVER_ENFORCE']
+    always_enforce = [setting['allocation_source'] for setting in override_settings if
+                      setting['override'] == 'ALWAYS_ENFORCE']
+    allocation_source = AllocationSource.objects.get(name=allocation_source_name)
+    try:
+        from service.instance import check_allocation
+        with mock.patch('service.instance.settings', autospec=True) as mock_settings:
+            mock_settings.ENFORCING = True
+            mock_settings.ALLOCATION_OVERRIDES_NEVER_ENFORCE = never_enforce
+            mock_settings.ALLOCATION_OVERRIDES_ALWAYS_ENFORCE = always_enforce
+            with django.test.override_settings(
+                    ALLOCATION_OVERRIDES_NEVER_ENFORCE=never_enforce,
+                    ALLOCATION_OVERRIDES_ALWAYS_ENFORCE=always_enforce
+            ):
+                check_allocation(username, allocation_source)
+    except Exception as e:
+        if yes_or_no == 'No':
+            raise ValueError('Did not expect an exception and got it', e)
+    else:
+        if yes_or_no == 'Yes':
+            raise ValueError('Expected exception and did not get it')
+
+
+
 @when('create_allocation_source command is fired')
 def create_allocation_source_command_fired(context):
     for row in context.table:


### PR DESCRIPTION
Based on previous work: https://github.com/cyverse/atmosphere/pull/565

- Allow instances to always be started/resumed/unshelved if they are
    associated with an allocation source which is set to `NEVER_ENFORCE`
- Prevent instances from being started/resumed/unshelved if they are
    associated with an allocation source which is set to `ALWAYS_ENFORCE`

Solution:
- Run `check_allocation` in `service.instance.run_instance_action` if
    the action is in `('start', 'resume', 'unshelve')`

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- ~[ ] If necessary, include a snippet in CHANGELOG.md~
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~
