### PR TITLE
Fix invalid argument to check_allocation

### DIFF
--- a/service/instance.py
+++ b/service/instance.py
@@ -2054,8 +2054,9 @@ def run_instance_action(user, identity, instance_id, action_type, action_params)
     logger.info("User %s has initiated instance action %s to be executed on Instance %s" % (user, action_type, instance_id))
     if action_type in ('start', 'resume', 'unshelve'):
         logger.info('Going to check the allocation of the instance due to the action type: %s', action_type)
-        instance_allocation_source = InstanceAllocationSourceSnapshot.objects.get(instance__provider_alias=instance_id)
-        check_allocation(user.username, instance_allocation_source)
+        allocation_snapshot = InstanceAllocationSourceSnapshot.objects.get(instance__provider_alias=instance_id)
+        allocation = allocation_snapshot.allocation_source
+        check_allocation(user.username, allocation)
     if 'resize' == action_type:
         size_alias = action_params.get('size', '')
         if isinstance(size_alias, int):


### PR DESCRIPTION
## Description
When an instance is started, a call is made to check_allocation with an allocation source snapshot. However, check_allocation expects an allocation_source. This causes an assertion error to be thrown, which results in a generic service error.

Here is a stack trace, which would lead to the assertion error. The error is introduced in the third trace at line 2053.
```
      /opt/dev/atmosphere/api/v2/views/instance.py(99)actions()
         98             return self.list_instance_actions(request, pk=pk)
    ---> 99         return self.post_instance_action(request, pk=pk)
        100
    
      /opt/dev/atmosphere/api/v2/views/instance.py(119)post_instance_action()
        118         try:
    --> 119             result_obj = run_instance_action(user, identity, instance_id, action, action_params)
        120             api_response = {
    
      /opt/dev/atmosphere/service/instance.py(2054)run_instance_action()
       2053         instance_allocation_source = InstanceAllocationSourceSnapshot.objects.get(instance__provider_alias=instance_id)
    -> 2054         check_allocation(user.username, instance_allocation_source)
       2055     if 'resize' == action_type:
    
      /opt/dev/atmosphere/service/instance.py(1327)check_allocation()
       1326     enforcement_override_choice = AllocationSourcePluginManager.get_enforcement_override(user,
    -> 1327                                                                                          allocation_source)
       1328     logger.debug('check_allocation - enforcement_override_choice: %s', enforcement_override_choice)
    
      /opt/dev/atmosphere/core/plugins.py(200)get_enforcement_override()
        199                                                                            allocation_source=allocation_source,
    --> 200                                                                            provider=provider)
        201             if _enforcement_override_choice != EnforcementOverrideChoice.NO_OVERRIDE:
    
      /opt/dev/atmosphere/cyverse_allocation/plugins/allocation_source.py(39)get_enforcement_override()
         38         """
    ---> 39         return _get_enforcement_override(allocation_source)
         40
    
    > /opt/dev/atmosphere/cyverse_allocation/plugins/allocation_source.py(51)_get_enforcement_override()
    ---> 50     assert isinstance(allocation_source, AllocationSource)
         51     import core.plugins
```
## Checklist before merging Pull Requests
~~- [ ] New test(s) included to reproduce the bug/verify the feature~~
~~- [ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~~
~~- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~~
- [x] Reviewed and approved by at least one other contributor.
~~- [ ] If necessary, include a snippet in CHANGELOG.md~~
~~- [ ] New variables supported in Clank~~
~~- [ ] New variables committed to secrets repos~~