### PR TITLE
Fix test breaking because of implicit dependency on current time

### DIFF
--- a/features/allocation.features/story.feature
+++ b/features/allocation.features/story.feature
@@ -12,6 +12,8 @@ Feature: Testing a story
 
   Scenario: Use cases of allocation source
 
+    Given a current time of "February 21, 2018 10:44:22 UTC"
+
     When admin creates allocation source
     |  name                       |  compute allowed   |  renewal strategy   |   allocation_source_id | date_created |
     |  DefaultAllocationSource    |  250               |  default            |   1                    | current      |


### PR DESCRIPTION
## Description

Problem: spurious broken test
Solution: explicitly include a current time in the test

This test fails today, i'm guessing because of how renewal occurs. None the less, the test shouldn't be a function of when it is run.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] If necessary, include a snippet in CHANGELOG.md
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos
