### PR TITLE
bump ansible version to 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/v37-2...HEAD) - YYYY-MM-DD
+### Changed
+  - bump ansible to 2.8
+  - calls `ansible-playbook` executable directly to execute ansible playbooks
 
 ## [v37-2](https://github.com/cyverse/atmosphere/compare/v37-0...v37-2) - 2020-10-26
 ### Added

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,205 +4,205 @@
 #
 #    pip-compile --output-file=dev_requirements.txt dev_requirements.in requirements.txt
 #
-amqp==2.2.2
-ansible==2.7.12
-apache-libcloud==0.20.1
-appdirs==1.4.3
-asn1crypto==0.22.0
+amqp==2.2.2               # via -r requirements.txt, kombu
+ansible==2.8.15           # via -r requirements.txt
+apache-libcloud==0.20.1   # via -r requirements.txt, django-cyverse-auth, rtwo
+appdirs==1.4.3            # via -r requirements.txt, os-client-config
+asn1crypto==0.22.0        # via -r requirements.txt, cryptography
 astroid==1.5.3            # via pylint, pylint-celery, pylint-flask, pylint-plugin-utils, requirements-detector
-babel==2.5.1
-backports-abc==0.5
+babel==2.5.1              # via -r requirements.txt, flower, osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-heatclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
+backports-abc==0.5        # via -r requirements.txt, tornado
 backports.functools-lru-cache==1.4  # via astroid, pylint
 backports.shutil-get-terminal-size==1.0.0  # via ipython
-backports.ssl-match-hostname==3.5.0.1
-bcrypt==3.1.3
-behave-django==0.5.0
-behave==1.2.5
-behaving==1.5.6
-billiard==3.5.0.3
-boto==2.39.0
-business-rules==1.0.1
-caslib.py==2.3.0
-celery==4.0.2
-certifi==2017.7.27.1
-cffi==1.10.0
-chardet==3.0.4
-chromogenic==0.5.4
-cliff==2.8.0
-cmd2==0.7.5
-colorama==0.3.9
+backports.ssl-match-hostname==3.5.0.1  # via -r requirements.txt, apache-libcloud
+bcrypt==3.1.3             # via -r requirements.txt, paramiko
+behave-django==0.5.0      # via -r dev_requirements.in
+behave==1.2.5             # via -r dev_requirements.in, behave-django, behaving
+behaving==1.5.6           # via -r dev_requirements.in
+billiard==3.5.0.3         # via -r requirements.txt, celery
+boto==2.39.0              # via -r requirements.txt, chromogenic
+business-rules==1.0.1     # via -r requirements.txt
+caslib.py==2.3.0          # via -r requirements.txt, django-cyverse-auth
+celery==4.0.2             # via -r requirements.txt, django-celery-beat, flower
+certifi==2017.7.27.1      # via -r requirements.txt, requests, tornado, urllib3
+cffi==1.10.0              # via -r requirements.txt, bcrypt, cryptography, pynacl
+chardet==3.0.4            # via -r requirements.txt, requests
+chromogenic==0.5.4        # via -r requirements.txt
+cliff==2.8.0              # via -r requirements.txt, osc-lib, python-heatclient, python-neutronclient, python-openstackclient
+cmd2==0.7.5               # via -r requirements.txt, cliff
+colorama==0.3.9           # via -r requirements.txt
 configparser==3.5.0       # via flake8, pylint
-contextlib2==0.5.5
-coverage==4.4.1
-coveralls==1.2.0
-cryptography==2.7
-debtcollector==1.17.0
+contextlib2==0.5.5        # via -r requirements.txt, raven, vcrpy
+coverage==4.4.1           # via -r dev_requirements.in, coveralls
+coveralls==1.2.0          # via -r dev_requirements.in
+cryptography==2.7         # via -r requirements.txt, ansible, paramiko, pyopenssl, requests, urllib3
+debtcollector==1.17.0     # via -r requirements.txt, oslo.config, oslo.context, oslo.log, oslo.utils, python-keystoneclient, python-neutronclient
 decorator==4.1.2          # via ipython, traitlets
