### PR TITLE
Fix broken atmosphere ansible version reported from api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
   - Update license to 2018
-  - Updated CHANGELOG.md to use the recommendations from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+  - Update CHANGELOG.md to use the recommendations from [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Change ./manage.py maintenance to be non-interactive
+  - Return less information in the version api (api/v{1,2}/version) like
+    atmosphere's major minor and patch version
+
+### Fixed
+  - The version reported for atmopshere ansible (api/v{1,2}/deploy_version now
+  returns results
 
 ## [v31-1](https://github.com/cyverse/atmosphere/compare/v31-0...v31-1) 2018-04-03
 ### Fixed

--- a/api/base/views/__init__.py
+++ b/api/base/views/__init__.py
@@ -1,0 +1,1 @@
+from .version import VersionViewSet, DeployVersionViewSet

--- a/api/base/views/version.py
+++ b/api/base/views/version.py
@@ -1,17 +1,13 @@
 """
-Atmosphere version views
-
+Atmosphere api to lookup version info from git
 """
+from os.path import join
+from django.conf import settings
 from rest_framework import viewsets, mixins
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
-from atmosphere.version import get_version
-try:
-    from atmosphere_ansible_bioci.version import get_version as get_deploy_version
-except ImportError:
-    get_deploy_version = None
-
+from atmosphere.version import git_version_lookup
 from api.permissions import InMaintenance
 
 
@@ -20,26 +16,17 @@ class VersionViewSet(mixins.ListModelMixin,
     permission_classes = (IsAuthenticatedOrReadOnly,
                           InMaintenance)
 
+    git_directory = join(settings.PROJECT_ROOT, ".git")
+
     def list(self, request, *args, **kwargs):
         """
         This request will retrieve Atmosphere's version,
         including the latest update to the code base and the date the
         update was written.
         """
-        return Response(get_version("all"))
+        version = git_version_lookup(git_directory=self.git_directory)
+        return Response(version)
 
 
-class DeployVersionViewSet(mixins.ListModelMixin,
-                           viewsets.GenericViewSet):
-    permission_classes = (IsAuthenticatedOrReadOnly,
-                          InMaintenance)
-
-    def list(self, request, format=None):
-        """
-        This request will retrieve Atmosphere's version,
-        including the latest update to the code base and the date the
-        update was written.
-        """
-        if not get_deploy_version:
-            return Response("N/A")
-        return Response(get_deploy_version("all"))
+class DeployVersionViewSet(VersionViewSet):
+    git_directory = join(settings.ANSIBLE_ROOT, ".git")

--- a/api/base/views/version.py
+++ b/api/base/views/version.py
@@ -1,5 +1,5 @@
 """
-Atmosphere API Common/Base views.
+Atmosphere version views
 
 """
 from rest_framework import viewsets, mixins

--- a/api/tests/base/test_version.py
+++ b/api/tests/base/test_version.py
@@ -1,0 +1,33 @@
+"""
+Tests for base views (i.e. views shared between api versions)
+"""
+from rest_framework.test import APIRequestFactory
+from rest_framework.test import APITestCase, force_authenticate
+
+from api.base.views import VersionViewSet, DeployVersionViewSet
+from api.tests.factories import UserFactory
+
+
+class VersionTests(APITestCase):
+    view_set = VersionViewSet
+
+    def test_get_version(self):
+        """
+        Test a sucessful response and shape
+        """
+        user_a = UserFactory.create()
+        view = self.view_set.as_view({'get': 'list'})
+        request = APIRequestFactory().get("")
+        force_authenticate(request, user=user_a)
+        response = view(request)
+        self.assertEquals(response.status_code, 200)
+
+        data = response.data
+        keys = ['git_sha', 'git_sha_abbrev', 'commit_date', 'git_branch']
+        for key in keys:
+            self.assertIn(key, data)
+            self.assertIsNotNone(data[key])
+
+
+class DeployVersionTests(VersionTests):
+    view_set = DeployVersionViewSet

--- a/api/tests/test_pattern_matches_viewset.py
+++ b/api/tests/test_pattern_matches_viewset.py
@@ -1,0 +1,16 @@
+from django.urls import reverse, resolve
+
+
+class PatternMatchesViewsetTest(object):
+    """
+    A mixin which should be added to a TestCase, tests that a url pattern maps
+    to a viewset.
+    """
+    def test_pattern_matches_viewset(self, url_pattern, view_set):
+        """
+        Assert that the url maps to the given viewset
+        """
+        url = reverse(url_pattern)
+        match = resolve(url)
+        view = match.func
+        self.assertEqual(view.cls, view_set)

--- a/api/tests/v1/test_version.py
+++ b/api/tests/v1/test_version.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from api.base.views import VersionViewSet, DeployVersionViewSet
+from api.tests.test_pattern_matches_viewset import PatternMatchesViewsetTest
+
+
+class VersionSanityTests(TestCase, PatternMatchesViewsetTest):
+    def test_pattern_matches_viewset(self):
+        super(self.__class__, self).test_pattern_matches_viewset('api:v1:v1-atmo', VersionViewSet)
+
+
+class DeployVersionSanityTests(TestCase, PatternMatchesViewsetTest):
+    def test_pattern_matches_viewset(self):
+        super(self.__class__, self).test_pattern_matches_viewset( 'api:v1:v1-deploy', DeployVersionViewSet)

--- a/api/tests/v2/test_version.py
+++ b/api/tests/v2/test_version.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from api.base.views import VersionViewSet, DeployVersionViewSet
+from api.tests.test_pattern_matches_viewset import PatternMatchesViewsetTest
+
+
+class VersionSanityTests(TestCase, PatternMatchesViewsetTest):
+    def test_pattern_matches_viewset(self):
+        super(self.__class__, self).test_pattern_matches_viewset('api:v2:version-atmo-list', VersionViewSet)
+
+
+class DeployVersionSanityTests(TestCase, PatternMatchesViewsetTest):
+    def test_pattern_matches_viewset(self):
+        super(self.__class__, self).test_pattern_matches_viewset('api:v2:version-deploy-list', DeployVersionViewSet)

--- a/atmosphere/version.py
+++ b/atmosphere/version.py
@@ -37,7 +37,7 @@ def git_branch():
         return None
 
 
-def get_version(form='short'):
+def get_version(form='short', git_branch_name=None, git_head_info=None):
     """
     Returns the version string.
 
@@ -70,10 +70,10 @@ def get_version(form='short'):
     versions["normal"] = v
     if form is "normal":
         return v
-    info = git_info()
+    info = git_head_info or git_info()
     versions["git_sha"] = info[0:39]
     versions["git_sha_abbrev"] = "@" + info[0:6]
-    versions["git_branch"] = git_branch()
+    versions["git_branch"] = git_branch_name or git_branch()
     versions["commit_date"] = parser.parse(info[40:])
     v += " " + versions["git_sha_abbrev"]
     versions["verbose"] = v

--- a/core/management/commands/maintenance.py
+++ b/core/management/commands/maintenance.py
@@ -92,7 +92,8 @@ class Command(BaseCommand):
 
 def _default_title():
     now = timezone.localdate()
-    branch_name = git_branch()
+    git_directory = os.path.join(settings.PROJECT_ROOT, ".git")
+    branch_name = git_branch(git_directory=git_directory)
 
     return "{0}/{1} ({2}) Maintenance".format(now.month, now.day,
                                               branch_name)

--- a/core/tests/test_version.py
+++ b/core/tests/test_version.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from atmosphere.version import get_version
+import datetime
+from dateutil.tz import tzoffset
+import mock
+
+class VersionTests(TestCase):
+    def test_existing_version_behavior(self):
+        git_head_info="f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5f2018-03-07 10:00:35 -0700"
+        git_branch_name="foobar"
+
+        with mock.patch('atmosphere.version.VERSION', (9, 9, 9, 'dev', 9)):
+            actual = get_version("all", git_branch_name=git_branch_name, git_head_info=git_head_info)
+
+        expected = {
+            'git_sha': 'f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5',
+            'git_sha_abbrev': '@f5d084',
+            'short': '9.9.9',
+            'verbose': '9.9.9 dev 9 @f5d084',
+            'normal': '9.9.9 dev 9',
+            'commit_date': datetime.datetime(2018, 3, 7, 10, 0, 35, tzinfo=tzoffset(None, -25200)),
+            'git_branch': 'foobar',
+            'branch': '9.9',
+            'tertiary': '.9'
+        }
+
+        self.assertEqual(expected, actual);

--- a/core/tests/test_version.py
+++ b/core/tests/test_version.py
@@ -1,27 +1,21 @@
 from django.test import TestCase
-from atmosphere.version import get_version
+from django.conf import settings
+from atmosphere.version import git_version_lookup
 import datetime
 from dateutil.tz import tzoffset
-import mock
 
 class VersionTests(TestCase):
     def test_existing_version_behavior(self):
         git_head_info="f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5f2018-03-07 10:00:35 -0700"
         git_branch_name="foobar"
 
-        with mock.patch('atmosphere.version.VERSION', (9, 9, 9, 'dev', 9)):
-            actual = get_version("all", git_branch_name=git_branch_name, git_head_info=git_head_info)
+        actual = git_version_lookup(git_branch_name=git_branch_name, git_head_info=git_head_info)
 
         expected = {
             'git_sha': 'f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5',
             'git_sha_abbrev': '@f5d084',
-            'short': '9.9.9',
-            'verbose': '9.9.9 dev 9 @f5d084',
-            'normal': '9.9.9 dev 9',
             'commit_date': datetime.datetime(2018, 3, 7, 10, 0, 35, tzinfo=tzoffset(None, -25200)),
             'git_branch': 'foobar',
-            'branch': '9.9',
-            'tertiary': '.9'
         }
 
         self.assertEqual(expected, actual);

--- a/core/tests/test_version.py
+++ b/core/tests/test_version.py
@@ -1,3 +1,4 @@
+import os
 from django.test import TestCase
 from django.conf import settings
 from atmosphere.version import git_version_lookup
@@ -5,11 +6,13 @@ import datetime
 from dateutil.tz import tzoffset
 
 class VersionTests(TestCase):
-    def test_existing_version_behavior(self):
-        git_head_info="f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5f2018-03-07 10:00:35 -0700"
-        git_branch_name="foobar"
-
-        actual = git_version_lookup(git_branch_name=git_branch_name, git_head_info=git_head_info)
+    def test_version_format(self):
+        """
+        Test expected behavior when git_version_lookup is just formatting output from git
+        """
+        actual = git_version_lookup(
+            git_branch_name="foobar",
+            git_head_info="f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5f2018-03-07 10:00:35 -0700")
 
         expected = {
             'git_sha': 'f5d0849f7a6dbb608d2e5c81c16ac499b0af3a5',
@@ -19,3 +22,15 @@ class VersionTests(TestCase):
         }
 
         self.assertEqual(expected, actual);
+
+    def test_version_lookup(self):
+        """
+        Test expected behavior when git_version_lookup retrieves output from git
+        """
+        git_directory = os.path.join(settings.PROJECT_ROOT, ".git")
+        version = git_version_lookup(git_directory=git_directory)
+
+        keys = ['git_sha', 'git_sha_abbrev', 'commit_date', 'git_branch']
+        for key in keys:
+            self.assertIn(key, version)
+            self.assertIsNotNone(version[key])


### PR DESCRIPTION
## Description
Problem: api/v{1,2}/deploy_version is not returning git information from atmosphere-ansible
Solution: return information about atmosphere-ansible like we return it from atmosphere

There was a decent amount of refactoring, and a decent amount of tests added!

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog