### PR TITLE
Reproduce spurious build failures

### DIFF
--- a/features/allocation.features/alternate_story.feature
+++ b/features/allocation.features/alternate_story.feature
@@ -46,9 +46,10 @@ Feature: Testing an Alternate story
     ## NOTE: Currently, the rules engine is set to renew in every 3 days. After every renewal the compute used is reset and remaining compute is carried over
 
     Then calculate allocations used by allocation source after certain number of days
-    |  report start date                  | number of days   | total compute used   | current compute used | current compute allowed | allocation_source_id |
-    |      current                        |  1               |     24               | 24                   | 168                     | 1                    |
-    |      current                        |  1               |     24               | 24                   | 168                     | 2                    |
+    | report start date             | number of days | total compute used | current compute used | current compute allowed | allocation_source_id |
+    | January 30, 2018 10:44:22 UTC | 1              | 24                 | 24                   | 168                     | 1                    |
+    | current                       | 1              | 24                 | 24                   | 168                     | 1                    |
+    | current                       | 1              | 24                 | 24                   | 168                     | 2                    |
 
     And Compute Allowed is increased for Allocation Source
     | allocation_source_id | new_compute_allowed |

--- a/features/allocation.features/story.feature
+++ b/features/allocation.features/story.feature
@@ -39,6 +39,7 @@ Feature: Testing a story
     ## NOTE: Currently, the rules engine is set to renew in every 3 days. After every renewal the compute used is reset and remaining compute is carried over
 
     Then calculate allocations used by allocation source after certain number of days
-    |  report start date                  | number of days   | total compute used   | current compute used | current compute allowed | allocation_source_id |
-    |      current                        |  4               |     240              | 240                  | 250                     | 1                    |
+    | report start date             | number of days | total compute used | current compute used | current compute allowed | allocation_source_id |
+    | January 30, 2018 10:44:22 UTC | 4              | 240                | 240                  | 250                     | 1                    |
+    | current                       | 4              | 240                | 240                  | 250                     | 1                    |
 


### PR DESCRIPTION
## Description

**This shouldn't be merged!** It just recreates the test conditions that caused atmosphere's travis to fail several builds.

At some point in time we had build failures for apparently no reason (the commit that introduced the failures just updated the license!).
https://travis-ci.org/cyverse/atmosphere/jobs/334770979#L971

I took the timestamp from the build failure and threw it into the behave failing test and was able to reproduce the failing build.

To run just the broken tests:
```
./manage.py behave -i features/allocation.features/'(story.feature|alternate_story.feature)'
```

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
