### PR TITLE
Change ATMO_DAEMON variable to be formatted with DEFAULT_EMAIL_DOMAIN

### DIFF
--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -202,7 +202,7 @@ SERVER_NAME = SERVER_URL.replace('https://','')
 EMAIL_SUBJECT_PREFIX = "[Django - %s] " % (SERVER_NAME,)
 
 # Sends all emails
-ATMO_DAEMON = ("Atmosphere Admin", "<atmo-notify@{}>".format(SERVER_NAME))
+ATMO_DAEMON = ("Atmosphere Admin", "atmo-notify@{}".format(DEFAULT_EMAIL_DOMAIN))
 
 # Prevents warnings
 ADDITIONAL_ALLOWED_HOSTNAMES = {{ ADDITIONAL_ALLOWED_HOSTNAMES }}


### PR DESCRIPTION
## Description

Using SERVER_NAME to format the ATMO_DAEMON variable caused emails to be sent from atmo-notify@atmo.cyverse.org, but they should come from atmo.cyverse.org.

Also removed '<>' from the email string because these are added by Atmosphere before sending the email.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
