### PR TITLE
Include atmosphere-ansible in Dockerfile build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#700](https://github.com/cyverse/atmosphere/pull/700))
   - Added Dockerfile and related files to enable automated Dockerhub build/test
     ([#702](https://github.com/cyverse/atmosphere/pull/702))
+  - Added atmosphere-ansible to Dockerfile
+    ([#706](https://github.com/cyverse/atmosphere/pull/706))
 
 ### Changed
   - Refactored email to make variables and methods used for sending emails

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir /opt/env && \
     pip install --upgrade pip==9.0.3 virtualenv &&\
     virtualenv /opt/env/atmosphere &&\
     ln -s /opt/env/atmosphere/ /opt/env/atmo
+RUN git clone --depth 1 https://github.com/cyverse/atmosphere-ansible.git /opt/dev/atmosphere-ansible
 
 COPY . /opt/dev/atmosphere
 WORKDIR /opt/dev/atmosphere


### PR DESCRIPTION
## Description

Since production deployments of Atmosphere Docker will not mount local code volumes, atmosphere-ansible needs to be built-in to the image. This adds a line to shallow clone the repository. Note this is built off of #704 and includes those commits

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.