### PR TITLE
Fix reference to deleted model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v34-0...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix reference to deleted model ProviderDNSServerIP
+    ([#673](https://github.com/cyverse/atmosphere/pull/673))
+
 ## [v34-0](https://github.com/cyverse/atmosphere/compare/v33-0...v34-0) - 2018-09-17
 ### Added
   - Added AccessTokens model, API view, and serializers to enable new feature

--- a/service/accounts/openstack_manager.py
+++ b/service/accounts/openstack_manager.py
@@ -655,12 +655,7 @@ class AccountDriver(BaseAccountDriver):
         return network_strategy
 
     def dns_nameservers_for(self, identity):
-        dns_nameservers = identity.provider.get_config('network', 'dns_nameservers', [])
-        db_dns_nameservers = [
-            dns_server.ip_address for dns_server
-            in identity.provider.dns_server_ips.order_by('order')
-        ]
-        return list(set(db_dns_nameservers + dns_nameservers))
+        return identity.provider.get_config('network', 'dns_nameservers', [])
 
     def delete_user_network(self, identity, options={}):
         """


### PR DESCRIPTION
## Description

### Problem
There was a lingering reference to a deleted model through

### Solution
Remove the reference

The provider's config includes the dnsnameservers. Its use here is a relic.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.