### PR TITLE
JETSTREAM-240: Don't allow users to create Instances in Projects they do not own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v36-1...HEAD) - YYYY-MM-DD
+### Fixed
+  - Don't allow users to create Instances in Projects they do not own
+    ([#712](https://github.com/cyverse/atmosphere/pull/712))
 
 
 ## [v36-1](https://github.com/cyverse/atmosphere/compare/v36-0...v36-1) - 2019-06-19


### PR DESCRIPTION
## Description

Jetstream users noticed that, when using atmosphere-cli, they were able to specify a project UUID when launching an instance that did not belong to the user launching the instance. This PR fixes this by adding `created_by_id=user.id` when querying for the project. This will raise a `DoesNotExist` exception in the case that a project with specified UUID **and** creator ID does not exist. I was able to test this locally using a project ID owned by a different user to get this output:
```
ERROR: {u'errors': [{u'message': u'Project matching query does not exist.', u'code': 409}]}
Error, instance not created! Make sure to supply name, identity, project, size, source (or image), and allocation_source.
```

~Projects are owned by a Group and created by a AtmosphereUser. I chose to check the `created_by_id` attribute since there was already an existing AtmosphereUser object in the method. However, if a user creates a project for a different user, then this could cause conflict. This is an unlikely (or maybe impossible?) case.~

I was able to confirm that a user cannot create a project for a different user:
```
$ atmo project create --description "WOW" --owner julianp "TEST"
ERROR: [u'calvinmclean is not a member of group julianp']
Error, project not created! Make sure to supply a name, description, and owner (group name).
```
However, this output leads me to believe that if UserA and UserB are in the same group, then UserA could probably create a project for UserB, but UserB would not be able to create an instance in that project. I will look into changing this to check based on group, but this will require additional testing.

---

I was able to fix this case by querying the Project based on GroupMembership. I added a comment to explain the code used to do this since it looks complicated at first glance. Basically, I get all GroupMemberships for the User in question, then use `map` to create a list of `GroupMembership.group_id`. Then I can query Projects with `owner_id__in` to see if the Project's `owner_id` is in this list of User's `group_id`.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
