### PR TITLE
Simplify v2 action api, fix volume detach 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Updated Ansible version to 2.6.1 by changing requirements and changing
     `deploy.py` Playbook arg `--inventory-file` to `--inventory`
     ([#635](https://github.com/cyverse/atmosphere/pull/635))
+  - Simplified v2 instance action api to exclude 'object' field
+    ([#655](https://github.com/cyverse/atmosphere/pull/655))
   - Prefer importing settings from django.conf
     ([#658](https://github.com/cyverse/atmosphere/pull/658))
 
@@ -43,6 +45,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#650](https://github.com/cyverse/atmosphere/pull/650))
   - Variable changes to DJANGO_DEBUG and SEND_EMAILS
     ([#649](https://github.com/cyverse/atmosphere/pull/649))
+  - Fixed v2 volume detach throwing 500 serialization error
+    ([#655](https://github.com/cyverse/atmosphere/pull/655))
 
 ### Added
   - Added AccessTokens model, API view, and serializers to enable new feature on

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -129,11 +129,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
         if type(action) == list:
             action = action[0]
         try:
-            result_obj = run_instance_action(user, identity, instance_id, action, action_params)
+            run_instance_action(user, identity, instance_id, action, action_params)
             api_response = {
                 'result': 'success',
                 'message': 'The requested action <%s> was run successfully' % (action,),
-                'object': result_obj,
             }
             response = Response(api_response, status=status.HTTP_200_OK)
             return response


### PR DESCRIPTION
## Description

When detaching a volume, run_instance_action would return the volume. The api would then attempt to return that volume object, rather than a serialized volume. The action api doesn't need to return anything besides the status of the action. It should definitely not know how serialize objects like instances and volumes.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.