### PR TITLE
Fix monitor_machines_for in the presence of inactive clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v32-2...HEAD) - YYYY-MM-DD
 ### Fixed
-- `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
+  - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
+  - monitor_machines_for fails in the presence of inactive provider ([#614](https://github.com/cyverse/atmosphere/pull/614))
 
 ### Removed
   - In the general feedback email we no longer include the users selected


### PR DESCRIPTION
## Description

### Problem
AttributeError: 'NoneType' object has no attribute 'get_image_members'

### Solution
Remove irrelevant code

### Background
During monitor_machines_for we fetch the latest images from the cloud and sync those with our database. Part of that syncing is creating the Membership relations which affect who can see an atmosphere image (more correctly a provider machine). There was a bug in this process.

For each image we convert to a provider machine, we check if a machine request exists on any provider. If one does exist and the provider of the request doesn't equal the provider of the machine we're syncing, then we copy the image members of that original provider onto this provider machine. The error is that we never check if that original provider is active (i.e still running). If it's not active, then we cannot fetch the image members. This occurred after the Tucson cloud was taken offline/made inactive.

We do not need to be copying image members in this way. If the cloud machine exists, then it should have the members as part of the image synchronization between providers.

### Reproduce
```
from core.models import *
from service.tasks.monitoring import monitor_machines_for

# Fetch provider-independent identifiers of machines on Tucson
tucson_identifiers = ProviderMachine.objects.filter(
    instance_source__provider__location__contains="Tucson").values_list(
        "instance_source__identifier", flat=True)

# Fetch the first machine that will cause the bug
bad_machine = ProviderMachine.objects.filter(
    application_version__application__private=True,
    instance_source__identifier__in=tucson_identifiers,
    instance_source__provider__location__contains="arana",
    application_version__end_date=None,
    instance_source__end_date=None).first()

# Monitor on Marana (id=7)
monitor_machines_for(7, limit_machines=[bad_machine.identifier])
```

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.