-defusedxml==0.5.0
-deprecation==1.0.1
-django-celery-beat==1.0.1
-django-cors-headers==2.1.0
-django-cyverse-auth==1.2.0
-django-debug-toolbar==1.8
-django-filter==1.0.4
-django-jenkins==0.110.0
-django-memoize==2.1.0
-django-nose==1.4.4
-django-redis-cache==1.7.1
-django-sslserver==0.20
-django==1.11.23
-djangorestframework-csv==2.0.0
-djangorestframework-jsonp==1.0.2
-djangorestframework-xml==1.3.0
-djangorestframework-yaml==1.0.3
-djangorestframework==3.9.4
+defusedxml==0.5.0         # via -r requirements.txt, djangorestframework-xml
+deprecation==1.0.1        # via -r requirements.txt, openstacksdk
+django-celery-beat==1.0.1  # via -r requirements.txt
+django-cors-headers==2.1.0  # via -r requirements.txt
+django-cyverse-auth==1.2.0  # via -r requirements.txt
+django-debug-toolbar==1.8  # via -r dev_requirements.in
+django-filter==1.0.4      # via -r requirements.txt
+django-jenkins==0.110.0   # via -r dev_requirements.in
+django-memoize==2.1.0     # via -r requirements.txt
+django-nose==1.4.4        # via -r dev_requirements.in
+django-redis-cache==1.7.1  # via -r requirements.txt
+django-sslserver==0.20    # via -r requirements.txt
+django==1.11.23           # via -r requirements.txt, behave-django, django-debug-toolbar, django-jenkins, django-memoize, django-sslserver
+djangorestframework-csv==2.0.0  # via -r requirements.txt
+djangorestframework-jsonp==1.0.2  # via -r requirements.txt
+djangorestframework-xml==1.3.0  # via -r requirements.txt
+djangorestframework-yaml==1.0.3  # via -r requirements.txt
+djangorestframework==3.9.4  # via -r requirements.txt, django-cyverse-auth, djangorestframework-csv
 docopt==0.6.2             # via coveralls
 dodgy==0.1.9              # via prospector
-emoji==0.4.5
-enum-compat==0.0.2
-enum34==1.1.6
-eventlet==0.21.0
-fabric==1.10
-factory-boy==2.9.2
+emoji==0.4.5              # via -r dev_requirements.in
+enum-compat==0.0.2        # via -r requirements.txt, eventlet
+enum34==1.1.6             # via -r requirements.txt, astroid, cryptography, enum-compat, flake8, parse-type, traitlets
+eventlet==0.21.0          # via -r requirements.txt
+fabric==1.10              # via -r requirements.txt, rfive
+factory-boy==2.9.2        # via -r dev_requirements.in
 faker==0.7.18             # via factory-boy
-flake8==3.4.1
-flower==0.9.2
-freezegun==0.3.9
-funcsigs==1.0.2
-functools32==3.2.3.post2
-futures==3.1.1
-gevent==1.2.2
+flake8==3.4.1             # via -r dev_requirements.in
+flower==0.9.2             # via -r requirements.txt
+freezegun==0.3.9          # via -r dev_requirements.in
+funcsigs==1.0.2           # via -r requirements.txt, debtcollector, mock, oslo.utils
+functools32==3.2.3.post2  # via -r requirements.txt, jsonschema
+futures==3.1.1            # via -r requirements.txt, flower, python-swiftclient
+gevent==1.2.2             # via -r requirements.txt
 gitdb2==2.0.2             # via gitpython
-gitpython==2.1.5
-greenlet==0.4.12
-httplib2==0.10.3
-idna==2.5
-ipaddress==1.0.18
-ipdb==0.10.3
+gitpython==2.1.5          # via -r dev_requirements.in
+greenlet==0.4.12          # via -r requirements.txt, eventlet, gevent
+httplib2==0.10.3          # via -r requirements.txt, oauth2client
+idna==2.5                 # via -r requirements.txt, requests, urllib3
+ipaddress==1.0.18         # via -r requirements.txt, cryptography, faker, urllib3
+ipdb==0.10.3              # via -r dev_requirements.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==5.4.1
-iso8601==0.1.12
+ipython==5.4.1            # via -r dev_requirements.in, ipdb
+iso8601==0.1.12           # via -r requirements.txt, keystoneauth1, oslo.utils, python-heatclient, python-neutronclient, python-novaclient
 isort==4.2.15             # via pylint
