### PR TITLE
Make another attempt to fix adding fixed ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
  - Support multiple hostnames for Atmosphere(1) server ([#602](https://github.com/cyverse/atmosphere/pull/602))
 
+### Fixed
+ - On start/unshelve instances would fail to be reachable because ports added
+   post boot ([#604](https://github.com/cyverse/atmosphere/pull/604))
+
 ## [v32-0](https://github.com/cyverse/atmosphere/compare/v31-1...v32-0) 2018-04-03
 ### Changed
 ### Added


### PR DESCRIPTION
## Description
Try different approach to working around openstack port availability zone issue

### Problem
After upgrading Marana to Pike we found that ports which were attached post boot, would never successfully attach. This meant that every time an instance would boot (start/unshelve) minus initial launch, it would not be reachable. A workaround was discovered to enable allow-hotplug for the given interface in cloud-init, but it was deemed more complicated than simply preserving the ports.

We were deleting/recreating the ports in the first place, because of a bug which affected j7m https://bugs.launchpad.net/nova/+bug/1759924.

### Solution

Rather than add/delete ports, add/remove fixed ips, but explicitly check if we're dealing with the availability zone issue and then try deleting/recreating the port. It is unknown why j7m is able to attach ports post boot, and we cannot.

I tested the following scenarios. Start/stop, shelve/unshelve on marana and indiana. (and in particular the shelve scenario where the AZ was incorrect)

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.