### PR TITLE
Increase default renewal AUs from 168 to 336.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Refactored email to make variables and methods used for sending emails
     easier to understand and use
     ([#665](https://github.com/cyverse/atmosphere/pull/665))
+  - Increased default renewal Allocation Units to 336
+    ([#703](https://github.com/cyverse/atmosphere/pull/703))
 
 ### Removed
   - Removed dead code ([#689](https://github.com/cyverse/atmosphere/pull/689))

--- a/cyverse_allocation/cyverse_rules_engine_setup.py
+++ b/cyverse_allocation/cyverse_rules_engine_setup.py
@@ -4,6 +4,7 @@ from business_rules.variables import BaseVariables, boolean_rule_variable, numer
 
 from core.models.allocation_source import AllocationSource
 from core.models.event_table import EventTable
+from django.conf import settings
 
 
 class CyverseTestRenewalVariables(BaseVariables):
@@ -207,7 +208,7 @@ renewal_strategies = {
     'default':
         {
             'id': 1,
-            'compute_allowed': 336,
+            'compute_allowed': getattr(settings, 'ALLOCATION_SOURCE_COMPUTER_ALLOWED', 336),
             'period_type': 'on_calendar_day',
             'period_param': 1
         },

--- a/cyverse_allocation/cyverse_rules_engine_setup.py
+++ b/cyverse_allocation/cyverse_rules_engine_setup.py
@@ -207,10 +207,14 @@ def _create_actions_for(strategy_name, strategy_config):
 renewal_strategies = {
     'default':
         {
-            'id': 1,
-            'compute_allowed': getattr(settings, 'ALLOCATION_SOURCE_COMPUTER_ALLOWED', 336),
-            'period_type': 'on_calendar_day',
-            'period_param': 1
+            'id':
+                1,
+            'compute_allowed':
+                getattr(settings, 'ALLOCATION_SOURCE_COMPUTER_ALLOWED', 336),
+            'period_type':
+                'on_calendar_day',
+            'period_param':
+                1
         },
     'bi-weekly':
         {

--- a/cyverse_allocation/cyverse_rules_engine_setup.py
+++ b/cyverse_allocation/cyverse_rules_engine_setup.py
@@ -207,7 +207,7 @@ renewal_strategies = {
     'default':
         {
             'id': 1,
-            'compute_allowed': 168,
+            'compute_allowed': 336,
             'period_type': 'on_calendar_day',
             'period_param': 1
         },

--- a/cyverse_allocation/plugins/allocation_source.py
+++ b/cyverse_allocation/plugins/allocation_source.py
@@ -115,7 +115,7 @@ def _ensure_user_allocation_source(user):
 
 def _create_allocation_source(name):
     default_compute_allowed = getattr(
-        settings, 'ALLOCATION_SOURCE_COMPUTE_ALLOWED', 168
+        settings, 'ALLOCATION_SOURCE_COMPUTE_ALLOWED', 336
     )
     payload = {
         'uuid': str(uuid.uuid4()),

--- a/features/allocation.features/alternate_story.feature
+++ b/features/allocation.features/alternate_story.feature
@@ -16,8 +16,8 @@ Feature: Testing an Alternate story
 
     When admin creates allocation source
     |  name     |  compute allowed   |  renewal strategy   |   allocation_source_id | date_created |
-    |  amitj    |  168               |  default            |   1                    | current      |
-    |  julianp  |  168               |  default            |   2                    | current      |
+    |  amitj    |  336               |  default            |   1                    | current      |
+    |  julianp  |  336               |  default            |   2                    | current      |
 
     And Users are added to allocation source
     |  username    | allocation_source_id    |
@@ -49,8 +49,8 @@ Feature: Testing an Alternate story
 
     Then calculate allocations used by allocation source after certain number of days
     |  report start date                  | number of days   | total compute used   | current compute used | current compute allowed | allocation_source_id |
-    |      current                        |  1               |     24               | 24                   | 168                     | 1                    |
-    |      current                        |  1               |     24               | 24                   | 168                     | 2                    |
+    |      current                        |  1               |     24               | 24                   | 336                     | 1                    |
+    |      current                        |  1               |     24               | 24                   | 336                     | 2                    |
 
     And Compute Allowed is increased for Allocation Source
     | allocation_source_id | new_compute_allowed |
@@ -60,4 +60,4 @@ Feature: Testing an Alternate story
     And One off Renewal task is run without rules engine
     | current compute used | current compute allowed | allocation_source_id |
     | 0                    | 400                     | 1                    |
-    | 0                    | 168                     | 2                    |
+    | 0                    | 336                     | 2                    |

--- a/run_tests_like_travis_docker.sh
+++ b/run_tests_like_travis_docker.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+
+# BEWARE! This script:
+# - Drops two databases
+# - Deletes a user
+# - Overwrites your variables.ini, local.py, secrets.py, etc.
+# - Forcibly updates packages in your virtual environment
+#
+# Read it.
+
+# Usage:
+# 0. Start a bash session in your atmosphere docker container
+#    (docker exec -it <container_name> /bin/bash)
+# 1. ./run_tests_like_travis.sh [cyverse|jetstream]
+
+set -e
+set -x
+
+# Install pre-dependencies
+apt-get update && apt-get install -y postgresql
+
+DISTRIBUTION=${1:-cyverse}
+VENV_PATH=/opt/env/atmo-test
+ATMO_PATH=/opt/dev/atmosphere
+SUDO_POSTGRES=''  # Leave empty if sudo not required to run dropdb, createdb & psql
+PIP_TOOLS_VERSION=1.9.0
+
+cd $ATMO_PATH
+if [ ! -d "$VENV_PATH" ]; then
+    virtualenv "$VENV_PATH";
+fi
+source $VENV_PATH/bin/activate
+
+# pip install -U pip setuptools pip-tools=="$PIP_TOOLS_VERSION"
+# pip-sync dev_requirements.txt
+pip install -r dev_requirements.txt
+echo "DROP DATABASE IF EXISTS atmosphere_db" | ./manage.py dbshell
+echo "DROP DATABASE IF EXISTS test_atmosphere_db" | ./manage.py dbshell
+echo "DROP USER IF EXISTS atmosphere_db_user" | ./manage.py dbshell
+echo "CREATE USER atmosphere_db_user WITH PASSWORD 'atmosphere_db_pass' CREATEDB;" | ./manage.py dbshell
+echo "CREATE DATABASE atmosphere_db WITH OWNER atmosphere_db_user;" | ./manage.py dbshell
+
+
+mv ./variables.ini ./variables.ini.bak
+cp ./variables.ini.dist ./variables.ini
+patch variables.ini variables_for_testing_${DISTRIBUTION}_docker.ini.patch
+./configure
+# ./travis/check_properly_generated_requirements.sh
+
+# python manage.py test --keepdb
+rm -f rerun_failing.features
+python manage.py behave --keepdb --tags ~@skip-if-${DISTRIBUTION}
+mv ./variables.ini.bak ./variables.ini

--- a/variables_for_testing_cyverse_docker.ini.patch
+++ b/variables_for_testing_cyverse_docker.ini.patch
@@ -1,0 +1,23 @@
+--- variables.ini.dist	2019-05-31 21:38:20.029217819 +0000
++++ variables.ini	2019-05-31 21:45:15.413243671 +0000
+@@ -40,7 +40,7 @@
+ DATABASE_ENGINE = django.db.backends.postgresql_psycopg2 # postgres only (for now)
+ DATABASE_USER = atmosphere_db_user # psql_user
+ DATABASE_PASSWORD = atmosphere_db_pass # psql_password
+-DATABASE_HOST = localhost # remote.postgres-server.com
++DATABASE_HOST = postgres # remote.postgres-server.com
+ DATABASE_PORT = 5432
+ DATABASE_CONN_MAX_AGE = 60 # in seconds
+ DEBUG =  True # Boolean required
+@@ -58,7 +58,10 @@
+ LOGSTASH_PORT = # 8000
+ METRIC_SERVER = # atmosphere-metrics.server.com
+ SELF_SIGNED_CERT =  False # Boolean required
+-TESTING =  False # Boolean required
++TESTING =  True # Boolean required
++TEST_RUNNER_USER = # Nothing
++TEST_RUNNER_PASS = # Nothing
++DJANGO_JENKINS = False
+ #local.py - site configuration
+ AUTO_CREATE_NEW_ACCOUNTS =  False # Boolean required
+ AUTO_CREATE_NEW_PROJECTS =  False # Boolean required

--- a/variables_for_testing_jetstream_docker.ini.patch
+++ b/variables_for_testing_jetstream_docker.ini.patch
@@ -1,0 +1,29 @@
+--- variables.ini.dist	2019-05-31 20:42:48.909010495 +0000
++++ variables.ini	2019-05-31 21:30:15.025187633 +0000
+@@ -40,7 +40,7 @@
+ DATABASE_ENGINE = django.db.backends.postgresql_psycopg2 # postgres only (for now)
+ DATABASE_USER = atmosphere_db_user # psql_user
+ DATABASE_PASSWORD = atmosphere_db_pass # psql_password
+-DATABASE_HOST = localhost # remote.postgres-server.com
++DATABASE_HOST = postgres # remote.postgres-server.com
+ DATABASE_PORT = 5432
+ DATABASE_CONN_MAX_AGE = 60 # in seconds
+ DEBUG =  True # Boolean required
+@@ -58,12 +58,15 @@
+ LOGSTASH_PORT = # 8000
+ METRIC_SERVER = # atmosphere-metrics.server.com
+ SELF_SIGNED_CERT =  False # Boolean required
+-TESTING =  False # Boolean required
++TESTING =  True # Boolean required
++TEST_RUNNER_USER = # Nothing
++TEST_RUNNER_PASS = # Nothing
++DJANGO_JENKINS = False
+ #local.py - site configuration
+ AUTO_CREATE_NEW_ACCOUNTS =  False # Boolean required
+ AUTO_CREATE_NEW_PROJECTS =  False # Boolean required
+ ALLOCATION_SOURCE_COMPUTE_ALLOWED =  168 # Boolean required
+-USE_JETSTREAM_PLUGIN =  False # Boolean required
++USE_JETSTREAM_PLUGIN =  True # Boolean required
+ TIME_ZONE = # America/Phoenix
+ SITE_NAME = # CyVerse
+ ORG_NAME = # CyVerse


### PR DESCRIPTION
## Description

Increased the default renewal Allocation Units from 168 to 336.

## Checklist before merging Pull Requests
- [x] ~New~ Modified test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.
- [ ] ~New variables supported in Clank~