-itsdangerous==0.24
-jinja2==2.10.1
-json-delta==2.0
-jsonpatch==1.16
-jsonpointer==1.10
-jsonschema==2.6.0
-jwt.py==0.1.1
-keystoneauth1==3.1.0
-kombu==4.1.0
+itsdangerous==0.24        # via -r requirements.txt
+jinja2==2.10.1            # via -r requirements.txt, ansible
+json-delta==2.0           # via -r dev_requirements.in
+jsonpatch==1.16           # via -r requirements.txt, openstacksdk, warlock
+jsonpointer==1.10         # via -r requirements.txt, jsonpatch
+jsonschema==2.6.0         # via -r requirements.txt, warlock
+jwt.py==0.1.1             # via -r requirements.txt, django-cyverse-auth
+keystoneauth1==3.1.0      # via -r requirements.txt, django-cyverse-auth, openstacksdk, os-client-config, osc-lib, python-cinderclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
+kombu==4.1.0              # via -r requirements.txt, celery
 lazy-object-proxy==1.3.1  # via astroid
-markupsafe==1.0
+markupsafe==1.0           # via -r requirements.txt, jinja2
 mccabe==0.6.1             # via flake8, prospector, pylint
-mock==2.0.0
-monotonic==1.3
-msgpack-python==0.4.8
-netaddr==0.7.19
-netifaces==0.10.6
-newrelic==2.90.0.75
+mock==2.0.0               # via -r dev_requirements.in, vcrpy
+monotonic==1.3            # via -r requirements.txt, oslo.log, oslo.utils
+msgpack-python==0.4.8     # via -r requirements.txt, oslo.serialization
+netaddr==0.7.19           # via -r requirements.txt, oslo.config, oslo.utils, python-neutronclient
+netifaces==0.10.6         # via -r requirements.txt, oslo.utils
+newrelic==2.90.0.75       # via -r requirements.txt
 nose==1.3.7               # via django-nose
-numpy==1.13.1
-oauth2client==4.1.2
-olefile==0.44
-openstacksdk==0.9.17
-os-client-config==1.28.0
-osc-lib==1.7.0
-oslo.config==4.11.0
-oslo.context==2.17.0
-oslo.i18n==3.17.0
-oslo.log==3.30.0
-oslo.serialization==2.20.0
-oslo.utils==3.28.0
-pandas==0.20.3
-paramiko==2.6.0
+numpy==1.13.1             # via -r requirements.txt, pandas
+oauth2client==4.1.2       # via -r requirements.txt, django-cyverse-auth
+olefile==0.44             # via -r requirements.txt, pillow
+openstacksdk==0.9.17      # via -r requirements.txt, python-openstackclient
+os-client-config==1.28.0  # via -r requirements.txt, openstacksdk, osc-lib, python-neutronclient
+osc-lib==1.7.0            # via -r requirements.txt, python-heatclient, python-neutronclient, python-openstackclient, python-saharaclient
+oslo.config==4.11.0       # via -r requirements.txt, oslo.log, python-keystoneclient
+oslo.context==2.17.0      # via -r requirements.txt, oslo.log
+oslo.i18n==3.17.0         # via -r requirements.txt, osc-lib, oslo.config, oslo.log, oslo.utils, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
+oslo.log==3.30.0          # via -r requirements.txt, python-saharaclient
+oslo.serialization==2.20.0  # via -r requirements.txt, oslo.log, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-saharaclient
+oslo.utils==3.28.0        # via -r requirements.txt, osc-lib, oslo.log, oslo.serialization, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
+pandas==0.20.3            # via -r requirements.txt
+paramiko==2.6.0           # via -r requirements.txt, fabric
 parse-type==0.3.4         # via behave
 parse==1.8.2              # via behave, behaving, parse-type
 pathlib2==2.3.0           # via ipython, pickleshare
-pathlib==1.0.1
-pbr==3.1.1
+pathlib==1.0.1            # via -r dev_requirements.in
+pbr==3.1.1                # via -r requirements.txt, cliff, debtcollector, keystoneauth1, mock, openstacksdk, osc-lib, oslo.context, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, positional, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, stevedore
 pep8-naming==0.4.1        # via prospector
-pep8==1.7.0
+pep8==1.7.0               # via -r dev_requirements.in
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
-pillow==4.2.1
-positional==1.2.1
-prettytable==0.7.2
+pillow==4.2.1             # via -r requirements.txt
+positional==1.2.1         # via -r requirements.txt, keystoneauth1, oslo.context, python-keystoneclient
+prettytable==0.7.2        # via -r requirements.txt, cliff, python-cinderclient, python-glanceclient, python-heatclient, python-irodsclient, python-novaclient
 prompt-toolkit==1.0.15    # via ipython
