### PR TITLE
Fix bug in 'machine_request.get_access_list()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 
-## [v36-2](https://github.com/cyverse/atmosphere/compare/v36-1...HEAD) - 2019-08-06
+## [Unreleased](https://github.com/cyverse/atmosphere/compare/v36-2...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix uncommon bug with `machine_request.get_access_list()`
+    ([#713](https://github.com/cyverse/atmosphere/pull/713))
+
+
+## [v36-2](https://github.com/cyverse/atmosphere/compare/v36-1...v36-2) - 2019-08-06
 ### Security
   - Update dependencies
     ([#711](https://github.com/cyverse/atmosphere/pull/711))
@@ -34,7 +40,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Security
   - Update jwt.py dependency from django-cyverse-auth
     ([#714](https://github.com/cyverse/atmosphere/pull/714))
-
 
 ## [v36-1](https://github.com/cyverse/atmosphere/compare/v36-0...v36-1) - 2019-06-19
 ### Changed

--- a/core/models/machine_request.py
+++ b/core/models/machine_request.py
@@ -249,7 +249,7 @@ class MachineRequest(BaseRequest):
             # New Format = "[u'test1', u'test2', u'test3']"
         else:
             json_loads_list = self.access_list
-        json_loads_list = json_loads_list.replace("'", '"').replace('u"', '"')
+        json_loads_list = json_loads_list.replace('u"', '"').replace("'", '"')
         user_list = json.loads(json_loads_list)
         return user_list
 


### PR DESCRIPTION
## Description

Jetstream encountered an error when a user with username ending in 'u' tried to create a private image. The `get_access_list()` method replaces `u"` of unicode strings which also replaced the 'u' at the end of the username. This is a simple fix that just replaces `u"` before swapping all `'` with `"`

## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
