### PR TITLE
Run monitor_machines once each night rather than every 30 mins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     shelved, stopped) instances ([#608](https://github.com/cyverse/atmosphere/pull/608))
     - Additionally atmosphere no longer reports the private ip in the absence
       of the public ip
+  - `monitor_machines` periodic task runs once each night rather than every 30 minutes
 
 ### Fixed
   - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -474,8 +474,7 @@ CELERYBEAT_SCHEDULE = {
     "monitor_machines": {
         "task": "monitor_machines",
         # Every day of the week @ 1am
-        #"schedule": crontab(hour="1", minute="0", day_of_week="*"),
-        "schedule": timedelta(minutes=30),
+        "schedule": crontab(hour="1", minute="0", day_of_week="*"),
         "options": {"expires": 10 * 60, "time_limit": 10 * 60}
     },
     "monitor_volumes": {


### PR DESCRIPTION
## Description

This task is taking >1 hour to run in production for each provider, doesn't make sense to run every 30 mins. Image import via this method is rare, and `monitor_machines` can always be run on-demand if needed. See #atmosphere_issues channel in Jetstream Slack from morning of 2018-06-15.

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
- [ ] ~New variables committed to secrets repos~