### PR TITLE
Fixes for application_to_provider Glance client v1 native (non-iRODS) upload method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v32-2...HEAD) - YYYY-MM-DD
+### Fixed
+- `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
+
 ## [v32-2](https://github.com/cyverse/atmosphere/compare/v32-1...v32-2) - 2018-04-26
 ### Fixed
  - Quota updates concerning volumes would silently fail ([#611](https://github.com/cyverse/atmosphere/pull/611))


### PR DESCRIPTION
## Description

Glance Client v1 uses a different method for uploading image data; this PR accommodates that.

This codepath was previously untested with Glance Client v1 because we were using the "direct iRODS transfer" mode of application_to_provider. We recently stopped using that (because Marana Cloud Glance is now backed by Ceph), and this bug surfaced.

Also, apparently in Glance API v1, it is valid for an image's checksum to be missing even though that image is in active state; we can catch this and log a warning.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
- [ ] New variables committed to secrets repos