### PR TITLE
Add get_short_name() function patching NotImplementedError at /admin/

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -74,7 +74,7 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
         
-    def get_short_name():
+    def get_short_name(self):
         """
         Returns the first initial of first_name and last name, with a space in between.
         """

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -79,10 +79,8 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
         Returns the first initial of first_name and last name, with a space in between.
         """
         short_name = '%s. %s' % (self.first_name[0], self.last_name)
-        return short_name
+        return short_name.strip()
     
-    # END-rip.
-
     @staticmethod
     def users_for_instance(instance_id, is_leader=None):
         """

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -74,6 +74,14 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
+    def get_short_name(self):
+        """
+        Returns the first initial of first_name and last_name, with a space in betweem.
+        """
+        short_name = '%s. %s' % (self.first_name[0], self.last_name)
+        return short_name
+
+
     # END-rip.
 
     @staticmethod

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -77,6 +77,7 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
     def get_short_name(self):
         """
         Returns the first initial of first_name and last_name, with a space in betweem.
+        E.g. J. Smith
         """
         short_name = '%s. %s' % (self.first_name[0], self.last_name)
         return short_name

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -73,14 +73,14 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
         """
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
-        
+
     def get_short_name(self):
         """
         Returns the first initial of first_name and last name, with a space in between.
         """
         short_name = '%s. %s' % (self.first_name[0], self.last_name)
         return short_name.strip()
-    
+
     @staticmethod
     def users_for_instance(instance_id, is_leader=None):
         """

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -73,16 +73,14 @@ class AtmosphereUser(AbstractBaseUser, PermissionsMixin):
         """
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
-
-    def get_short_name(self):
+        
+    def get_short_name():
         """
-        Returns the first initial of first_name and last_name, with a space in betweem.
-        E.g. J. Smith
+        Returns the first initial of first_name and last name, with a space in between.
         """
         short_name = '%s. %s' % (self.first_name[0], self.last_name)
         return short_name
-
-
+    
     # END-rip.
 
     @staticmethod


### PR DESCRIPTION
## Description

When attempting to login into the /admin/ page on localhost, a NotImplementedError was thrown as a subclass of the AbstractBaseUser did not contain the necessary get_short_name() function. This turned out to be a function omitted from user.py and has now been added. 


To reproduce:
1. Go to the admin page
2. Enter login credentials. *Error should appear after you press Log In.*


## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.

