### PR TITLE
Prefer importing settings from django.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Updated Ansible version to 2.6.1 by changing requirements and changing
     `deploy.py` Playbook arg `--inventory-file` to `--inventory`
     ([#635](https://github.com/cyverse/atmosphere/pull/635))
+  - Prefer importing settings from django.conf
+    ([#658](https://github.com/cyverse/atmosphere/pull/658))
 
 ### Fixed
   - Consecutive test runs would fail because django-memoize was intercepting

--- a/api/v1/views/instance_query.py
+++ b/api/v1/views/instance_query.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 
 from threepio import logger
 
-from atmosphere import settings
+from django.conf import settings
 from core.models.instance import Instance
 
 

--- a/api/v2/views/machine_request.py
+++ b/api/v2/views/machine_request.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from django.db.models import Q
 from django.utils import timezone
 
-from atmosphere import settings
+from django.conf import settings
 
 from core import exceptions as core_exceptions
 from core.email import send_denied_resource_email

--- a/atmosphere/celery_init.py
+++ b/atmosphere/celery_init.py
@@ -18,7 +18,7 @@ app.autodiscover_tasks()
 
 #NOTE: Some settings are not being set properly.. so we'll override them.. again. here
 # Load task modules from all registered Django app configs.
-from atmosphere import settings
+from django.conf import settings
 app.Task.resultrepr_maxsize = 2000
 
 # Django-Celery secrets ( set inside atmosphere/settings/__init__.py )

--- a/atmosphere/settings/__init__.py
+++ b/atmosphere/settings/__init__.py
@@ -535,16 +535,3 @@ except ImportError:
 Import local settings specific to the server, and secrets not checked into Git.
 """
 from atmosphere.settings.local import *
-
-
-def _get_method_for_string(method_str, the_globals=None):
-    """
-    This setting will provide a way to move easily from
-    'my_method' --> my_method the function
-    """
-    if not the_globals:
-        the_globals = globals()
-    return the_globals[method_str]
-
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.

--- a/core/email.py
+++ b/core/email.py
@@ -14,7 +14,7 @@ from pytz import timezone as pytz_timezone
 
 from threepio import logger
 
-from atmosphere import settings
+from django.conf import settings
 from core.models.allocation_source import total_usage
 from core.models import IdentityMembership, MachineRequest, EmailTemplate
 

--- a/core/email.py
+++ b/core/email.py
@@ -150,9 +150,7 @@ def lookupEmail(username):
     """
     if not hasattr(settings, 'EMAIL_LOOKUP_METHOD'):
         return ldapLookupEmail(username)
-    lookup_fn_str = settings.EMAIL_LOOKUP_METHOD
-    lookup_fn = settings._get_method_for_string(lookup_fn_str, the_globals=globals())
-    # Known function and args..
+    lookup_fn = globals()[settings.EMAIL_LOOKUP_METHOD]
     return lookup_fn(username)
 
 def user_email_info(username):
@@ -162,9 +160,7 @@ def user_email_info(username):
     """
     if not hasattr(settings, 'USER_EMAIL_LOOKUP_METHOD'):
         return ldap_get_email_info(username)
-    lookup_fn_str = settings.USER_EMAIL_LOOKUP_METHOD
-    lookup_fn = settings._get_method_for_string(lookup_fn_str, the_globals=globals())
-    # Known function and args..
+    lookup_fn = globals()[settings.USER_EMAIL_LOOKUP_METHOD]
     return lookup_fn(username)
 
 

--- a/core/models/application.py
+++ b/core/models/application.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from threepio import logger
 
-from atmosphere import settings
+from django.conf import settings
 
 from core import query
 from core.models.provider import Provider, AccountProvider

--- a/core/models/instance.py
+++ b/core/models/instance.py
@@ -31,7 +31,7 @@ from core.models.size import (
 )
 from core.models.tag import Tag
 from core.models.managers import ActiveInstancesManager
-from atmosphere import settings
+from django.conf import settings
 from service.mock import MockInstance
 
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -8,7 +8,7 @@ from celery.decorators import task
 from django.core.mail import EmailMessage
 from django.utils import timezone
 
-from atmosphere import settings
+from django.conf import settings
 from threepio import celery_logger, email_logger
 
 from core.models.status_type import get_status_type

--- a/core/views.py
+++ b/core/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseRedirect
 
 from threepio import logger
 
-from atmosphere import settings
+from django.conf import settings
 from django_cyverse_auth.decorators import atmo_login_required
 from django_cyverse_auth.models import Token as AuthToken
 from core.models import AtmosphereUser as DjangoUser

--- a/scripts/add_new_provider.py
+++ b/scripts/add_new_provider.py
@@ -20,7 +20,7 @@ from core.models import Provider, PlatformType, ProviderType, Identity, Group,\
 from core.models import InstanceAction
 from service.driver import get_account_driver
 from service.networking import topology_list
-from atmosphere import settings
+from django.conf import settings
 
 libcloud.security.VERIFY_SSL_CERT = False
 libcloud.security.VERIFY_SSL_CERT_STRICT = False
@@ -506,7 +506,7 @@ def _create_provider_and_identity(arguments):
     provider_credentials.update(json_provider_credentials)
     cloud_config.update(json_cloud_config)
 
-    
+
     while True:
         get_provider_info(provider_info)
         get_admin_info(admin_info)

--- a/scripts/admin_update_keypairs.py
+++ b/scripts/admin_update_keypairs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from atmosphere import settings
+from django.conf import settings
 from core.models import Provider, Identity
 from service.accounts.openstack_manager import AccountDriver as OSAccountDriver
 from rtwo.exceptions import KeystoneUnauthorized

--- a/service/accounts/eucalyptus.py
+++ b/service/accounts/eucalyptus.py
@@ -17,7 +17,7 @@ from core.models.provider import Provider
 from rtwo.drivers.eucalyptus_user import UserManager
 from chromogenic.drivers.eucalyptus import ImageManager
 
-from atmosphere import settings
+from django.conf import settings
 
 
 class AccountDriver():

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -36,7 +36,7 @@ from rtwo.drivers.openstack_network import NetworkManager
 from rtwo.drivers.openstack_user import UserManager
 from chromogenic.drivers.openstack import ImageManager
 
-from atmosphere import settings
+from django.conf import settings
 
 from core.query import contains_credential
 from core.models import GroupMembership
@@ -58,7 +58,7 @@ def timeout_after(seconds):
             raise TimeoutError()
 
         # set the timeout handler
-        signal.signal(signal.SIGALRM, handler) 
+        signal.signal(signal.SIGALRM, handler)
         signal.alarm(seconds)
         try:
             result = func(*args, **kwargs)
@@ -567,7 +567,7 @@ class AccountDriver(BaseAccountDriver):
                     % (glance_image, project_name))
         return project
 
-        
+
 
     def rebuild_security_groups(self, core_identity, rules_list=None):
         creds = self.parse_identity(core_identity)
@@ -1086,7 +1086,7 @@ class AccountDriver(BaseAccountDriver):
             limits['ram'] = absolute_limits['maxTotalRAMSize']
         except:
             logger.exception("The method for 'reading' absolute limits has changed!")
-            
+
         return limits
 
     def get_user_limits(self, username, project_name):
@@ -1126,7 +1126,7 @@ class AccountDriver(BaseAccountDriver):
                                              % (tenant_id, user_id))
         quota_obj = server_resp.object
         return quota_obj
-        
+
 
 
 
@@ -1241,7 +1241,7 @@ class AccountDriver(BaseAccountDriver):
             tenant_name = self.get_project_name_for(username)
         if not password:
             password = self.hashpass(tenant_name)
-        version = self.user_manager.keystone_version() 
+        version = self.user_manager.keystone_version()
         if version == 2:
             ex_version = '2.0_password'
             keystone_auth_url = self.credentials['auth_url'].replace('/tokens','')

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -12,7 +12,7 @@ from django.utils.timezone import datetime
 
 from threepio import logger, deploy_logger
 
-from atmosphere import settings
+from django.conf import settings
 from atmosphere.settings import secrets
 
 from django_cyverse_auth.protocol import ldap

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -6,7 +6,7 @@ Atmosphere service exceptions.
 from ansible.errors import AnsibleError
 from socket import error as socket_error
 from rtwo.exceptions import ConnectionFailure, LibcloudInvalidCredsError, LibcloudBadResponseError
-from atmosphere import settings
+from django.conf import settings
 
 
 class ServiceException(Exception):

--- a/service/instance.py
+++ b/service/instance.py
@@ -46,7 +46,7 @@ from core.models.volume import convert_esh_volume
 from core.models.provider import AccountProvider, Provider, ProviderInstanceAction
 from core.exceptions import ProviderNotActive
 
-from atmosphere import settings
+from django.conf import settings
 from atmosphere.settings import secrets
 
 from service.cache import get_cached_driver, invalidate_cached_instances

--- a/service/networking.py
+++ b/service/networking.py
@@ -11,7 +11,7 @@ import random
 from rtwo.exceptions import NeutronClientException, NeutronNotFound
 from service.driver import get_account_driver
 
-from atmosphere import settings
+from django.conf import settings
 from threepio import logger
 
 


### PR DESCRIPTION
## Description

The proper way to import settings is via 'from django.conf import settings'. This is because settings are a part of Django's abstractions. For example, `@override_settings` has no effect unless settings are imported this way.

https://docs.djangoproject.com/en/1.10/topics/settings/#using-settings-in-python-code

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.