### PR TITLE
Fix python-ldap and install sendmail in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v36-0...HEAD) - YYYY-MM-DD
+### Changed
+  - Downgrade python-ldap and install/start sendmail in Docker
+    ([#709](https://github.com/cyverse/atmosphere/pull/709))
 
 
-## [Unreleased](https://github.com/cyverse/atmosphere/compare/v34-4...v36-0) - 2019-06-18
+## [v36-0](https://github.com/cyverse/atmosphere/compare/v34-4...v36-0) - 2019-06-18
 ### Added
   - Format codebase with `yapf` require code to be formatted in travis build
     ([#677](https://github.com/cyverse/atmosphere/pull/677))

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
       python-setuptools \
       python-tk \
       redis-server \
+      sendmail \
       ssh \
       sudo \
       swig \

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -158,7 +158,7 @@ python-glanceclient==2.5.0
 python-heatclient==1.11.0
 python-irodsclient==0.6.0
 python-keystoneclient==3.6.0
-python-ldap==3.1.0
+python-ldap==3.0.0
 python-logstash==0.4.6
 python-neutronclient==6.0.0
 python-novaclient==6.0.0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,6 +69,7 @@ sed -i "s/^bind 127.0.0.1 ::1$/bind 127.0.0.1/" /etc/redis/redis.conf
 service redis-server start
 service celerybeat start
 service celeryd start
+service sendmail start
 
 # Wait for DB to be active
 echo "Waiting for postgres..."

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ python-glanceclient==2.5.0  # via python-openstackclient, rtwo
 python-heatclient==1.11.0  # via rtwo
 python-irodsclient==0.6.0  # via rtwo
 python-keystoneclient==3.6.0  # via django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
-python-ldap==3.1.0
+python-ldap==3.0.0
 python-logstash==0.4.6
 python-neutronclient==6.0.0  # via rtwo
 python-novaclient==6.0.0  # via python-openstackclient, rtwo


### PR DESCRIPTION
## Description

When testing the new deploy of v36-0, email was failing to send since sendmail was not installed.

Additionally, after imaging requests would complete, an error would occur from python-ldap. [This issue](https://github.com/python-ldap/python-ldap/issues/226) revealed it was a bug in version 3.1.0.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.