### PR TITLE
Fix unregistered tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v34-3...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix un-registered service tasks
+    ([#683](https://github.com/cyverse/atmosphere/pull/683))
+
 ## [v34-3](https://github.com/cyverse/atmosphere/compare/v34-2...v34-3) - 2018-09-24
 ### Changed
   - Upgrade to rtwo version 0.5.24 to get more defensive pagination logic

--- a/service/tasks/__init__.py
+++ b/service/tasks/__init__.py
@@ -1,0 +1,7 @@
+import service.tasks.accounts # noqa
+import service.tasks.monitoring # noqa
+import service.tasks.driver # noqa
+import service.tasks.volume # noqa
+import service.tasks.machine # noqa
+import service.tasks.snapshot # noqa
+import chromogenic.tasks # noqa


### PR DESCRIPTION
## Description
### Problem
Tasks reported as unregistered

### Solution
Re-include imports in service.tasks.__init__.py

When these imports were removed (reported as unused) celery became unable to
auto-discover the tasks defined there.

It's not clear to me how to properly fix this. Will need to look into a proper fix later.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.