### PR TITLE
Remove atmosphere-ansible from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,29 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 
-## [Unreleased](https://github.com/cyverse/atmosphere/compare/v37-0...HEAD) - YYYY-MM-DD
+## [Unreleased](https://github.com/cyverse/atmosphere/compare/v37-1...HEAD) - YYYY-MM-DD
+## [<exact release including patch>](<github compare url>) - <release date in YYYY-MM-DD>
+### Added
+  - <summary of new features>
+
+### Changed
+  - moved apt-get remove with other apt commands in Dockerfile
+
+### Deprecated
+  - <for soon-to-be removed features>
+
+### Removed
+  - removed atmosphere-ansible from Dockerfile
+
+### Fixed
+  - <for any bug fixes>
+
+### Security
+  - <in case of vulnerabilities>
 
 
 
-## [v37-0](https://github.com/cyverse/atmosphere/compare/v36-9...v37-0) - 2020-08-13
+## [v37-0](https://github.com/cyverse/atmosphere/compare/v36-9...v37-1) - 2020-08-13
 ### Added
   - script to create access token for users
     ([#744](https://github.com/cyverse/atmosphere/pull/744))

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
       uwsgi \
       uwsgi-plugin-python \
       zlib1g-dev && \
+      apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
 
@@ -57,7 +58,6 @@ RUN mkdir /opt/env && \
     pip install --upgrade pip==9.0.3 virtualenv &&\
     virtualenv /opt/env/atmosphere &&\
     ln -s /opt/env/atmosphere/ /opt/env/atmo
-RUN git clone --depth 1 https://github.com/cyverse/atmosphere-ansible.git /opt/dev/atmosphere-ansible
 
 COPY . /opt/dev/atmosphere
 WORKDIR /opt/dev/atmosphere
@@ -74,10 +74,6 @@ RUN mkdir -p /etc/uwsgi/apps-available /etc/uwsgi/apps-enabled && \
     ln -s /etc/uwsgi/apps-available/atmosphere.ini /etc/uwsgi/apps-enabled/atmosphere.ini
 
 RUN source /opt/env/atmo/bin/activate && pip install -r requirements.txt
-
-# Cleanup
-RUN apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
 
 RUN useradd user
 


### PR DESCRIPTION

## Description

With the new containerized deployment, atmosphere-ansible should be mounted as a volume, rather than part of the build for better manageability.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x ] Add an entry in the changelog
- [NA] Documentation created/updated (include links)
- [NA] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.

