### PR TITLE
Fix volume quota update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v32-1...HEAD)
+### Fixed
+ - Quota updates concerning volumes would silently fail ([#611](https://github.com/cyverse/atmosphere/pull/611))
+
 ## [v32-1](https://github.com/cyverse/atmosphere/compare/v32-0...v32-1) - 2018-04-17
 ### Added
  - Support multiple hostnames for Atmosphere(1) server ([#602](https://github.com/cyverse/atmosphere/pull/602))

--- a/service/quota.py
+++ b/service/quota.py
@@ -209,10 +209,10 @@ def _set_volume_quota(user_quota, identity):
     username = identity.created_by.username
     logger.info("Updating quota for %s to %s" % (username, volume_values))
     driver = get_cached_driver(identity=identity)
-    username = driver._connection._get_username()
     ad = get_account_driver(identity.provider)
     admin_driver = ad.admin_driver
-    result = admin_driver._connection._cinder_update_quota(username, volume_values)
+    tenant = ad.get_project(username)
+    result = admin_driver._connection._cinder_update_quota(tenant.id, volume_values)
     logger.info("Updated quota for %s to %s" % (username, result))
     return result
 


### PR DESCRIPTION
## Description
### Problem
Updating a user's volume quota, would return a successful response including the updated quota values. However, the values wouldn't actually be updated in openstack.

### Solution
Pass a tenant id rather than a tenant name in /os-quota-sets/<tenant id>

The current OS api[1] silently fails, reporting a successful update, even when the update did not occur. Tested against all providers in use. Verified that storage is updated from OS pov.

[1] https://developer.openstack.org/api-ref/block-storage/v3/index.html#quota-sets-extension-os-quota-sets
## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.