### PR TITLE
Fix several issues in attempt to add timeout to tas api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v34-1...HEAD) - YYYY-MM-DD
+### Fixed
+  - Several issues in the TACC_API_TIMEOUT implementation prevented the
+    desired behavior of offline (no access to tas) user validation
+    ([#668](https://github.com/cyverse/atmosphere/pull/668))
+
 ## [v34-1](https://github.com/cyverse/atmosphere/compare/v34-0...v34-1) - 2018-09-18
 ### Fixed
   - Fix reference to deleted model ProviderDNSServerIP

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -467,7 +467,7 @@ INSTALLED_APPS += (
 TACC_API_USER = '{{ TACC_API_USER }}'
 TACC_API_PASS = '{{ TACC_API_PASS }}'
 TACC_API_URL = '{{ TACC_API_URL }}'
-TACC_READ_API_TIMEOUT = '{{ TACC_READ_API_TIMEOUT | default(5) }}'
+TACC_READ_API_TIMEOUT = {{ TACC_READ_API_TIMEOUT | default(5) }}
 # Uncomment this DEFAULT_QUOTA_PLUGINS line to use the JetstreamSpecialAllocationQuota plugin
 DEFAULT_QUOTA_PLUGINS = [
     'jetstream.plugins.quota.default_quota.JetstreamSpecialAllocationQuota',
@@ -496,7 +496,7 @@ SPECIAL_ALLOCATION_SOURCES = {
 TACC_API_USER = ''
 TACC_API_PASS = ''
 TACC_API_URL = ''
-TACC_READ_API_TIMEOUT = ''
+TACC_READ_API_TIMEOUT = None
 {% endif %}
 
 {% if ALLOCATION_OVERRIDES_NEVER_ENFORCE %}

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -467,7 +467,7 @@ INSTALLED_APPS += (
 TACC_API_USER = '{{ TACC_API_USER }}'
 TACC_API_PASS = '{{ TACC_API_PASS }}'
 TACC_API_URL = '{{ TACC_API_URL }}'
-TACC_API_TIMEOUT = '{{ TACC_API_TIMEOUT | default(5) }}'
+TACC_READ_API_TIMEOUT = '{{ TACC_READ_API_TIMEOUT | default(5) }}'
 # Uncomment this DEFAULT_QUOTA_PLUGINS line to use the JetstreamSpecialAllocationQuota plugin
 DEFAULT_QUOTA_PLUGINS = [
     'jetstream.plugins.quota.default_quota.JetstreamSpecialAllocationQuota',
@@ -496,7 +496,7 @@ SPECIAL_ALLOCATION_SOURCES = {
 TACC_API_USER = ''
 TACC_API_PASS = ''
 TACC_API_URL = ''
-TACC_API_TIMEOUT = ''
+TACC_READ_API_TIMEOUT = ''
 {% endif %}
 
 {% if ALLOCATION_OVERRIDES_NEVER_ENFORCE %}

--- a/jetstream/tas_api.py
+++ b/jetstream/tas_api.py
@@ -14,10 +14,7 @@ def tacc_api_post(url, post_data, username=None, password=None):
         password = settings.TACC_API_PASS
     logger.debug('url: %s', url)
     # logger.debug("REQ BODY: %s" % post_data)
-    resp = requests.post(
-        url, post_data,
-        auth=(username, password),
-        timeout=settings.TACC_API_TIMEOUT)
+    resp = requests.post(url, post_data, auth=(username, password))
     logger.debug('resp.status_code: %s', resp.status_code)
     # logger.debug('resp.__dict__: %s', resp.__dict__)
     return resp
@@ -33,7 +30,7 @@ def tacc_api_get(url, username=None, password=None):
     resp = requests.get(
         url,
         auth=(username, password),
-        timeout=settings.TACC_API_TIMEOUT)
+        timeout=settings.TACC_READ_API_TIMEOUT)
     logger.debug('resp.status_code: %s', resp.status_code)
     # logger.debug('resp.__dict__: %s', resp.__dict__)
     if resp.status_code != 200:

--- a/jetstream/test_tas_api.py
+++ b/jetstream/test_tas_api.py
@@ -20,7 +20,7 @@ my_vcr = vcr.VCR(
     'append': 'jetstream',
 })
 @override_settings(
-    TACC_API_URL='https://localhost/api-test', TACC_API_TIMEOUT=5)
+    TACC_API_URL='https://localhost/api-test', TACC_READ_API_TIMEOUT=5)
 class TestJetstream(TestCase):
     """Tests for Jetstream allocation source API"""
 

--- a/jetstream/tests/test_user_validation.py
+++ b/jetstream/tests/test_user_validation.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 import mock
+from requests.exceptions import ReadTimeout
 
 from jetstream.plugins.auth.validation import XsedeProjectRequired
-from jetstream.exceptions import TASAPIException
 from api.tests.factories import UserFactory, UserAllocationSourceFactory
 
 # Create an instance
@@ -25,9 +25,9 @@ class TestOfflineUserValidation(TestCase):
         # Create an allocation for the user
         UserAllocationSourceFactory.create(user=self.user)
 
-        # Simulate offline TAS api by throwing TASAPIException
-        with mock.patch('jetstream.allocation.tacc_api_get') as mock_tacc_api_get:
-            mock_tacc_api_get.side_effect = TASAPIException("Unknown network failure")
+        # Simulate offline TAS api by throwing requests.exceptions.ReadTimeout
+        with mock.patch('jetstream.tas_api.requests.get') as mock_requests_get:
+            mock_requests_get.side_effect = ReadTimeout("Unknown network failure")
             self.assertTrue(plugin.validate_user(self.user))
 
     def test_offline_validation_when_user_has_no_allocations(self):
@@ -37,7 +37,7 @@ class TestOfflineUserValidation(TestCase):
         """
         plugin = XsedeProjectRequired()
 
-        # Simulate offline TAS api by throwing TASAPIException
-        with mock.patch('jetstream.allocation.tacc_api_get') as mock_tacc_api_get:
-            mock_tacc_api_get.side_effect = TASAPIException("Unknown network failure")
+        # Simulate offline TAS api by throwing requests.exceptions.ReadTimeout
+        with mock.patch('jetstream.tas_api.requests.get') as mock_requests_get:
+            mock_requests_get.side_effect = ReadTimeout("Unknown network failure")
             self.assertFalse(plugin.validate_user(self.user))

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -121,7 +121,7 @@ GROUPER_SEARCH_USER = ; ""
 TACC_API_USER = # "tas-username"
 TACC_API_PASS = # "tas-password"
 TACC_API_URL  = # "/path to api/"
-TACC_API_TIMEOUT = 5
+TACC_READ_API_TIMEOUT = 5
 
 #NOTE: Their are *REQUIRED* quotations around 'timedelta(..)'!
 CELERYBEAT_SCHEDULE = {} # {"monitor_instances": {"schedule": 'timedelta(minutes=5)',}}


### PR DESCRIPTION
## Description

The previous pr https://github.com/cyverse/atmosphere/pull/639 did not actually work. 
- `TACC_API_TIMEOUT` was being templated as a string, rather than a number
- The exception raised during a timeout didn't result in offline validation of a users allocation

I tested this locally and fixed the issues. I additionally changed the scope so that the timeout only applies to GETs, I adjusted the variable so that its scope is obvious. Changed `TACC_API_TIMEOUT` to `TACC_READ_API_TIMEOUT`.

## Checklist before merging Pull Requests
- [x] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
- [x] New variables supported in Clank
  - https://github.com/cyverse/clank/pull/278