### PR TITLE
Remove reference to non-existent Allocation model

### DIFF
--- a/core/tests/helpers.py
+++ b/core/tests/helpers.py
@@ -3,7 +3,7 @@ These helper classes are written to make it easier to write 'mock test cases'
 for Core objects
 """
 from core.models import (
-    Allocation, Application, ApplicationVersion,
+    Application, ApplicationVersion,
     AtmosphereUser, Group,
     Identity, IdentityMembership,
     Instance, InstanceSource, InstanceStatusHistory,
@@ -45,10 +45,8 @@ def _new_mock_identity_member(username, provider):
         created_by=mock_user,
         quota=mock_quota,
         provider=provider)[0]
-    mock_allocation = Allocation.default_allocation()
     mock_identity_member = IdentityMembership.objects.get_or_create(
-        identity=mock_identity, member=mock_group,
-        allocation=mock_allocation)[0]
+        identity=mock_identity, member=mock_group)[0]
     return mock_identity_member
 
 


### PR DESCRIPTION
## Description
This pr fixes an issue introduced in the build.

I merged two prs back to back that each individually passed the build, but resulted in a build failure together. I didn't completely remove all references to Allocation, there were some references in our old tests which were not being run. I merged the pr to re-incorporate these old tests after the pr which removed allocation. The result is that these tests had a reference to the old allocation system, which then prompted a failure since the old allocation had been removed.