-prospector==0.12.7
-psycopg2==2.7.3.1
+prospector==0.12.7        # via -r dev_requirements.in
+psycopg2==2.7.3.1         # via -r requirements.txt
 ptyprocess==0.5.2         # via pexpect
-pyasn1-modules==0.2.4
-pyasn1==0.4.5
+pyasn1-modules==0.2.4     # via -r requirements.txt, oauth2client, python-ldap
+pyasn1==0.4.5             # via -r requirements.txt, oauth2client, pyasn1-modules, python-ldap, rsa
 pycodestyle==2.0.0        # via flake8, prospector
-pycparser==2.18
-pycryptodome==3.8.2
+pycparser==2.18           # via -r requirements.txt, cffi
+pycryptodome==3.8.2       # via -r requirements.txt, jwt.py
 pydocstyle==2.0.0         # via prospector
 pyflakes==1.5.0           # via flake8, prospector
 pygments==2.2.0           # via ipython
-pyinotify==0.9.6
-pyjwt==1.5.2
+pyinotify==0.9.6          # via -r requirements.txt, oslo.log
+pyjwt==1.5.2              # via -r requirements.txt
 pylint-celery==0.3        # via prospector
 pylint-common==0.2.5      # via prospector
 pylint-django==0.7.2      # via prospector
 pylint-flask==0.5         # via prospector
 pylint-plugin-utils==0.2.6  # via prospector, pylint-celery, pylint-common, pylint-django, pylint-flask
 pylint==1.7.2             # via prospector, pylint-celery, pylint-common, pylint-django, pylint-flask, pylint-plugin-utils
-pynacl==1.1.2
-pyopenssl==19.0.0
-pyparsing==2.2.0
-pyperclip==1.5.27
-python-cinderclient==1.9.0
-python-dateutil==2.6.1
-python-glanceclient==2.5.0
-python-heatclient==1.11.0
-python-irodsclient==0.6.0
-python-keystoneclient==3.6.0
-python-ldap==3.0.0
-python-logstash==0.4.6
-python-neutronclient==6.0.0
-python-novaclient==6.0.0
-python-openstackclient==3.3.0
-python-saharaclient==1.2.0
-python-swiftclient==3.3.0
-pytz==2017.2
-pyyaml==5.1.1
-raven==6.1.0
-redis==2.10.5
-requests[security]==2.22.0
-requestsexceptions==1.3.0
+pynacl==1.1.2             # via -r requirements.txt, paramiko
+pyopenssl==19.0.0         # via -r requirements.txt, requests, urllib3
+pyparsing==2.2.0          # via -r requirements.txt, cliff, cmd2, oslo.utils
+pyperclip==1.5.27         # via -r requirements.txt, cmd2
+python-cinderclient==1.9.0  # via -r requirements.txt, python-openstackclient, rtwo
+python-dateutil==2.6.1    # via -r requirements.txt, faker, freezegun, oslo.log, pandas
+python-glanceclient==2.5.0  # via -r requirements.txt, python-openstackclient, rtwo
+python-heatclient==1.11.0  # via -r requirements.txt, rtwo
+python-irodsclient==0.6.0  # via -r requirements.txt, rtwo
+python-keystoneclient==3.6.0  # via -r requirements.txt, django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
+python-ldap==3.0.0        # via -r requirements.txt, django-cyverse-auth
+python-logstash==0.4.6    # via -r requirements.txt
+python-neutronclient==6.0.0  # via -r requirements.txt, rtwo
+python-novaclient==6.0.0  # via -r requirements.txt, python-openstackclient, rtwo
+python-openstackclient==3.3.0  # via -r requirements.txt, python-saharaclient, rtwo
+python-saharaclient==1.2.0  # via -r requirements.txt, rtwo
+python-swiftclient==3.3.0  # via -r requirements.txt, python-heatclient, rtwo
+pytz==2017.2              # via -r requirements.txt, babel, celery, django, flower, oslo.serialization, oslo.utils, pandas
+pyyaml==5.1.1             # via -r requirements.txt, ansible, cliff, djangorestframework-yaml, os-client-config, oslo.config, prospector, python-heatclient, vcrpy
+raven==6.1.0              # via -r requirements.txt
+redis==2.10.5             # via -r requirements.txt, django-redis-cache
+requests[security]==2.22.0  # via -r requirements.txt, caslib.py, coveralls, django-cyverse-auth, keystoneauth1, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-saharaclient, python-swiftclient, rtwo
+requestsexceptions==1.3.0  # via -r requirements.txt, os-client-config
 requirements-detector==0.5.2  # via prospector
