### PR TITLE
Upgrade Ansible version to the latest (2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
       of the public ip
   - `monitor_machines` periodic task runs once each night rather than every 30 minutes
   - Subspace is replaced by Ansible's PlaybookCLI for instance deployment ([#631](https://github.com/cyverse/atmosphere/pull/631))
+  - Updated Ansible version to 2.6.1 by changing requirements and changing `deploy.py` Playbook arg `--inventory-file` to `--inventory` ([#635](https://github.com/cyverse/atmosphere/pull/635))
 
 ### Fixed
   - `application_to_provider` was using an invalid method in Glance Client v1 to upload image data ([#618](https://github.com/cyverse/atmosphere/pull/618))

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file dev_requirements.txt dev_requirements.in requirements.txt
 #
 amqp==2.2.2
-ansible==2.3.2.0
+ansible==2.6.1
 apache-libcloud==0.20.1
 appdirs==1.4.3
 asn1crypto==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 amqp==2.2.2               # via kombu
-ansible==2.3.2.0
+ansible==2.6.1
 apache-libcloud==0.20.1
 appdirs==1.4.3            # via os-client-config
 asn1crypto==0.22.0        # via cryptography

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -309,7 +309,7 @@ def execute_playbooks(playbook_dir, host_file, extra_vars, host,
     for pb in limit_playbooks:
         logger.info("Executing playbook %s/%s" % (playbook_dir, pb))
         args = [
-            "--inventory-file=%s" % inventory_dir,
+            "--inventory=%s" % inventory_dir,
             "--limit=%s" % host,
             "--extra-vars=%s" % json.dumps(extra_vars),
             "%s/%s" % (playbook_dir, pb)


### PR DESCRIPTION
## Description

This PR upgrades the Ansible version used by Atmosphere to the latest (2.6.1). The only change required was the `--inventory-file` argument was changed to just `--inventory`.

Related PR: Atmosphere-Ansible [PR #155](https://github.com/cyverse/atmosphere-ansible/pull/155)