### PR TITLE
Django tests fail when run consecutively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))
   - monitor_machines_for fails in the presence of inactive provider ([#614](https://github.com/cyverse/atmosphere/pull/614))
   - Chromogenic (0.4.17) had a caching issue causing imaging to fail ([#619](https://github.com/cyverse/atmosphere/pull/619))
+  - Consecutive test runs would fail because django-memoize was intercepting
+    cassette playback ([#626](https://github.com/cyverse/atmosphere/pull/626))
 
 ### Removed
   - In the general feedback email we no longer include the users selected

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -1,5 +1,5 @@
 import json
-
+import memoize
 import freezegun
 import vcr
 from django.test import TestCase, override_settings, modify_settings
@@ -22,6 +22,14 @@ my_vcr = vcr.VCR(
 @override_settings(TACC_API_URL='https://localhost/api-test')
 class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
+
+    def setUp(self):
+        # Because we use memoize to cache the tacc api, calling tacc_api_get
+        # doesn't necessarily trigger an http request. This means that a
+        # cassette will not necessarily be played. In order to test cassette
+        # playback, we just need to clear the memoize cache
+        from jetstream.tas_api import tacc_api_get
+        memoize.delete_memoized(tacc_api_get)
 
     @my_vcr.use_cassette()
     def test_validate_account(self, cassette):


### PR DESCRIPTION
## Description
Fix test failures when run consecutively

## Problem
Running tests twice causes failures

## Solution
Remove the memoize cache before test runs

This would fail if run twice:
```
./manage.py test --keepdb jetstream.test_tas_api.TestJetstream.test_validate_account
```

It would fail because the cassettes did not reflect the correct number of plays, i.e. api calls didn't happen like we expected. Normally cassettes store the results of a first http call, and intercept and respond to all future calls with the results of the first. We assert that the cassette was called a certain number of times. However, django-memoize intercepts the functions that would even make these http calls, so the cassettes were under-reporting the number of playbacks.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.