### PR TITLE
Fix quota update bug "index out of range"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
  - On start/unshelve instances would fail to be reachable because ports added
    post boot ([#604](https://github.com/cyverse/atmosphere/pull/604))
+ - Quota update would yield an index out of bounds error ((606)[https://github.com/cyverse/atmosphere/pull/606])
  - Travis build failure, specify version 9 of pip until we're ready for pip 10 ((607)[https://github.com/cyverse/atmosphere/pull/607])
 
 ## [v32-0](https://github.com/cyverse/atmosphere/compare/v31-1...v32-0) 2018-04-03


### PR DESCRIPTION
## Description

Fix quota update causing index out of range

### Problem
Updating a users quota, would trigger an index out of range error

### Solution
Use a different api for fetching the users tenant id

In the act of changing quota, we require a tenant id for the user. The original api which fetched this id, did so through a side effect of establishing a connection to the nova compute api. This side effect changed when marana was upgraded to use the 2.1 compute api rather than the 2 version. It changed as a result of a new url returned from the service catalog discovery.

We are no longer using this method in rtwo `_get_tenant_id`.
I tested against marana, workshop, iu, and tacc.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.