### PR TITLE
Upgrade django-cyverse-auth from 1.1.6 to 1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
   - Fix reference to deleted model ProviderDNSServerIP
     ([#673](https://github.com/cyverse/atmosphere/pull/673))
+  - Upgrade to django-cyverse-auth 1.1.7 from 1.1.6 to avoid error in OAuth
+    ([#674](https://github.com/cyverse/atmosphere/pull/674))
 
 ## [v34-0](https://github.com/cyverse/atmosphere/compare/v33-0...v34-0) - 2018-09-17
 ### Added

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -42,7 +42,7 @@ defusedxml==0.5.0
 deprecation==1.0.1
 django-celery-beat==1.0.1
 django-cors-headers==2.1.0
-django-cyverse-auth==1.1.6
+django-cyverse-auth==1.1.7
 django-debug-toolbar==1.8
 django-filter==1.0.4
 django-jenkins==0.110.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ defusedxml==0.5.0         # via djangorestframework-xml
 deprecation==1.0.1        # via openstacksdk
 django-celery-beat==1.0.1
 django-cors-headers==2.1.0
-django-cyverse-auth==1.1.6
+django-cyverse-auth==1.1.7
 django-filter==1.0.4
 django-memoize==2.1.0
 django-redis-cache==1.7.1


### PR DESCRIPTION
## Description
In django-cyverse-auth 1.1.6, there was usage of an undefined value breaking OAuth

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