-rfc3986==1.1.0
-rfive==0.2.0
-rsa==3.4.2
-rtwo==0.5.25
+rfc3986==1.1.0            # via -r requirements.txt, oslo.config
+rfive==0.2.0              # via -r requirements.txt, rtwo
+rsa==3.4.2                # via -r requirements.txt, oauth2client
+rtwo==0.5.25              # via -r requirements.txt, chromogenic
 scandir==1.5              # via pathlib2
 selenium==3.5.0           # via splinter
 setoptconf==0.2.0         # via prospector
 simplegeneric==0.8.1      # via ipython
-simplejson==3.11.1
-singledispatch==3.4.0.3
-six==1.11.0
+simplejson==3.11.1        # via -r requirements.txt, osc-lib, python-cinderclient, python-neutronclient, python-novaclient
+singledispatch==3.4.0.3   # via -r requirements.txt, astroid, pylint, tornado
+six==1.11.0               # via -r requirements.txt, astroid, bcrypt, behave, cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, faker, freezegun, keystoneauth1, mock, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, parse-type, pathlib2, prompt-toolkit, pydocstyle, pylint, pynacl, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, python-swiftclient, singledispatch, stevedore, traitlets, vcrpy, warlock
 smmap2==2.0.3             # via gitdb2
 snowballstemmer==1.2.1    # via pydocstyle
 splinter==0.7.6           # via behaving
 sqlparse==0.2.3           # via django-debug-toolbar
-stevedore==1.25.0
-threepio==0.2.0
-tornado==4.5.2
+stevedore==1.25.0         # via -r requirements.txt, cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
+threepio==0.2.0           # via -r requirements.txt, chromogenic, django-cyverse-auth, rtwo
+tornado==4.5.2            # via -r requirements.txt, flower
 traitlets==4.3.2          # via ipython
-unicodecsv==0.14.1
-urllib3[secure]==1.25.3
-uwsgi==2.0.15
-vcrpy==1.11.1
-vine==1.1.4
-vulture==0.29
-warlock==1.2.0
+unicodecsv==0.14.1        # via -r requirements.txt, cliff, djangorestframework-csv
+urllib3[secure]==1.25.3   # via -r requirements.txt, coveralls, requests
+uwsgi==2.0.15             # via -r requirements.txt
+vcrpy==1.11.1             # via -r dev_requirements.in
+vine==1.1.4               # via -r requirements.txt, amqp
+vulture==0.29             # via -r dev_requirements.in
+warlock==1.2.0            # via -r requirements.txt, python-glanceclient
 wcwidth==0.1.7            # via prompt-toolkit
-wheel==0.29.0
-wrapt==1.10.10
-xlsxwriter==0.9.8
-yapf==0.24.0
+wheel==0.29.0             # via -r dev_requirements.in
+wrapt==1.10.10            # via -r requirements.txt, astroid, debtcollector, positional, vcrpy
+xlsxwriter==0.9.8         # via -r requirements.txt
+yapf==0.24.0              # via -r dev_requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via ansible, django-sslserver, ipdb, ipython
+# setuptools

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -40,8 +40,9 @@ cp $SECRETS_DIR/ssh/id_rsa.pub /opt/dev/atmosphere/extras/ssh/id_rsa.pub
 echo -e "Host *\n\tIdentityFile /opt/dev/atmosphere/extras/ssh/id_rsa\n\tStrictHostKeyChecking no\n\tUserKnownHostsFile=/dev/null" >> ~/.ssh/config
 
 # Setup instance deploy automation
-cp $SECRETS_DIR/atmosphere-ansible/hosts /opt/dev/atmosphere-ansible/ansible/hosts
-cp -r $SECRETS_DIR/atmosphere-ansible/group_vars /opt/dev/atmosphere-ansible/ansible/group_vars
+mkdir -p /opt/dev/atmosphere-ansible/ansible/inventory
+cp $SECRETS_DIR/atmosphere-ansible/hosts /opt/dev/atmosphere-ansible/ansible/inventory/hosts
+cp -r $SECRETS_DIR/atmosphere-ansible/group_vars /opt/dev/atmosphere-ansible/ansible/inventory/group_vars
 
 # Link ini files
 ln -s $SECRETS_DIR/inis/atmosphere.ini /opt/dev/atmosphere/variables.ini

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ansible<2.8
+ansible>=2.8.15
 business_rules
 colorama # used by ./configure
 django>=1.11.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,60 +5,60 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 amqp==2.2.2               # via kombu
-ansible==2.7.12
-apache-libcloud==0.20.1
+ansible==2.8.15           # via -r requirements.in
+apache-libcloud==0.20.1   # via -r requirements.in, django-cyverse-auth, rtwo
 appdirs==1.4.3            # via os-client-config
 asn1crypto==0.22.0        # via cryptography
 babel==2.5.1              # via flower, osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-heatclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
 backports-abc==0.5        # via tornado
 backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud
 bcrypt==3.1.3             # via paramiko
-billiard==3.5.0.3
+billiard==3.5.0.3         # via -r requirements.in, celery
 boto==2.39.0              # via chromogenic
-business-rules==1.0.1
+business-rules==1.0.1     # via -r requirements.in
 caslib.py==2.3.0          # via django-cyverse-auth
-celery==4.0.2
+celery==4.0.2             # via -r requirements.in, django-celery-beat, flower
 certifi==2017.7.27.1      # via requests, tornado
 cffi==1.10.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-chromogenic==0.5.4
+chromogenic==0.5.4        # via -r requirements.in
 cliff==2.8.0              # via osc-lib, python-heatclient, python-neutronclient, python-openstackclient
 cmd2==0.7.5               # via cliff
-colorama==0.3.9
+colorama==0.3.9           # via -r requirements.in
 contextlib2==0.5.5        # via raven
 cryptography==2.7         # via ansible, paramiko, pyopenssl, requests
 debtcollector==1.17.0     # via oslo.config, oslo.context, oslo.log, oslo.utils, python-keystoneclient, python-neutronclient
 defusedxml==0.5.0         # via djangorestframework-xml
 deprecation==1.0.1        # via openstacksdk
-django-celery-beat==1.0.1
-django-cors-headers==2.1.0
-django-cyverse-auth==1.2.0
-django-filter==1.0.4
-django-memoize==2.1.0
-django-redis-cache==1.7.1
-django-sslserver==0.20
-django==1.11.23
-djangorestframework-csv==2.0.0
-djangorestframework-jsonp==1.0.2
-djangorestframework-xml==1.3.0
-djangorestframework-yaml==1.0.3
-djangorestframework==3.9.4
+django-celery-beat==1.0.1  # via -r requirements.in
+django-cors-headers==2.1.0  # via -r requirements.in
+django-cyverse-auth==1.2.0  # via -r requirements.in
+django-filter==1.0.4      # via -r requirements.in
+django-memoize==2.1.0     # via -r requirements.in
+django-redis-cache==1.7.1  # via -r requirements.in
+django-sslserver==0.20    # via -r requirements.in
+django==1.11.23           # via -r requirements.in, django-memoize, django-sslserver
+djangorestframework-csv==2.0.0  # via -r requirements.in
+djangorestframework-jsonp==1.0.2  # via -r requirements.in
+djangorestframework-xml==1.3.0  # via -r requirements.in
+djangorestframework-yaml==1.0.3  # via -r requirements.in
+djangorestframework==3.9.4  # via -r requirements.in, django-cyverse-auth, djangorestframework-csv
 enum-compat==0.0.2        # via eventlet
-enum34==1.1.6
-eventlet==0.21.0
+enum34==1.1.6             # via -r requirements.in, cryptography, enum-compat
+eventlet==0.21.0          # via -r requirements.in
 fabric==1.10              # via rfive
-flower==0.9.2
+flower==0.9.2             # via -r requirements.in
 funcsigs==1.0.2           # via debtcollector, oslo.utils
 functools32==3.2.3.post2  # via jsonschema
 futures==3.1.1            # via flower, python-swiftclient
-gevent==1.2.2
+gevent==1.2.2             # via -r requirements.in
 greenlet==0.4.12          # via eventlet, gevent
 httplib2==0.10.3          # via oauth2client
 idna==2.5                 # via requests
 ipaddress==1.0.18         # via cryptography
 iso8601==0.1.12           # via keystoneauth1, oslo.utils, python-heatclient, python-neutronclient, python-novaclient
