### PR TITLE
Fix exception handling preventing instance destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
   - Fix nginx gateway timeout on unshelve
     ([#686](https://github.com/cyverse/atmosphere/pull/686))
+  - Fix exception handling preventing instance destroy
+    ([#690](https://github.com/cyverse/atmosphere/pull/690))
+
 
 ## [v34-4](https://github.com/cyverse/atmosphere/compare/v34-3...v34-4) - 2018-09-25
 ### Fixed

--- a/service/instance.py
+++ b/service/instance.py
@@ -660,18 +660,10 @@ def _destroy_instance(identity_uuid, instance_alias):
         return (True, None)
     if isinstance(esh_driver, OSDriver):
         try:
-            # Openstack: Remove floating IP first
+            # Make an attempt to remove floating ips if they exist
             esh_driver._connection.ex_disassociate_floating_ip(instance)
-        except Exception as exc:
-            # Ignore 'safe' errors related to
-            # no floating IP
-            # or no Volume capabilities.
-            if not (
-                "floating ip not found" in exc.message
-                or "422 Unprocessable Entity Floating ip" in exc.message
-                or "500 Internal Server Error" in exc.message
-            ):
-                raise
+        except:
+            pass
     node_destroyed = esh_driver._connection.destroy_node(instance)
     return (node_destroyed, instance)
 


### PR DESCRIPTION
## Description

When an instance was missing a floating ip, Nova would report "floating IP not found", we attempted to handle that case, by checking if the string matched "floating ip not found". They don't match so the exception would surface.

Rather than performing frail checks, just try and give up.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.