### PR TITLE
Multi instance launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v36-6...HEAD) - YYYY-MM-DD
+### Added
+  - Add support for multi-instance-launch, 1 request can launch multiple instances by passing `instance_count` as an extra parameter
+    ([#736](https://github.com/cyverse/atmosphere/pull/736))
 
 ## [v36-6](https://github.com/cyverse/atmosphere/compare/v36-5...v36-6) - 2019-10-22
 ### Changed

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -445,10 +445,7 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
                 partial=True
             )
             if not serialized_instance.is_valid():
-                return Response(
-                    serialized_instance.errors,
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+                logger.error("multi-instance-launch, serialized instance is invalid, {}".format(serialized_instance))
             instance = serialized_instance.save()
             instance.project = project
             instance.save()

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -355,9 +355,9 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
 
             if 'instance_count' in extra:
                 return self._multi_create(
-                    user, identity_uuid, size_alias, source_alias, name,
-                    deploy, allocation_source, project, boot_scripts, extra
-                    )
+                    user, identity_uuid, size_alias, source_alias, name, deploy,
+                    allocation_source, project, boot_scripts, extra
+                )
 
             core_instance = launch_instance(
                 user,
@@ -415,7 +415,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             )
             return failure_response(status.HTTP_409_CONFLICT, str(exc.message))
 
-    def _multi_create(self, user, identity_uuid, size_alias, source_alias, name, deploy, allocation_source, project, boot_scripts, extra):
+    def _multi_create(
+        self, user, identity_uuid, size_alias, source_alias, name, deploy,
+        allocation_source, project, boot_scripts, extra
+    ):
         """
         1. Launch multiple instances
         2. Serialize the launched instances
@@ -445,7 +448,10 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
                 partial=True
             )
             if not serialized_instance.is_valid():
-                logger.error("multi-instance-launch, serialized instance is invalid, {}".format(serialized_instance))
+                logger.error(
+                    "multi-instance-launch, serialized instance is invalid, {}".
+                    format(serialized_instance)
+                )
             instance = serialized_instance.save()
             instance.project = project
             instance.save()
@@ -457,6 +463,4 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             serialized_data.append(serialized_instance.data)
 
         # return a list of instances in the response
-        return Response(
-            serialized_data, status=status.HTTP_201_CREATED
-        )
+        return Response(serialized_data, status=status.HTTP_201_CREATED)

--- a/api/v2/views/instance.py
+++ b/api/v2/views/instance.py
@@ -419,7 +419,7 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
         """
         1. Launch multiple instances
         2. Serialize the launched instances
-        3. FIXME
+        3. Return a list of serialized instances
         """
 
         core_instances = launch_instance(
@@ -432,6 +432,8 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             allocation_source=allocation_source,
             **extra
         )
+
+        serialized_data = []
 
         # Serialize all instances launched
         for core_instance in core_instances:
@@ -453,7 +455,11 @@ class InstanceViewSet(MultipleFieldLookup, AuthModelViewSet):
             if boot_scripts:
                 _save_scripts_to_instance(instance, boot_scripts)
             instance.change_allocation_source(allocation_source)
-        # FIXME currently return last instance launched
+
+            # append to result
+            serialized_data.append(serialized_instance.data)
+
+        # return a list of instances in the response
         return Response(
-            serialized_instance.data, status=status.HTTP_201_CREATED
+            serialized_data, status=status.HTTP_201_CREATED
         )

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -211,3 +211,6 @@ class NonZeroDeploymentException(Exception):
 
 class TimeoutError(Exception):
     pass
+
+class BadInstanceCount(ServiceException):
+    pass

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -212,5 +212,6 @@ class NonZeroDeploymentException(Exception):
 class TimeoutError(Exception):
     pass
 
+
 class BadInstanceCount(ServiceException):
     pass

--- a/service/instance.py
+++ b/service/instance.py
@@ -720,6 +720,11 @@ def _pre_launch_validation(
     # May raise UnderThresholdError
     check_application_threshold(username, identity_uuid, size, boot_source)
 
+    # Raise Validation Error if bad instance_count
+    # FIXME use a more specific Exception type
+    if not isinstance(instance_count, int) or instance_count < 1:
+        raise ValidationError("Bad instance count: {}".format(instance_count))
+
     if boot_source.is_machine():
         machine = _retrieve_source(
             esh_driver, boot_source.identifier, "machine"

--- a/service/instance.py
+++ b/service/instance.py
@@ -1540,7 +1540,8 @@ def _get_default_rules():
         }, {
             "direction": "ingress",
             "ethertype": "IPv6",
-        }, {
+        },
+        {
             "direction": "ingress",
             "port_range_min": 22,
             "port_range_max": 22,

--- a/service/instance.py
+++ b/service/instance.py
@@ -53,8 +53,7 @@ from service.exceptions import (
     OverAllocationError, AllocationBlacklistedError, OverQuotaError,
     SizeNotAvailable, SecurityGroupNotCreated, VolumeAttachConflict,
     VolumeDetachConflict, UnderThresholdError, ActionNotAllowed,
-    InstanceDoesNotExist, InstanceLaunchConflict, Unauthorized,
-    BadInstanceCount
+    InstanceDoesNotExist, InstanceLaunchConflict, Unauthorized, BadInstanceCount
 )
 
 from service.accounts.openstack_manager import AccountDriver as OSAccountDriver
@@ -705,7 +704,13 @@ def update_status(esh_driver, instance_id, provider_uuid, identity_uuid, user):
 
 
 def _pre_launch_validation(
-    username, esh_driver, identity_uuid, boot_source, size, allocation_source, instance_count=1
+    username,
+    esh_driver,
+    identity_uuid,
+    boot_source,
+    size,
+    allocation_source,
+    instance_count=1
 ):
     """
     Used BEFORE launching a volume/instance .. Raise exceptions here to be dealt with by the caller.
@@ -717,7 +722,13 @@ def _pre_launch_validation(
     identity = CoreIdentity.objects.get(uuid=identity_uuid)
 
     # May raise OverQuotaError
-    check_quota(username, identity_uuid, size, include_networking=True, instance_count=instance_count)
+    check_quota(
+        username,
+        identity_uuid,
+        size,
+        include_networking=True,
+        instance_count=instance_count
+    )
 
     # May raise OverAllocationError, AllocationBlacklistedError
     check_allocation(username, allocation_source)
@@ -785,38 +796,44 @@ def launch_instance(
         return _launch_multiple_instances(
             user, esh_driver, identity_uuid, boot_source, size, name, deploy,
             instance_count, launch_kwargs
-            )
+        )
     else:
         return _launch_one_instance(
             user, esh_driver, identity_uuid, boot_source, size, name, deploy,
             launch_kwargs
-            )
+        )
+
 
 def _launch_multiple_instances(
     user, esh_driver, identity_uuid, boot_source, size, name, deploy,
     instance_count, launch_kwargs
-    ):
+):
     """
     Launching multiple instances, all from the same machine,
     can NOT boot from volume
     """
     # Raise any other exceptions before launching here
     _pre_launch_validation(
-        user.username, esh_driver, identity_uuid, boot_source, size,
-        launch_kwargs.get('allocation_source'), instance_count=instance_count
+        user.username,
+        esh_driver,
+        identity_uuid,
+        boot_source,
+        size,
+        launch_kwargs.get('allocation_source'),
+        instance_count=instance_count
     )
 
     # checking boot source
     if boot_source.is_volume():
-        raise Exception("Multi instance launch does not support volume as boot source")
+        raise Exception(
+            "Multi instance launch does not support volume as boot source"
+        )
     elif not boot_source.is_machine():
         raise Exception("Boot source is of an unknown type")
 
     identity = CoreIdentity.objects.get(uuid=identity_uuid)
 
-    machine = _retrieve_source(
-        esh_driver, boot_source.identifier, "machine"
-    )
+    machine = _retrieve_source(esh_driver, boot_source.identifier, "machine")
     core_instances = launch_multiple_machine_instances(
         esh_driver,
         user,
@@ -830,10 +847,11 @@ def _launch_multiple_instances(
     )
     return core_instances
 
+
 def _launch_one_instance(
-    user, esh_driver, identity_uuid, boot_source, size, name,
-    deploy, launch_kwargs
-    ):
+    user, esh_driver, identity_uuid, boot_source, size, name, deploy,
+    launch_kwargs
+):
     """
     Launching just a single instance
     """
@@ -855,6 +873,7 @@ def _launch_one_instance(
     )
 
     return core_instance
+
 
 # NOTE: Harmonizing these four methods below would be nice..
 """
@@ -975,8 +994,17 @@ def launch_machine_instance(
         driver, identity, instance, user, token, password, deploy=deploy
     )
 
+
 def launch_multiple_machine_instances(
-    driver, user, identity, machine, size, name, deploy=True, instance_count=1, **kwargs
+    driver,
+    user,
+    identity,
+    machine,
+    size,
+    name,
+    deploy=True,
+    instance_count=1,
+    **kwargs
 ):
     """
     Launch multiple instances off an existing machine