-itsdangerous==0.24
-jinja2==2.10.1
+itsdangerous==0.24        # via -r requirements.in
+jinja2==2.10.1            # via -r requirements.in, ansible
 jsonpatch==1.16           # via openstacksdk, warlock
 jsonpointer==1.10         # via jsonpatch
 jsonschema==2.6.0         # via warlock
@@ -70,8 +70,8 @@ monotonic==1.3            # via oslo.log, oslo.utils
 msgpack-python==0.4.8     # via oslo.serialization
 netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient
 netifaces==0.10.6         # via oslo.utils
-newrelic==2.90.0.75
-numpy==1.13.1
+newrelic==2.90.0.75       # via -r requirements.in
+numpy==1.13.1             # via -r requirements.in, pandas
 oauth2client==4.1.2       # via django-cyverse-auth
 olefile==0.44             # via pillow
 openstacksdk==0.9.17      # via python-openstackclient
@@ -83,59 +83,59 @@ oslo.i18n==3.17.0         # via osc-lib, oslo.config, oslo.log, oslo.utils, pyth
 oslo.log==3.30.0          # via python-saharaclient
 oslo.serialization==2.20.0  # via oslo.log, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-saharaclient
 oslo.utils==3.28.0        # via osc-lib, oslo.log, oslo.serialization, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient
-pandas==0.20.3
-paramiko==2.6.0
+pandas==0.20.3            # via -r requirements.in
+paramiko==2.6.0           # via -r requirements.in, fabric
 pbr==3.1.1                # via cliff, debtcollector, keystoneauth1, openstacksdk, osc-lib, oslo.context, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, positional, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, stevedore
-pillow==4.2.1
+pillow==4.2.1             # via -r requirements.in
 positional==1.2.1         # via keystoneauth1, oslo.context, python-keystoneclient
 prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-heatclient, python-irodsclient, python-novaclient
-psycopg2==2.7.3.1
+psycopg2==2.7.3.1         # via -r requirements.in
 pyasn1-modules==0.2.4     # via oauth2client, python-ldap
 pyasn1==0.4.5             # via oauth2client, pyasn1-modules, python-ldap, rsa
 pycparser==2.18           # via cffi
 pycryptodome==3.8.2       # via jwt.py
 pyinotify==0.9.6          # via oslo.log
-pyjwt==1.5.2
+pyjwt==1.5.2              # via -r requirements.in
 pynacl==1.1.2             # via paramiko
-pyopenssl==19.0.0
+pyopenssl==19.0.0         # via -r requirements.in, requests
 pyparsing==2.2.0          # via cliff, cmd2, oslo.utils
 pyperclip==1.5.27         # via cmd2
 python-cinderclient==1.9.0  # via python-openstackclient, rtwo
-python-dateutil==2.6.1
+python-dateutil==2.6.1    # via -r requirements.in, oslo.log, pandas
 python-glanceclient==2.5.0  # via python-openstackclient, rtwo
 python-heatclient==1.11.0  # via rtwo
 python-irodsclient==0.6.0  # via rtwo
 python-keystoneclient==3.6.0  # via django-cyverse-auth, python-glanceclient, python-openstackclient, rtwo
-python-ldap==3.0.0
-python-logstash==0.4.6
+python-ldap==3.0.0        # via -r requirements.in, django-cyverse-auth
+python-logstash==0.4.6    # via -r requirements.in
 python-neutronclient==6.0.0  # via rtwo
 python-novaclient==6.0.0  # via python-openstackclient, rtwo
 python-openstackclient==3.3.0  # via python-saharaclient, rtwo
 python-saharaclient==1.2.0  # via rtwo
 python-swiftclient==3.3.0  # via python-heatclient, rtwo
-pytz==2017.2
-pyyaml==5.1.1
-raven==6.1.0
-redis==2.10.5
-requests[security]==2.22.0
+pytz==2017.2              # via -r requirements.in, babel, celery, django, flower, oslo.serialization, oslo.utils, pandas
+pyyaml==5.1.1             # via -r requirements.in, ansible, cliff, djangorestframework-yaml, os-client-config, oslo.config, python-heatclient
+raven==6.1.0              # via -r requirements.in
+redis==2.10.5             # via -r requirements.in, django-redis-cache
+requests[security]==2.22.0  # via -r requirements.in, caslib.py, django-cyverse-auth, keystoneauth1, python-cinderclient, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-saharaclient, python-swiftclient, rtwo
 requestsexceptions==1.3.0  # via os-client-config
 rfc3986==1.1.0            # via oslo.config
 rfive==0.2.0              # via rtwo
 rsa==3.4.2                # via oauth2client
