### PR TITLE
Only return identities that exist on active providers

### DIFF
--- a/api/v2/views/identity.py
+++ b/api/v2/views/identity.py
@@ -6,7 +6,7 @@ from rest_framework.viewsets import ModelViewSet
 import django_filters
 
 from core.models import Identity, AtmosphereUser
-from core.query import only_current_provider
+from core.query import only_current_provider, only_active_provider
 
 from api.v2.serializers.details import IdentitySerializer
 from api.v2.views.base import UserListAdminQueryAndUpdate
@@ -62,4 +62,4 @@ class IdentityViewSet(MultipleFieldLookup, UserListAdminQueryAndUpdate, ModelVie
             user = AtmosphereUser.objects.filter(username=target_username).first()
             idents = Identity.shared_with_user(user)
 
-        return idents.filter(only_current_provider())
+        return idents.filter(only_active_provider(), only_current_provider())


### PR DESCRIPTION
## Description
### Problem
The volume creation modal was allowing users to choose providers/(really identities) that were no longer active

### Solution
Only return idents for active and non-endated providers.


## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor