### PR TITLE
Remove unnecessary enforcing restrictions

### DIFF
--- a/api/tests/v2/test_instance_actions.py
+++ b/api/tests/v2/test_instance_actions.py
@@ -12,7 +12,10 @@ from api.tests.factories import (
     ApplicationVersionFactory, ProviderMachineFactory, IdentityFactory, ProviderFactory,
     SizeFactory, AllocationSourceFactory)
 from api.v2.views import InstanceViewSet
-from core.models import InstanceAllocationSourceSnapshot
+from core.models import (
+    InstanceAllocationSourceSnapshot,
+    UserAllocationSnapshot, AllocationSourceSnapshot,
+    UserAllocationSource)
 from service.driver import get_esh_driver
 
 
@@ -69,6 +72,20 @@ class InstanceActionTests(APITestCase):
         self.mock_driver.add_core_instance(self.active_instance_second)
         self.allocation_source_1 = AllocationSourceFactory.create(name='TEST_INSTANCE_ALLOCATION_SOURCE_01',
                                                                   compute_allowed=1000)
+        UserAllocationSource.objects.create(
+                allocation_source=self.allocation_source_1,
+                user=self.user)
+        UserAllocationSnapshot.objects.create(
+                allocation_source=self.allocation_source_1,
+                user=self.user,
+                burn_rate=1,
+                compute_used=0)
+        AllocationSourceSnapshot.objects.create(
+            allocation_source=self.allocation_source_1,
+            compute_used=0,
+            compute_allowed=168,
+            global_burn_rate=1
+        )
         InstanceAllocationSourceSnapshot.objects.update_or_create(instance=self.active_instance,
                                                                   allocation_source=self.allocation_source_1)
 

--- a/core/hooks/allocation_source.py
+++ b/core/hooks/allocation_source.py
@@ -105,8 +105,6 @@ def listen_for_allocation_threshold_met(sender, instance, created, **kwargs):
     allocation_source_name = payload['allocation_source_name']
     threshold = payload['threshold']
     usage_percentage = payload['usage_percentage']
-    if not settings.ENFORCING:
-        return None
     source = AllocationSource.objects.filter(name=allocation_source_name).last()
     ##CHANGED
     # source = AllocationSource.objects.filter(name=allocation_source_name).last()

--- a/features/steps/allocation_steps.py
+++ b/features/steps/allocation_steps.py
@@ -106,7 +106,6 @@ def step_impl(context, username, allocation_source_name, yes_or_no):
     try:
         from service.instance import check_allocation
         with mock.patch('service.instance.settings', autospec=True) as mock_settings:
-            mock_settings.ENFORCING = True
             mock_settings.ALLOCATION_OVERRIDES_NEVER_ENFORCE = never_enforce
             mock_settings.ALLOCATION_OVERRIDES_ALWAYS_ENFORCE = always_enforce
             with django.test.override_settings(

--- a/service/instance.py
+++ b/service/instance.py
@@ -1319,9 +1319,6 @@ def _test_for_licensing(esh_machine, identity):
 def check_allocation(username, allocation_source):
     logger.debug('check_allocation - username: %s', username)
     logger.debug('check_allocation - allocation_source: %s', allocation_source)
-    if not settings.ENFORCING:
-        logger.debug('check_allocation - settings.ENFORCING is False - just returning')
-        return
     user = AtmosphereUser.objects.filter(username=username).first()
     if not user:
         raise Exception("Username %s does not exist" % username)


### PR DESCRIPTION
## Description

Problem: Testing allocation logic requires setting ENFORCING=true, which is dangerous
Solution: Remove ENFORCING from the equation

## Checklist before merging Pull Requests
- [ ] Reviewed and approved by at least one other contributor.

~~- [ ] New test(s) included to reproduce the bug/verify the feature~~
~~- [ ] Documentation created/updated at [Example link to documentation (https://example.test/doc#new_section) to give context to the feature~~
~~- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~~
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
~~- [ ] New variables supported in Clank~~
~~- [ ] New variables committed to secrets repos~~
