### PR TITLE
Fix incorrect order of arguments

### DIFF
--- a/jetstream/plugins/auth/validation.py
+++ b/jetstream/plugins/auth/validation.py
@@ -28,7 +28,7 @@ class XsedeProjectRequired(ValidationPlugin):
             # TODO: Also check that:
             # - the start date of the allocation source is in the past, and
             # - the end date of the allocation source is not set, or is in the future.
-            logger.debug('user: %s, active_allocation_count: %d', active_allocation_count, user)
+            logger.debug('user: %s, active_allocation_count: %d', user, active_allocation_count)
             return active_allocation_count > 0
 
 


### PR DESCRIPTION
## Description

Incorrect order of arguments would result in an exception always being raised. So the original intention of allowing validation to work in the absence of the TAS api was never realized.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.