### PR TITLE
Add description to image search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#677](https://github.com/cyverse/atmosphere/pull/677))
   - Add support for CAS 5
     ([#692](https://github.com/cyverse/atmosphere/pull/692))
+  - Add 'description' to image search fields
+    ([#700](https://github.com/cyverse/atmosphere/pull/700))
 
 ### Changed
   - Refactored email to make variables and methods used for sending emails

--- a/api/v2/views/image.py
+++ b/api/v2/views/image.py
@@ -112,8 +112,8 @@ class ImageViewSet(MultipleFieldLookup, AuthOptionalViewSet):
     )
     filter_class = ImageFilter
     search_fields = (
-        'id', 'name', 'versions__change_log', 'tags__name', 'tags__description',
-        'created_by__username',
+        'id', 'description', 'name', 'versions__change_log', 'tags__name',
+        'tags__description', 'created_by__username',
         'versions__machines__instance_source__identifier',
         'versions__machines__instance_source__provider__location'
     )


### PR DESCRIPTION
## Description

Simply add the 'description' field of the Application/Image model to the `search_fields` attribute of the ImageViewSet.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
