### PR TITLE
Update jwt.py dependency from django-cyverse-auth

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -89,7 +89,7 @@ json-delta==2.0
 jsonpatch==1.16
 jsonpointer==1.10
 jsonschema==2.6.0
-jwt.py==0.1.0
+jwt.py==0.1.1
 keystoneauth1==3.1.0
 kombu==4.1.0
 lazy-object-proxy==1.3.1  # via astroid
@@ -136,7 +136,7 @@ pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pycodestyle==2.0.0        # via flake8, prospector
 pycparser==2.18
-pycrypto==2.6.1
+pycryptodome==3.8.2
 pydocstyle==2.0.0         # via prospector
 pyflakes==1.5.0           # via flake8, prospector
 pygments==2.2.0           # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ jinja2==2.10.1
 jsonpatch==1.16           # via openstacksdk, warlock
 jsonpointer==1.10         # via jsonpatch
 jsonschema==2.6.0         # via warlock
-jwt.py==0.1.0             # via django-cyverse-auth
+jwt.py==0.1.1             # via django-cyverse-auth
 keystoneauth1==3.1.0      # via django-cyverse-auth, openstacksdk, os-client-config, osc-lib, python-cinderclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
 kombu==4.1.0              # via celery
 markupsafe==1.0           # via jinja2
@@ -93,7 +93,7 @@ psycopg2==2.7.3.1
 pyasn1-modules==0.2.4     # via oauth2client, python-ldap
 pyasn1==0.4.5             # via oauth2client, pyasn1-modules, python-ldap, rsa
 pycparser==2.18           # via cffi
-pycrypto==2.6.1           # via jwt.py
+pycryptodome==3.8.2       # via jwt.py
 pyinotify==0.9.6          # via oslo.log
 pyjwt==1.5.2
 pynacl==1.1.2             # via paramiko


### PR DESCRIPTION
## Description

This completes the dependency upgrades for Atmosphere. After creating a new version of `jwt.py` on PyPI, I had to run `pip-compile -P jwt.py requirements.in` in order to get the latest version of `jwt.py` since it is from `django-cyverse-auth` requirements with unspecified version. Without this command, `pip-compile` would avoid changing to the latest version since it was not explicitly required.