### PR TITLE
For application_to_provider, determine correct upload method based on Glance client version specified in main function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#655](https://github.com/cyverse/atmosphere/pull/655))
   - Reincluded/fixed broken tests
     ([#657](https://github.com/cyverse/atmosphere/pull/657))
+  - In application_to_provider,py, determine correct upload method based
+    on Glance client version specified in main function
+    ([#667](https://github.com/cyverse/atmosphere/pull/667))
 
 ## [v33-0](https://github.com/cyverse/atmosphere/compare/v32-2...v33-0) - 2018-08-06
 ### Changed


### PR DESCRIPTION
## Description

Apparently newer Glance client packages don't even have a v1 attribute, in which case 1. this code throws an `AttributeError` and 2. We're definitely not using old Glance v1. So, don't even test to see if we have a Glance v1 client. This is already hotfixed on J7m prod. 

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [x] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~