-rtwo==0.5.25
+rtwo==0.5.25              # via -r requirements.in, chromogenic
 simplejson==3.11.1        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 singledispatch==3.4.0.3   # via tornado
 six==1.11.0               # via bcrypt, cliff, cmd2, cryptography, debtcollector, djangorestframework-csv, keystoneauth1, oauth2client, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.log, oslo.serialization, oslo.utils, pynacl, pyopenssl, python-cinderclient, python-dateutil, python-glanceclient, python-heatclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, python-saharaclient, python-swiftclient, singledispatch, stevedore, warlock
 stevedore==1.25.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
-threepio==0.2.0
+threepio==0.2.0           # via -r requirements.in, chromogenic, django-cyverse-auth, rtwo
 tornado==4.5.2            # via flower
 unicodecsv==0.14.1        # via cliff, djangorestframework-csv
-urllib3==1.25.3
-uwsgi==2.0.15
+urllib3==1.25.3           # via -r requirements.in, requests
+uwsgi==2.0.15             # via -r requirements.in
 vine==1.1.4               # via amqp
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional
-xlsxwriter==0.9.8
+xlsxwriter==0.9.8         # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via ansible, django-sslserver
+# setuptools

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -334,7 +334,7 @@ def execute_playbooks(
     if not logger:
         logger = deploy_logger
 
-    inventory_dir = os.path.join(settings.ANSIBLE_ROOT, "ansible")
+    inventory_dir = os.path.join(settings.ANSIBLE_ROOT, "ansible", "inventory")
 
     # Run playbooks
     results = []

--- a/service/deploy.py
+++ b/service/deploy.py
@@ -4,6 +4,7 @@ Deploy methods for Atmosphere
 import os
 import re
 import json
+import subprocess
 from threepio import logger, deploy_logger
 from django.conf import settings
 from atmosphere.settings import secrets
@@ -329,28 +330,34 @@ def user_deploy_install(
 def execute_playbooks(
     playbook_dir, host_file, extra_vars, host, logger=None, limit_playbooks=[]
 ):
-    # Import PlaybookCLI here because if it is imported before reading ansible.cfg,
-    # ansible will try to create a tempdir that it does not have permission for.
-    from ansible.cli.playbook import PlaybookCLI
     # Force requirement of a logger for 2.0 playbook runs
     if not logger:
         logger = deploy_logger
 
-    inventory_dir = "%s/ansible" % settings.ANSIBLE_ROOT
+    inventory_dir = os.path.join(settings.ANSIBLE_ROOT, "ansible")
 
     # Run playbooks
     results = []
     for pb in limit_playbooks:
-        logger.info("Executing playbook %s/%s" % (playbook_dir, pb))
+        pb_path = os.path.join(playbook_dir, pb)
+        logger.info("Executing playbook {}".format(pb_path))
+
         args = [
-            "--inventory=%s" % inventory_dir,
-            "--limit=%s" % host,
-            "--extra-vars=%s" % json.dumps(extra_vars),
-            "%s/%s" % (playbook_dir, pb)
+            "ansible-playbook", "--inventory={}".format(inventory_dir),
+            "--limit={}".format(host),
+            "--extra-vars={}".format(json.dumps(extra_vars)), pb_path
         ]
-        pb_runner = PlaybookCLI(args)
-        pb_runner.parse()
-        results.append(pb_runner.run())
+        logger.info("args to ansible-playbook: {}".format(args))
+
+        proc = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        ansible_output, _ = proc.communicate()    # capture output
+        logger.debug(ansible_output)
+
+        logger.info("playbook {} result {}".format(pb, proc.returncode))
+        results.append(proc.returncode)
+
         if results[-1] != 0:
             break
     return results


### PR DESCRIPTION
- bump ansible version to 2.8
- calls `ansible-playbook` executable directly rather than via the ansible python library
<!--
## Description

Please describe your pull request. If you're solving a problem, include a oneline problem and oneline solution statement. Otherwise, just begin with a single line summary.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables supported in Clank
-->
