### PR TITLE
WIP: Use separate container for Celery and Redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && \
       python-psycopg2 \
       python-setuptools \
       python-tk \
-      redis-server \
       sendmail \
       ssh \
       sudo \

--- a/atmosphere/settings/local.py.j2
+++ b/atmosphere/settings/local.py.j2
@@ -8,9 +8,9 @@ from datetime import timedelta
 from celery.schedules import crontab
 
 from atmosphere.settings import (
-    secrets, TEMPLATES,
-    CELERYBEAT_SCHEDULE, REDIRECT_URL,
-    REST_FRAMEWORK, INSTALLED_APPS
+    secrets, TEMPLATES, CELERY_BROKER_URL,
+    CELERY_RESULT_BACKEND, CELERYBEAT_SCHEDULE,
+    REDIRECT_URL, REST_FRAMEWORK, INSTALLED_APPS
 )
 
 # This is used by dependencies (ex: chromogenic)
@@ -111,6 +111,11 @@ AUTO_CREATE_NEW_PROJECTS = True
 {%- else %}
 AUTO_CREATE_NEW_PROJECTS = False
 {%- endif %}
+
+REDIS_HOST = '{{REDIS_HOST}}'
+CELERY_BROKER_URL = 'redis://{{REDIS_HOST}}:6379/0'
+CELERY_RESULT_BACKEND = 'redis://{{REDIS_HOST}}:6379/0'
+
 {%- if CELERYBEAT_SCHEDULE %}
 #CELERYBEAT_SCHEDULE OVERRIDES:
   {%- for task_key, schedule in CELERYBEAT_SCHEDULE.items() %}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,6 +4,9 @@ version: '3'
 
 services:
 
+  redis:
+    image: 'redis:latest'
+
   postgres:
     image: 'postgres:9.6'
     environment:
@@ -15,3 +18,4 @@ services:
     entrypoint: '/root/test.sh'
     depends_on:
       - 'postgres'
+      - 'redis'

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,10 +65,6 @@ else
 fi
 
 # Start services
-sed -i "s/^bind 127.0.0.1 ::1$/bind 127.0.0.1/" /etc/redis/redis.conf
-service redis-server start
-service celerybeat start
-service celeryd start
 service sendmail start
 
 # Wait for DB to be active

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -11,8 +11,6 @@ source /opt/env/atmosphere/bin/activate
 apt-get update && apt-get install -y postgresql
 pip install -U pip==9.0.3 setuptools
 pip install pip-tools==1.11.0
-sed -i "s/^bind 127.0.0.1 ::1$/bind 127.0.0.1/" /etc/redis/redis.conf
-service redis-server start
 
 # Wait for DB to be active
 echo "Waiting for postgres..."

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -27,6 +27,7 @@ function run_tests_for_distribution() {
   pip uninstall -y backports.ssl-match-hostname
   pip-sync requirements.txt
   sed -i 's/DATABASE_HOST = localhost/DATABASE_HOST = postgres/' variables.ini.dist
+  sed -i 's/REDIS_HOST = localhost/REDIS_HOST = redis/' variables.ini.dist
   cp ./variables.ini.dist ./variables.ini
   ./configure
   python manage.py check

--- a/service/cache.py
+++ b/service/cache.py
@@ -1,6 +1,7 @@
 import cPickle as pickle
 import redis
 from threepio import logger
+from django.conf import settings
 
 from service.driver import get_esh_driver, get_admin_driver
 
@@ -33,7 +34,7 @@ def _get_cached_driver(provider=None, identity=None, force=True):
 def redis_connection():
     global connection
     if not connection:
-        connection = redis.StrictRedis()
+        connection = redis.StrictRedis(host=settings.REDIS_HOST)
     return connection
 
 

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -92,6 +92,8 @@ ALLOCATION_OVERRIDES_ALWAYS_ENFORCE = []
 BLACKLIST_METADATA_KEY = # default: 'atmo_image_exclude'
 WHITELIST_METADATA_KEY = # default: 'atmo_image_include'
 
+REDIS_HOST = localhost
+
 SENTRY_ENABLED =  True # Boolean required or False
 SENTRY_DSN = # https://...@sentry.io/....
 


### PR DESCRIPTION
## Description

Atmosphere Docker would benefit a lot from having a separate container for celery because it would allow the Atmosphere container to be replaced without losing celery tasks in progress.

This PR stops the Atmosphere container from starting celery and redis. It also adds variables to support an external redis host.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
