### PR TITLE
Raise separate error for blacklisted allocations

### DIFF
--- a/api/v1/views/instance.py
+++ b/api/v1/views/instance.py
@@ -21,7 +21,7 @@ from service.cache import get_cached_instances,\
     invalidate_cached_instances
 from service.driver import prepare_driver
 from service.exceptions import (
-    OverAllocationError, OverQuotaError,
+    OverAllocationError, AllocationBlacklistedError, OverQuotaError,
     SizeNotAvailable, HypervisorCapacityError, SecurityGroupNotCreated,
     VolumeAttachConflict, VolumeMountConflict, InstanceDoesNotExist,
     UnderThresholdError, ActionNotAllowed, Unauthorized,
@@ -189,6 +189,10 @@ class InstanceList(AuthAPIView):
             return over_quota(oqe)
         except OverAllocationError as oae:
             return over_quota(oae)
+        except AllocationBlacklistedError as e:
+            return failure_response(
+                status.HTTP_403_FORBIDDEN,
+                e.message)
         except Unauthorized:
             return invalid_creds(provider_uuid, identity_uuid)
         except SizeNotAvailable as snae:
@@ -499,6 +503,10 @@ class InstanceAction(AuthAPIView):
             return over_quota(oqe)
         except OverAllocationError as oae:
             return over_quota(oae)
+        except AllocationBlacklistedError as e:
+            return failure_response(
+                status.HTTP_403_FORBIDDEN,
+                e.message)
         except SizeNotAvailable as snae:
             return size_not_available(snae)
         except (socket_error, ConnectionFailure):

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -28,10 +28,10 @@ from api.exceptions import (
     over_capacity, mount_failed, inactive_provider)
 from rtwo.exceptions import LibcloudInvalidCredsError
 from service.exceptions import (
-    ActionNotAllowed, OverAllocationError, OverQuotaError,
-    SizeNotAvailable, HypervisorCapacityError, SecurityGroupNotCreated,
-    UnderThresholdError, VolumeAttachConflict, VolumeMountConflict,
-    InstanceDoesNotExist)
+    ActionNotAllowed, AllocationBlacklistedError, OverAllocationError,
+    OverQuotaError, SizeNotAvailable, HypervisorCapacityError,
+    SecurityGroupNotCreated, UnderThresholdError, VolumeAttachConflict,
+    VolumeMountConflict, InstanceDoesNotExist)
 from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure
 
@@ -138,6 +138,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             return inactive_provider(pna)
         except (OverQuotaError, OverAllocationError) as oqe:
             return over_quota(oqe)
+        except AllocationBlacklistedError as e:
+            return failure_response(
+                status.HTTP_403_FORBIDDEN,
+                e.message)
         except SizeNotAvailable as snae:
             return size_not_available(snae)
         except (socket_error, ConnectionFailure):
@@ -319,6 +323,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             return under_threshold(ute)
         except (OverQuotaError, OverAllocationError) as oqe:
             return over_quota(oqe)
+        except AllocationBlacklistedError as e:
+            return failure_response(
+                status.HTTP_403_FORBIDDEN,
+                e.message)
         except ProviderNotActive as pna:
             return inactive_provider(pna)
         except SizeNotAvailable as snae:

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -6,6 +6,7 @@ Atmosphere service exceptions.
 from ansible.errors import AnsibleError
 from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure, LibcloudInvalidCredsError, LibcloudBadResponseError
+from atmosphere import settings
 
 
 class ServiceException(Exception):
@@ -88,6 +89,16 @@ class HypervisorCapacityError(ServiceException):
         self.message = message
         super(HypervisorCapacityError, self).__init__(self.message)
 
+
+class AllocationBlacklistedError(ServiceException):
+    def __init__(self, source_name):
+        self.message = "Allocation disabled: Allocation '{}' has been " \
+                "blacklisted by staff. If you think this is in error, reach " \
+                "out to support at {}".format(source_name, settings.SUPPORT_EMAIL)
+        super(AllocationBlacklistedError, self).__init__(self.message)
+
+    def __str__(self):
+        return "%s" % (self.message, )
 
 class OverAllocationError(ServiceException):
 

--- a/service/instance.py
+++ b/service/instance.py
@@ -54,7 +54,7 @@ from service.driver import _retrieve_source, get_account_driver
 from service.licensing import _test_license
 from service.networking import get_topology_cls, ExternalRouter, ExternalNetwork, _get_unique_id
 from service.exceptions import (
-    OverAllocationError, OverQuotaError, SizeNotAvailable,
+    OverAllocationError, AllocationBlacklistedError, OverQuotaError, SizeNotAvailable,
     HypervisorCapacityError, SecurityGroupNotCreated,
     VolumeAttachConflict, VolumeDetachConflict, UnderThresholdError, ActionNotAllowed,
     socket_error, ConnectionFailure, InstanceDoesNotExist, InstanceLaunchConflict, LibcloudInvalidCredsError,
@@ -835,7 +835,7 @@ def _pre_launch_validation(
     check_quota(username, identity_uuid, size,
             include_networking=True)
 
-    # May raise OverAllocationError
+    # May raise OverAllocationError, AllocationBlacklistedError
     check_allocation(username, allocation_source)
 
     # May raise UnderThresholdError
@@ -1329,8 +1329,7 @@ def check_allocation(username, allocation_source):
     if enforcement_override_choice == EnforcementOverrideChoice.NEVER_ENFORCE:
         return
     elif enforcement_override_choice == EnforcementOverrideChoice.ALWAYS_ENFORCE:
-        # Using a dummy value of -1, should throw a separate error
-        raise OverAllocationError(allocation_source.name, -1)
+        raise AllocationBlacklistedError(allocation_source.name)
 
     compute_remaining = allocation_source.time_remaining(user)
     over_allocation = compute_remaining < 0


### PR DESCRIPTION
## Description

**Dependenices:**
- [x] https://github.com/cyverse/atmosphere/pull/585 (fixes a bug discovered in writing this test, need it so test passes)
- [x] https://github.com/cyverse/atmosphere/pull/584 (allows test to be written without ENFORCING=true)

Problem: when allocation name is blacklisted, user gets cryptic error when launching
Solution: Give them a precise error

This is sort of an edge case but warranted. Troposphere no longer performs allocation validation before launching, it defers to the backend to raise exceptions and thus trusts the backend to have good errors.

![2018-02-27-093438_2560x1440_scrot](https://user-images.githubusercontent.com/3847314/36742182-413a53aa-1ba4-11e8-896c-708f22fea081.png)
## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature

~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
~~- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~~
~~- [ ] Reviewed and approved by at least one other contributor.~~
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
~~- [ ] New variables supported in Clank~~
~~- [ ] New variables committed to secrets repos~~


