### PR TITLE
Upgrade django-cyverse-auth to 1.1.6 from 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#664](https://github.com/cyverse/atmosphere/pull/664))
   - Upgrade chromogenic from 0.4.18 to 0.4.20
     ([#670](https://github.com/cyverse/atmosphere/pull/670))
+  - Upgrade django-cyverse-auth to 1.1.6 from 1.1.4
+  ([#671](https://github.com/cyverse/atmosphere/pull/671))
 
 ### Removed
   - Remove code/vars related to old allocation system

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -42,7 +42,7 @@ defusedxml==0.5.0
 deprecation==1.0.1
 django-celery-beat==1.0.1
 django-cors-headers==2.1.0
-django-cyverse-auth==1.1.4
+django-cyverse-auth==1.1.6
 django-debug-toolbar==1.8
 django-filter==1.0.4
 django-jenkins==0.110.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ defusedxml==0.5.0         # via djangorestframework-xml
 deprecation==1.0.1        # via openstacksdk
 django-celery-beat==1.0.1
 django-cors-headers==2.1.0
-django-cyverse-auth==1.1.4
+django-cyverse-auth==1.1.6
 django-filter==1.0.4
 django-memoize==2.1.0
 django-redis-cache==1.7.1


### PR DESCRIPTION
## Description

Upgrade to django-cyverse-auth 1.1.6

A few other dependencies were changed as well but it was all done with `pip-compile` so I assume it is fine.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.