### PR TITLE
Reduce deploy retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v37-0...HEAD) - YYYY-MM-DD
 ### Changed
-  - <for changes in existing functionality>
+  - reduce the `max_retries` and timeout for the celery tasks that runs the deployment ansible
 
 ### Deprecated
   - <for soon-to-be removed features>

--- a/service/tasks/driver.py
+++ b/service/tasks/driver.py
@@ -1123,8 +1123,8 @@ def _deploy_instance_for_user(
 @task(
     name="_deploy_instance",
     default_retry_delay=124,
-    soft_time_limit=32 * 60,    # 32 minute hard-set time limit.
-    max_retries=10
+    soft_time_limit=25 * 60,    # 25 minute hard-set time limit.
+    max_retries=2
 )
 def _deploy_instance(
     driverCls,


### PR DESCRIPTION
## Description

Reduce number of retry and timeout on the celery task that runs the deployment ansible. The original retries count is too redundant because there is additional retries in Argo workflow that that tasks invoke. The change will allow deployment that cannot succeed to show up as failed quicker.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.

