### PR TITLE
Preserve private networks and private/fixed IPs for inactive instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v32-2...HEAD) - YYYY-MM-DD
+### Changed
+  - Private networking resources (fixed IP, port, private subnet, private network) are preserved for inactive (suspended,
+    shelved, stopped) instances ([#608](https://github.com/cyverse/atmosphere/pull/608))
+    - Additionally atmosphere no longer reports the private ip in the absence
+      of the public ip
+
 ### Fixed
   - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
   - monitor_machines_for fails in the presence of inactive provider ([#614](https://github.com/cyverse/atmosphere/pull/614))

--- a/atmosphere/celery_router.py
+++ b/atmosphere/celery_router.py
@@ -55,7 +55,6 @@ PERIODIC_TASKS = [
     "prune_machines", "prune_machines_for",
     "check_image_membership", "update_membership_for",
     "clear_empty_ips", "clear_empty_ips_for",
-    "remove_empty_network",
     "remove_empty_networks",
     "remove_empty_networks_for",
     "reset_provider_allocation",

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -495,7 +495,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "clear_empty_ips": {
         "task": "clear_empty_ips",
-        "schedule": timedelta(minutes=120),
+        "schedule": crontab(hour="1", minute="0", day_of_week="*"),
         "options": {"expires": 60 * 60}
     },
 }

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -498,12 +498,6 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=120),
         "options": {"expires": 60 * 60}
     },
-    "remove_empty_networks": {
-        "task": "remove_empty_networks",
-        # Every two hours.. midnight/2am/4am/...
-        "schedule": crontab(hour="*/2", minute="0", day_of_week="*"),
-        "options": {"expires": 5 * 60, "time_limit": 5 * 60}
-    },
 }
 
 #     # Django-Celery Development settings

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -713,19 +713,14 @@ def find_instance(instance_id):
 def _find_esh_ip(esh_instance):
     if esh_instance.ip:
         return esh_instance.ip
+
+    ip_address = "0.0.0.0"
     try:
-        if not hasattr(esh_instance, "extra")\
-           or not esh_instance.extra.get("addresses"):
-            return "0.0.0.0"
         ips = esh_instance.extra["addresses"].values()
         ip_address = [ip for ip in ips[0]
                       if ip["OS-EXT-IPS:type"] == "floating"][0]["addr"]
-    except Exception:  # no public ip
-        try:
-            ip_address = [ip for ip in ips[0]
-                          if ip["OS-EXT-IPS:type"] == "fixed"][0]["addr"]
-        except Exception:  # no private ip
-            ip_address = "0.0.0.0"
+    except Exception:
+        pass
     return ip_address
 
 


### PR DESCRIPTION
## Description

This PR removes the code that removes private network resources from inactive (suspended/stopped/shelved instances). This effectively leaves the private subnet and fixed IP intact. We are still removing floating (public) IP addresses.

## Background

Currently, Atmosphere(2) removes fixed IP addresses (and possibly private networks) from instances when they are stopped, suspended, or shelved, and also periodically on all 'inactive' instances. This was originally done for at least the following reasons:

> * support for isolated tenant subnets, where each tenant gets their own subnet of /24 (though in hindsight /24 is probably too large)
> * at the time, neutron overlapping ips didn't work for us as expected or there was some gotcha, which I forget
> * because we assumed that subnet space would be finite and to plan for future growth and larger scale, then atmosphere would reclaim unused subnets (esp given that some users will use atmosphere infrequently or only once e.g. a workshop environment)
> * in order to be able to claim unused subnets, we needed to ensure that private ips were reclaimed cleanly, which meant a tear down of the network and port at the vm level

It has also been mentioned that the OpenStack Neutron service (in OpenStack Havana, or earlier) had capacity issues with many concurrent private networks.

I have seen us chase several bugs and spend many engineering hours dealing with consequences of (and workarounds for) the decision to remove private network resources from inactive instances, most recently during the v32 deployment, #599 and #604. I believe that we don't need to be doing this. At best, I think it solves a problem that we don't have and are unlikely to have in the near future.

I suggest the following:
- There are nearly 18 million IP addresses in RFC 1918 (private) space; that's 70,000 /24 subnets (which is many times the total number of users in any Atmosphere(2) deployment), or e.g. 280,000 /22 subnets
- If we do approach 70,000 active users someday (a great problem to have!) then we could easily switch to using smaller private subnets, or justify the engineering effort to deal with the consequences of removing private networks from inactive instances, using overlapping private networks, etc. In other words, I think this decision is easy to change later if needed.
- I suspect that our modern, load-balanced, highly available Neutron control plane can handle many concurrent private networks/subnets.
- I think that reclaiming private networks/subnets from users that have zero instances (active or inactive) is a safe action that is unlikely to cause bugs, though that is not implemented here

## Todo
- [x] Deploy changes to atmobeta
- [x] Stop and start instances
- [x] Suspend and resume instances
- [x] shelve-offload and unshelve instances
- [x] instances that are suspended/shelved/stopped now display the private IP address in Troposphere. This is likely to confuse users.
- ~[ ] When resuming instance, this is logged: `2018-04-17 13:59:02,523 atmosphere-WARNING [/opt/dev/atmosphere/service/networking.py 191] Unable to create new_cidr for subnet for user: test-cmart (CIDR already used)`~ Pre-existing bug not related to this PR
- [x] Un-snowflake atmobeta when testing complete

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [x] Documentation created/updated (just changelog?)
- ~[ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- ~[ ] New variables supported in Clank~
- ~[ ] New variables committed to secrets repos~