### PR TITLE
Filter out system-y metadata keys introduced in Rocky which we aren't currently using and make Glance client confused

### DIFF
--- a/scripts/application_to_provider.py
+++ b/scripts/application_to_provider.py
@@ -458,9 +458,10 @@ def main(
             'application_tags', 'application_uuid', 'application_version',
             'checksum', 'container_format', 'created_at', 'direct_url',
             'disk_format', 'file', 'id', 'instance_uuid', 'is_public',
-            'kernel_id', 'locations', 'min_disk', 'min_ram', 'name', 'owner',
-            'protected', 'ramdisk_id', 'schema', 'self', 'size', 'status',
-            'tags', 'updated_at', 'virtual_size', 'visibility'
+            'kernel_id', 'locations', 'min_disk', 'min_ram', 'name',
+            'os_hash_algo', 'os_hash_value', 'os_hidden', 'owner', 'protected',
+            'ramdisk_id', 'schema', 'self', 'size', 'status', 'tags',
+            'updated_at', 'virtual_size', 'visibility'
         ]
 
         for key in filter_out_keys:


### PR DESCRIPTION
## Description

These specs introduce additional metadata keys:

https://specs.openstack.org/openstack/glance-specs/specs/queens/approved/glance/multihash.html
http://specs.openstack.org/openstack/glance-specs/specs/rocky/approved/glance/operator-image-workflow.html

This makes (at least some versions of) Glance client throw type validation errors [when you try to create an image](https://bugs.launchpad.net/glance/+bug/1812550), or in our case, when you try to set metadata on an existing image:

```
2019-03-16 01:22:13,880 - ERROR - Unable to set 'os_hash_algo' to 'None'. Reason: None is not of type u'string'

Failed validating u'type' in schema[u'additionalProperties']:
    {u'type': u'string'}

On instance['os_hash_algo']:
    None
Traceback (most recent call last):
  File "/opt/dev/atmosphere/scripts/application_sync_providers.py", line 127, in main
    if glance_client_versions else None
  File "/opt/dev/atmosphere/scripts/application_to_provider.py", line 389, in main
    dprov_glance_client.images.update(dprov_glance_image.id, **metadata)
  File "/opt/env/atmo/lib/python2.7/site-packages/glanceclient/v2/images.py", line 264, in update
    raise TypeError(encodeutils.exception_to_unicode(e))
TypeError: Unable to set 'os_hash_algo' to 'None'. Reason: None is not of type u'string'

Failed validating u'type' in schema[u'additionalProperties']:
    {u'type': u'string'}
```

Atmosphere(1) doesn't use these metadata fields for anything so I have added them to the `filter_out_keys` list, and now image syncing works again (at least on Jetstream Cloud).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
