### PR TITLE
Configure atmosphere to optionally report allocation usage

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -38,6 +38,12 @@ ENFORCING = True
 ENFORCING = False
 {% endif %}
 
+{% if REPORT_ALLOCATION_USAGE %}
+REPORT_ALLOCATION_USAGE = True
+{% else %}
+REPORT_ALLOCATION_USAGE = False
+{% endif %}
+
 #Cloud-Operator specific information
 SITE_NAME = '{{ SITE_NAME | default("") }}'
 SITE_TITLE = '{{ SITE_NAME | default("") }}'

--- a/jetstream/tasks.py
+++ b/jetstream/tasks.py
@@ -138,6 +138,11 @@ def _create_tas_report_for(user, tacc_username, tacc_project_name, end_date):
 
 @task(name="report_allocations_to_tas")
 def report_allocations_to_tas():
+    if not settings.REPORT_ALLOCATION_USAGE:
+        logger.warn(
+            "Report sending is disabled! The TACC API will NOT see changes in allocation ({})".
+            format(settings.TACC_API_URL))
+        return
     logger.info("Reporting: Begin creating reports")
     create_reports()
     logger.info("Reporting: Completed, begin sending reports")

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -6,6 +6,7 @@ DJANGO_SERVER_URL = # https://www.my-website.com
 VIRTUALENV_PATH =# /path/virtualenv/atmo
 
 [local.py]
+REPORT_ALLOCATION_USAGE = False # Whether we update the TAS api with our allocation usage reports (DO NOT SET TO TRUE UNLESS YOU ARE PRODUCTION)
 ADDITIONAL_ALLOWED_HOSTNAMES = [] # Additional HOST header values that django will permit in requests
 AUTH_USE_OVERRIDE =  True # Boolean required will override authentication set in __init__.py
 AUTH_MOCK_USER = # testuser


### PR DESCRIPTION
## Description
This was created so that a staging environment could include production TAS credentials without worrying about having an impact on reporting. The staging and production environment would run concurrently at times and we wouldn't want to overreport usage.

In the past we used the development tas api. This is just another route that allows us to change less variables between production/staging and avoid requests to grant users allocations on both production tas and developer tas.

https://github.com/cyverse/clank/pull/266

## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank