### PR TITLE
Use 'atmosphere' as host for uwsgi listener

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -4,7 +4,7 @@ chdir = /opt/dev/atmosphere
 home = /opt/env/atmosphere
 module = atmosphere.wsgi
 env = DJANGO_SETTINGS_MODULE=atmosphere.settings
-socket = 0.0.0.0:8000
+socket = atmosphere:8000
 processes = 24
 uid = www-data
 gid = www-data


### PR DESCRIPTION
This will allow us to use 'extra_hosts' in docker-compose to map the `atmosphere` hostname to any IP we want (which will be 127.0.0.1)

<!--
## Description

Please describe your pull request. If you're solving a problem, include a oneline problem and oneline solution statement. Otherwise, just begin with a single line summary.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
-->
