### PR TITLE
If using External Router topology then determine external network ID when adding floating IP and explicitly pass it to rtwo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
   - monitor_machines_for fails in the presence of inactive provider ([#614](https://github.com/cyverse/atmosphere/pull/614))
   - Chromogenic (0.4.17) had a caching issue causing imaging to fail ([#619](https://github.com/cyverse/atmosphere/pull/619))
+  - Explicitly specify external network to rtwo when associating a floating IP address ([#624](https://github.com/cyverse/atmosphere/pull/624))
 
 ### Removed
   - In the general feedback email we no longer include the users selected

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -175,7 +175,7 @@ requirements-detector==0.5.2  # via prospector
 rfc3986==1.1.0
 rfive==0.2.0
 rsa==3.4.2
-rtwo==0.5.19
+rtwo==0.5.20
 scandir==1.5              # via pathlib2
 selenium==3.5.0           # via splinter
 setoptconf==0.2.0         # via prospector

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,7 +122,7 @@ requestsexceptions==1.3.0  # via os-client-config
 rfc3986==1.1.0            # via oslo.config
 rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
-rtwo==0.5.19
+rtwo==0.5.20
 simplejson==3.11.1        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 singledispatch==3.4.0.3   # via tornado
 six==1.11.0               # via bcrypt, cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, pynacl, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, python-swiftclient, singledispatch, stevedore, warlock


### PR DESCRIPTION
## Description

Problem: When creating a floating IP address and associating it to an instance, rtwo chooses an arbitrary external network (the first one that happens to be returned from the API). If there are multiple extrenal networks, rtwo may select a network which is unreachable from the user's private network (no router connects them).

Solution: When using external router topology, determine the correct external network (based on the user's assigned public router) and explicitly specity it when creating a floating IP address.

Co-depends on [rtwo #27](https://github.com/cyverse/rtwo/pull/27)

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~