### PR TITLE
Guacamole web shell and desktop link generation update

### DIFF
--- a/api/v2/views/web_token.py
+++ b/api/v2/views/web_token.py
@@ -77,7 +77,7 @@ class WebTokenView(RetrieveAPIView):
         guac_secret = settings.GUACAMOLE['SECRET_KEY']
         # Create UUID for connection ID
         conn_id = str(uuid.uuid4())
-        base64_conn_id = base64.b64encode(conn_id[2:] + "\0" + 'c' + "\0" + 'hmac')
+        base64_conn_id = base64.b64encode(conn_id + "\0c\0hmac")
 
         # Create timestamp that looks like: 1489181545018
         timestamp = str(int(round(time.time()*1000)))


### PR DESCRIPTION
## Description

Previous versions of Guacamole required that the authentication plugin removed the first two characters of the connection ID in order to add some sort of extra metadata the the ID. This was removed, so the auth plugin no longer removes the two characters, so neither should Atmosphere.

**Before this goes into production**, please coordinate with me to make sure Guacamole server has the same changes because they have to go at the same time.
