### PR TITLE
Change maintenance command to be non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
   - Update license to 2018
   - Updated CHANGELOG.md to use the recommendations from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+  - Change ./manage.py maintenance to be non-interactive
 
 ## [v31-0](https://github.com/cyverse/atmosphere/compare/v30...v31-0) - 2018-03-08
 ### Added

--- a/core/management/commands/test_maintenance.py
+++ b/core/management/commands/test_maintenance.py
@@ -1,0 +1,50 @@
+import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+import datetime
+import pytz
+
+from core.management.commands import maintenance
+from core.models import MaintenanceRecord
+
+class MaintenanceTest(TestCase):
+    def test_start(self):
+        records_before = set(MaintenanceRecord.objects.all())
+        call_command(
+            maintenance.Command(),
+            "start",
+            title="title",
+            message="message",
+            start_date="2038-01-19T03:15:00Z")
+        records_after = set(MaintenanceRecord.objects.all())
+
+        created_records = records_after - records_before
+        self.assertEqual(len(created_records), 1, "One record was created")
+
+        record = next(iter(created_records))
+        self.assertEqual(record.title, "title")
+        self.assertEqual(record.message, "message")
+        self.assertEqual(record.start_date,
+            datetime.datetime(2038, 1, 19, 3, 15, tzinfo=pytz.utc))
+        self.assertIsNone(record.end_date)
+
+    def test_start_dry_run(self):
+        """
+        The start command with --dry-run shouldn't create a record
+        """
+        num_records_before = MaintenanceRecord.objects.count()
+        call_command(maintenance.Command(), "start", "--dry-run")
+        num_records_after = MaintenanceRecord.objects.count()
+        self.assertEqual(
+            num_records_before, num_records_after,
+            "The number of records before and after shouldn't change")
+
+    def test_stop(self):
+        records_before = set(MaintenanceRecord.objects.all())
+        call_command(maintenance.Command(), "start")
+        records_after = set(MaintenanceRecord.objects.all())
+        created_record = next(iter(records_after - records_before))
+
+        call_command(maintenance.Command(), "stop")
+        updated_record = MaintenanceRecord.objects.get(id=created_record.id)
+        self.assertIsNotNone(updated_record.end_date, "Record has an enddate")


### PR DESCRIPTION
## Description
Change ./manage.py maintenance sub-command to be easier to test and add features

I was making changes to `atmosphere.version.git_branch`, and found that this command would be affected. I wanted to write some tests to ensure that the command would still work. However, the previous command would not allow you to pass some arguments and not others. If you omitted any, it would go into an interactive mode. I couldn't test whether the defaults were working, because of this mode. The command has been pretty useful during deployments, so these changes just make the tool  more command-line friendly.

## Other changes:
- Defaults are used if not overriden
- Interactive mode is removed and replaced with --dry-run
- The start_date format accepts timezones now.
- The --start-now flag was removed, this is the default if no --start-date is specified.
- The show command will print a current maintenance if one exists

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [x] Documentation created/updated (include links)
  - https://github.com/cyverse/atmosphere-guides/pull/39
- [x] Reviewed and approved by at least one other contributor.