@@ -988,7 +1016,9 @@ def launch_multiple_machine_instances(
 
     core_instances = []
 
-    logger.debug("multi-instance-launch, launching {} instances".format(instance_count))
+    logger.debug(
+        "multi-instance-launch, launching {} instances".format(instance_count)
+    )
     # launch specified number of instances
     for i in range(instance_count):
         instance, token, password = _launch_machine(
@@ -1407,7 +1437,13 @@ def check_allocation(username, allocation_source):
         )
 
 
-def check_quota(username, identity_uuid, esh_size, include_networking=False, instance_count=1):
+def check_quota(
+    username,
+    identity_uuid,
+    esh_size,
+    include_networking=False,
+    instance_count=1
+):
     from service.quota import check_over_instance_quota
     try:
         check_over_instance_quota(
@@ -1504,8 +1540,7 @@ def _get_default_rules():
         }, {
             "direction": "ingress",
             "ethertype": "IPv6",
-        },
-        {
+        }, {
             "direction": "ingress",
             "port_range_min": 22,
             "port_range_max": 22,

--- a/service/instance.py
+++ b/service/instance.py
@@ -53,7 +53,8 @@ from service.exceptions import (
     OverAllocationError, AllocationBlacklistedError, OverQuotaError,
     SizeNotAvailable, SecurityGroupNotCreated, VolumeAttachConflict,
     VolumeDetachConflict, UnderThresholdError, ActionNotAllowed,
-    InstanceDoesNotExist, InstanceLaunchConflict, Unauthorized
+    InstanceDoesNotExist, InstanceLaunchConflict, Unauthorized,
+    BadInstanceCount
 )
 
 from service.accounts.openstack_manager import AccountDriver as OSAccountDriver
@@ -709,10 +710,9 @@ def _pre_launch_validation(
     """
     Used BEFORE launching a volume/instance .. Raise exceptions here to be dealt with by the caller.
     """
-    # Raise Validation Error if bad instance_count
-    # FIXME use a more specific Exception type
+    # Raise BadInstanceCount Error if not int or non-positive
     if not isinstance(instance_count, int) or instance_count < 1:
-        raise ValidationError("Bad instance count: {}".format(instance_count))
+        raise BadInstanceCount("Bad instance count: %s" % instance_count)
 
     identity = CoreIdentity.objects.get(uuid=identity_uuid)
 

--- a/service/instance.py
+++ b/service/instance.py
@@ -742,6 +742,7 @@ def launch_instance(
     Initialization point --> launch_*_instance --> ..
     Required arguments will launch the instance, extras will do
     provider-specific modifications.
+    pass in number of instance to launch_kwargs['instance_count'].
 
     1. Test for available Size (on specific driver!)
     2. Test user has Quota/Allocation (on our DB)

--- a/service/instance.py
+++ b/service/instance.py
@@ -899,12 +899,22 @@ def launch_machine_instance(
         driver, user, identity, size, name, **kwargs
     )
     kwargs.update(prep_kwargs)
-    instance, token, password = _launch_machine(
-        driver, identity, machine, size, name, userdata, network, **kwargs
-    )
-    return _complete_launch_instance(
-        driver, identity, instance, user, token, password, deploy=deploy
-    )
+
+    core_instances = []
+
+    # launch specified number of instances
+    for i in range(kwargs.get('instance_count')):
+        instance, token, password = _launch_machine(
+            driver, identity, machine, size, name, userdata, network, **kwargs
+        )
+        core_instance = _complete_launch_instance(
+            driver, identity, instance, user, token, password, deploy=deploy
+        )
+        core_instances.append(core_instance)
+
+    # currently only return the 1st instance
+    # FIXME should return all
+    return core_instances[0]
 
 
 def _boot_volume(

--- a/service/instance.py
+++ b/service/instance.py
@@ -709,6 +709,11 @@ def _pre_launch_validation(
     """
     Used BEFORE launching a volume/instance .. Raise exceptions here to be dealt with by the caller.
     """
+    # Raise Validation Error if bad instance_count
+    # FIXME use a more specific Exception type
+    if not isinstance(instance_count, int) or instance_count < 1:
+        raise ValidationError("Bad instance count: {}".format(instance_count))
+
     identity = CoreIdentity.objects.get(uuid=identity_uuid)
 
     # May raise OverQuotaError
@@ -719,11 +724,6 @@ def _pre_launch_validation(
 
     # May raise UnderThresholdError
     check_application_threshold(username, identity_uuid, size, boot_source)
-
-    # Raise Validation Error if bad instance_count
-    # FIXME use a more specific Exception type
-    if not isinstance(instance_count, int) or instance_count < 1:
-        raise ValidationError("Bad instance count: {}".format(instance_count))
 
     if boot_source.is_machine():
         machine = _retrieve_source(

--- a/service/quota.py
+++ b/service/quota.py
@@ -17,13 +17,15 @@ def check_over_instance_quota(
     identity_uuid,
     esh_size=None,
     include_networking=False,
-    raise_exc=True
+    raise_exc=True,
+    instance_count=1
 ):
     """
     Checks quota based on current limits (and an instance of size, if passed).
     param - esh_size - if included, update the CPU and Memory totals & increase instance_count
     param - launch_networking - if True, increase floating_ip_count
     param - raise_exc - if True, raise ValidationError, otherwise return False
+    param - instance_count - number of instance to be launched with the same size, default to 1
 
     return True if passing
     return False if ValidationError occurs and raise_exc=False
@@ -42,12 +44,12 @@ def check_over_instance_quota(
     driver = get_cached_driver(identity=identity)
     new_port = new_floating_ip = new_instance = new_cpu = new_ram = 0
     if esh_size:
-        new_cpu += esh_size.cpu
-        new_ram += esh_size.ram
-        new_instance += 1
-        new_port += 1
+        new_cpu += esh_size.cpu * instance_count
+        new_ram += esh_size.ram * instance_count
+        new_instance += instance_count
+        new_port += instance_count
     if include_networking:
-        new_floating_ip += 1
+        new_floating_ip += instance_count
     # Will throw ValidationError if false.
     try:
         has_cpu_quota(driver, quota, new_cpu)


### PR DESCRIPTION
## Description

Enable launching multiple instances with a single request.
Multi-instance launch request is just the normal launch request with an extra parameter.
e.g.
```
{
"extra": {"instance_count": 2}
}
```

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
